### PR TITLE
Add file field helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ruby-version
 doc/*
 *.gem
 *.yardoc

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -15,6 +15,7 @@ require 'govuk_design_system_formbuilder/elements/error_message'
 require 'govuk_design_system_formbuilder/elements/error_summary'
 require 'govuk_design_system_formbuilder/elements/submit'
 require 'govuk_design_system_formbuilder/elements/text_area'
+require 'govuk_design_system_formbuilder/elements/file'
 
 require 'govuk_design_system_formbuilder/containers/form_group'
 require 'govuk_design_system_formbuilder/containers/fieldset'

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -472,5 +472,27 @@ module GOVUKDesignSystemFormBuilder
     def govuk_fieldset(legend: { text: 'Fieldset heading' }, described_by: nil, &block)
       Containers::Fieldset.new(self, legend: legend, described_by: described_by).html(&block)
     end
+
+    # Generates an input of type +file+
+    #
+    # @param attribute_name [Symbol] The name of the attribute
+    # @option label text [String] the label text
+    # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
+    # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
+    # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
+    # @option args [Hash] args additional arguments are applied as attributes to +input+ element
+    #
+    # @example A photo upload field with file type specifier
+    #   = f.govuk_file_field :photo, label: { text: 'Upload your photo' }, accept: 'image/*'
+    #
+    # @see https://design-system.service.gov.uk/components/file-upload/ GOV.UK file upload
+    # @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file MDN documentation for file upload
+    #
+    # @note Remember to set +multipart: true+ when creating a form with file
+    #   uploads, {https://guides.rubyonrails.org/form_helpers.html#uploading-files see
+    #   the Rails documentation} for more information
+    def govuk_file_field(attribute_name, label: {}, hint_text: nil, **args)
+      Elements::File.new(self, object_name, attribute_name, label: label, hint_text: hint_text, **args).html
+    end
   end
 end

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -203,7 +203,7 @@ module GOVUKDesignSystemFormBuilder
     # @param text_method [Symbol] The method called against each member of the collection to provide the text
     # @param hint_method [Symbol] The method called against each member of the collection to provide the hint text
     # @param hint_text [String] The content of the fieldset hint. No hint will be injected if left +nil+
-    # @param legend [Hash] options for configuring the hash
+    # @param legend [Hash] options for configuring the legend
     # @param inline [Boolean] controls whether the radio buttons are displayed inline or not
     # @param small [Boolean] controls whether small radio buttons are used instead of regular-sized ones
     # @option legend text [String] the fieldset legend's text content
@@ -257,7 +257,7 @@ module GOVUKDesignSystemFormBuilder
     #
     # @param attribute_name [Symbol] The name of the attribute
     # @param hint_text [String] The content of the fieldset hint. No hint will be injected if left +nil+
-    # @param legend [Hash] options for configuring the hash
+    # @param legend [Hash] options for configuring the legend
     # @param inline [Boolean] controls whether the radio buttons are displayed inline or not
     # @param small [Boolean] controls whether small radio buttons are used instead of regular-sized ones
     # @option legend text [String] the fieldset legend's text content
@@ -334,7 +334,7 @@ module GOVUKDesignSystemFormBuilder
     # @param hint_method [Symbol] The method called against each member of the collection to provide the hint text
     # @param hint_text [String] The content of the fieldset hint. No hint will be injected if left +nil+
     # @param small [Boolean] controls whether small check boxes are used instead of regular-sized ones
-    # @param legend [Hash] options for configuring the hash
+    # @param legend [Hash] options for configuring the legend
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
@@ -415,7 +415,7 @@ module GOVUKDesignSystemFormBuilder
     #   be 'rounded' up to +2019-10-01+.
     # @param attribute_name [Symbol] The name of the attribute
     # @param hint_text [String] the contents of the hint
-    # @param legend [Hash] options for configuring the hash
+    # @param legend [Hash] options for configuring the legend
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
@@ -455,7 +455,7 @@ module GOVUKDesignSystemFormBuilder
 
     # Generates a fieldset containing the contents of the block
     #
-    # @param legend [Hash] options for configuring the hash
+    # @param legend [Hash] options for configuring the legend
     # @param described_by [Array<String>] the ids of the elements that describe this fieldset, usually hints and errors
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -1,0 +1,48 @@
+module GOVUKDesignSystemFormBuilder
+  module Elements
+    class File < GOVUKDesignSystemFormBuilder::Base
+      def initialize(builder, object_name, attribute_name, hint_text:, label:, **extra_args)
+        super(builder, object_name, attribute_name)
+
+        @label      = label
+        @hint_text  = hint_text
+        @extra_args = extra_args
+      end
+
+      def html
+        hint_element  = Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text)
+        label_element = Elements::Label.new(@builder, @object_name, @attribute_name, @label)
+        error_element = Elements::ErrorMessage.new(@builder, @object_name, @attribute_name)
+
+        Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
+          @builder.safe_join(
+            [
+              label_element.html,
+              hint_element.html,
+              error_element.html,
+              @builder.file_field(
+                @attribute_name,
+                class: file_classes,
+                aria: {
+                  describedby: [
+                    hint_element.hint_id,
+                    error_element.error_id
+                  ].compact.join(' ').presence
+                },
+                **@extra_args
+              )
+            ]
+          )
+        end
+      end
+
+    private
+
+      def file_classes
+        %w(govuk-file-upload).tap do |c|
+          c.push('govuk-file-upload--error') if has_errors?
+        end
+      end
+    end
+  end
+end

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -1,0 +1,108 @@
+describe GOVUKDesignSystemFormBuilder::FormBuilder do
+  include_context 'setup builder'
+
+  describe '#govuk_file_field' do
+    let(:method) { :govuk_file_field }
+    let(:attribute) { :photo }
+    let(:label_text) { 'Upload certificate' }
+    let(:hint_text) { 'Only PDFs are accepted' }
+
+    subject do
+      builder.send(method, attribute)
+    end
+
+    specify 'output should be a form group containing a file input and label' do
+      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+        expect(subject).to have_tag('input', with: { type: 'file' })
+        expect(subject).to have_tag('label')
+      end
+    end
+
+    describe 'label' do
+      context 'when a label is provided' do
+        subject { builder.send(method, attribute, label: { text: label_text }) }
+
+        specify 'the label should be included' do
+          expect(subject).to have_tag('label', with: { class: 'govuk-label' }, text: label_text)
+        end
+      end
+
+      context 'when no label is provided' do
+        specify 'the label should have the default value' do
+          expect(subject).to have_tag('label', with: { class: 'govuk-label' }, text: attribute.capitalize)
+        end
+      end
+
+      context 'when the label is supplied with a wrapping tag' do
+        let(:wrapping_tag) { 'h2' }
+        subject { builder.send(method, attribute, label: { text: label_text, tag: wrapping_tag }) }
+
+        specify 'the label should be wrapped in by the wrapping tag' do
+          expect(subject).to have_tag(wrapping_tag, with: { class: %w(govuk-label-wrapper) }) do |wt|
+            expect(wt).to have_tag('label', text: label_text)
+          end
+        end
+      end
+    end
+
+    describe 'hint' do
+      context 'when a hint is provided' do
+        subject { builder.send(method, attribute, hint_text: hint_text) }
+
+        specify 'the hint should be included' do
+          expect(subject).to have_tag('span', with: { class: 'govuk-hint' }, text: hint_text)
+        end
+      end
+
+      context 'when no hint is provided' do
+        specify 'no hint should be included' do
+          expect(subject).not_to have_tag('span', with: { class: 'govuk-hint' })
+        end
+      end
+    end
+
+    describe 'errors' do
+      context 'when the attribute has errors' do
+        let(:object) { Person.new(photo: 'me.tiff') }
+        let(:error_identifier) { 'person-photo-error' }
+        before { object.valid? }
+
+        specify 'an error message should be displayed' do
+          expect(subject).to have_tag('span', with: { class: 'govuk-error-message' }, text: /Must be a JPEG/)
+        end
+
+        specify 'the file upload element should have the correct error classes' do
+          expect(subject).to have_tag('input', with: { class: 'govuk-file-upload--error' })
+        end
+
+        specify 'the error message should be associated with the file input' do
+          expect(subject).to have_tag('input', with: { 'aria-describedby' => error_identifier })
+          expect(subject).to have_tag('span', with: {
+            class: 'govuk-error-message',
+            id: error_identifier
+          })
+        end
+      end
+
+      context 'when the attribute has no errors' do
+        let(:object) { Person.new(photo: 'me.jpeg') }
+
+        specify 'no error messages should be displayed' do
+          expect(subject).not_to have_tag('span', with: { class: 'govuk-error-message' })
+        end
+      end
+    end
+
+    describe 'additional attributes' do
+      subject { builder.send(method, attribute, accept: 'image/*', multiple: true) }
+
+      specify 'input should have additional attributes' do
+        expect(subject).to have_tag('input', with: {
+          accept: 'image/*',
+          multiple: 'multiple'
+        })
+      end
+    end
+  end
+end
+

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -3,6 +3,7 @@ class Person
   attr_accessor(:name, :born_on, :gender, :over_18, :favourite_colour, :favourite_colour_reason)
   attr_accessor(:projects, :project_responsibilities)
   attr_accessor(:cv)
+  attr_accessor(:photo)
 
   validates :name, presence: { message: 'Enter a name' }
   validates :favourite_colour, presence: { message: 'Choose a favourite colour' }
@@ -10,6 +11,7 @@ class Person
   validates :cv, length: { maximum: 30 }
 
   validate :born_on_must_be_in_the_past, if: -> { born_on.present? }
+  validate :photo_must_be_jpeg, if: -> { photo.present? }
 
   def self.valid_example
     new(
@@ -25,6 +27,10 @@ private
 
   def born_on_must_be_in_the_past
     errors.add(:born_on, 'Your date of birth must be in the past') unless born_on < Date.today
+  end
+
+  def photo_must_be_jpeg
+    errors.add(:photo, 'Must be a JPEG') unless photo.end_with?('.jpeg')
   end
 end
 


### PR DESCRIPTION
Adds the missing [file upload](https://design-system.service.gov.uk/components/file-upload/) functionality from the Design System, along with associated docs and specs.