### PR TITLE
Refactor and de-duplicate specs

### DIFF
--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -35,9 +35,9 @@ module GOVUKDesignSystemFormBuilder
 
       def legend_classes
         size = @legend.dig(:size)
-        fail "invalid size #{size}, must be #{LEGEND_SIZES.join(', ')}" unless size.in?(LEGEND_SIZES)
+        fail "invalid size '#{size}', must be #{LEGEND_SIZES.join(', ')}" unless size.in?(LEGEND_SIZES)
 
-        "govuk-fieldset__legend govuk-fieldset__legend--#{size}"
+        ["govuk-fieldset__legend", "govuk-fieldset__legend--#{size}"]
       end
 
       def legend_heading_classes

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -53,7 +53,7 @@ module GOVUKDesignSystemFormBuilder
         when 's'       then "govuk-label--s"
         when nil       then nil
         else
-          fail "size must be either 'xl', 'l', 'm', 's' or nil"
+          fail "invalid size '#{size}', must be xl, l, m, s or nil"
         end
       end
     end

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -27,6 +27,12 @@ module GOVUKDesignSystemFormBuilder
                 @builder.text_area(
                   @attribute_name,
                   class: govuk_textarea_classes,
+                  aria: {
+                    describedby: [
+                      hint_element.hint_id,
+                      error_element.error_id
+                    ].compact.join(' ').presence
+                  },
                   **@extra_args.merge(rows: @rows)
                 ),
                 character_count_info

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -34,6 +34,28 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:error_identifier) { 'person-born-on-error' }
     end
 
+    it_behaves_like 'a field that accepts arbitrary blocks of HTML' do
+      # the block content (p) should be between the hint (span) and the input container (div)
+      context 'ordering' do
+        let(:hint_span_selector) { 'span.govuk-hint' }
+        let(:block_paragraph_selector) { 'p.block-content' }
+        let(:govuk_date_selector) { 'div.govuk-date-input' }
+
+        let(:paragraph) { 'A descriptive paragraph all about dates' }
+        subject do
+          builder.send(*args.push(legend: { text: legend_text }, hint_text: hint_text)) do
+            builder.tag.p(paragraph, class: 'block-content')
+          end
+        end
+
+        specify 'the block content should be between the hint and the date inputs' do
+          expect(
+            parsed_subject.css([hint_span_selector, block_paragraph_selector, govuk_date_selector].join(',')).map(&:name)
+          ).to eql(%w(span p div))
+        end
+      end
+    end
+
     specify 'should output a form group with fieldset, date group and 3 inputs and labels' do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
         expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
@@ -60,7 +82,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
 
-      context 'attributes' do
+      context 'input attributes' do
         specify 'inputs should have a pattern that restricts entries to numbers' do
           expect(subject).to have_tag('input', with: { pattern: '[0-9]*' })
         end
@@ -69,34 +91,34 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           expect(subject).to have_tag('input', with: { inputmode: 'numeric' })
         end
       end
-    end
 
-    specify 'inputs should have the correct classes' do
-      expect(subject).to have_tag(
-        'input',
-        count: 3,
-        with: { class: %w(govuk-input govuk-date-input__input) }
-      )
-    end
+      specify 'labels should be associated with inputs' do
+        [day_identifier, month_identifier, year_identifier].each do |identifier|
+          expect(subject).to have_tag('label', with: { for: identifier }, count: 1)
+          expect(subject).to have_tag('input', with: { id: identifier }, count: 1)
+        end
+      end
 
-    specify 'inputs should have the width class' do
-      expect(subject).to have_tag(
-        'input',
-        count: 2,
-        with: { class: %w(govuk-input--width-2) }
-      )
+      specify 'inputs should have the correct classes' do
+        expect(subject).to have_tag(
+          'input',
+          count: 3,
+          with: { class: %w(govuk-input govuk-date-input__input) }
+        )
+      end
 
-      expect(subject).to have_tag(
-        'input',
-        count: 1,
-        with: { class: %w(govuk-input--width-4) }
-      )
-    end
+      specify 'inputs should have the width class' do
+        expect(subject).to have_tag(
+          'input',
+          count: 2,
+          with: { class: %w(govuk-input--width-2) }
+        )
 
-    specify 'labels should be associated with inputs' do
-      [day_identifier, month_identifier, year_identifier].each do |identifier|
-        expect(subject).to have_tag('label', with: { for: identifier }, count: 1)
-        expect(subject).to have_tag('input', with: { id: identifier }, count: 1)
+        expect(subject).to have_tag(
+          'input',
+          count: 1,
+          with: { class: %w(govuk-input--width-4) }
+        )
       end
     end
 
@@ -133,40 +155,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
-    context 'block' do
-      let(:paragraph) { 'A descriptive paragraph all about dates' }
-      subject do
-        builder.send(*args.push(legend: { text: legend_text }, hint_text: hint_text)) do
-          builder.tag.p(paragraph, class: 'block-content')
-        end
-      end
-
-      specify 'should add the block content in addition to the other elements' do
-        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-          expect(fg).to have_tag('input', count: 3)
-          expect(fg).to have_tag('legend', text: legend_text)
-          expect(fg).to have_tag('span', with: { class: 'govuk-hint' }, text: hint_text)
-
-          expect(fg).to have_tag('p', paragraph)
-        end
-      end
-
-      # the block content (p) should be between the hint (span) and the input container (div)
-      let(:hint_span_selector) { 'span.govuk-hint' }
-      let(:block_paragraph_selector) { 'p.block-content' }
-      let(:govuk_date_selector) { 'div.govuk-date-input' }
-
-      specify 'the block content should be between the hint and the date inputs' do
-        expect(
-          parsed_subject.css([hint_span_selector, block_paragraph_selector, govuk_date_selector].join(',')).map(&:name)
-        ).to eql(%w(span p div))
-      end
-    end
-
-    context 'dates of birth' do
-      subject { builder.send(*args.push(date_of_birth: true)) }
-
-      context 'auto-completion attributes' do
+    context 'auto-completion' do
+      context 'date of birth' do
+        subject { builder.send(*args.push(date_of_birth: true)) }
         specify "day field should have autocomplete attribute with value 'bday-day'" do
           expect(subject).to have_tag('input', with: { autocomplete: 'bday-day' })
         end

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -100,25 +100,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
-    context 'legend' do
-      context 'when a legend is supplied' do
-        subject { builder.send(*args.push(legend: { text: legend_text })) }
-        specify 'legend tag should be present and have the correct contents' do
-          expect(subject).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
-            expect(fs).to have_tag('legend', with: { class: 'govuk-fieldset__legend' }) do |legend|
-              expect(legend).to have_tag('h1', text: legend_text, with: { class: 'govuk-fieldset__heading' })
-            end
-          end
-        end
-      end
-
-      context 'when no legend is supplied' do
-        specify 'legend tag should not be present' do
-          expect(subject).not_to have_tag('legend')
-        end
-      end
-    end
-
     context 'default values' do
       let(:birth_day) { 3 }
       let(:birth_month) { 2 }
@@ -170,7 +151,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
 
-      # the block content (p) shold be between the hint (span) and the input container (div)
+      # the block content (p) should be between the hint (span) and the input container (div)
       let(:hint_span_selector) { 'span.govuk-hint' }
       let(:block_paragraph_selector) { 'p.block-content' }
       let(:govuk_date_selector) { 'div.govuk-date-input' }

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -4,12 +4,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   describe '#govuk_file_field' do
     let(:method) { :govuk_file_field }
     let(:attribute) { :photo }
-    let(:label_text) { 'Upload certificate' }
-    let(:hint_text) { 'Only PDFs are accepted' }
+    let(:label_text) { 'Upload an image' }
+    let(:hint_text) { 'Only JPEGs are accepted' }
 
-    subject do
-      builder.send(method, attribute)
-    end
+    let(:args) { [method, attribute] }
+    let(:field_type) { 'input' }
+    subject { builder.send(*args) }
 
     specify 'output should be a form group containing a file input and label' do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
@@ -18,79 +18,19 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
-    describe 'label' do
-      context 'when a label is provided' do
-        subject { builder.send(method, attribute, label: { text: label_text }) }
+    it_behaves_like 'a field that supports labels'
 
-        specify 'the label should be included' do
-          expect(subject).to have_tag('label', with: { class: 'govuk-label' }, text: label_text)
-        end
-      end
-
-      context 'when no label is provided' do
-        specify 'the label should have the default value' do
-          expect(subject).to have_tag('label', with: { class: 'govuk-label' }, text: attribute.capitalize)
-        end
-      end
-
-      context 'when the label is supplied with a wrapping tag' do
-        let(:wrapping_tag) { 'h2' }
-        subject { builder.send(method, attribute, label: { text: label_text, tag: wrapping_tag }) }
-
-        specify 'the label should be wrapped in by the wrapping tag' do
-          expect(subject).to have_tag(wrapping_tag, with: { class: %w(govuk-label-wrapper) }) do |wt|
-            expect(wt).to have_tag('label', text: label_text)
-          end
-        end
-      end
+    it_behaves_like 'a field that supports hints' do
+      let(:aria_described_by_target) { 'input' }
     end
 
-    describe 'hint' do
-      context 'when a hint is provided' do
-        subject { builder.send(method, attribute, hint_text: hint_text) }
+    it_behaves_like 'a field that supports errors' do
+      let(:object) { Person.new(photo: 'me.tiff') }
+      let(:aria_described_by_target) { 'input' }
 
-        specify 'the hint should be included' do
-          expect(subject).to have_tag('span', with: { class: 'govuk-hint' }, text: hint_text)
-        end
-      end
-
-      context 'when no hint is provided' do
-        specify 'no hint should be included' do
-          expect(subject).not_to have_tag('span', with: { class: 'govuk-hint' })
-        end
-      end
-    end
-
-    describe 'errors' do
-      context 'when the attribute has errors' do
-        let(:object) { Person.new(photo: 'me.tiff') }
-        let(:error_identifier) { 'person-photo-error' }
-        before { object.valid? }
-
-        specify 'an error message should be displayed' do
-          expect(subject).to have_tag('span', with: { class: 'govuk-error-message' }, text: /Must be a JPEG/)
-        end
-
-        specify 'the file upload element should have the correct error classes' do
-          expect(subject).to have_tag('input', with: { class: 'govuk-file-upload--error' })
-        end
-
-        specify 'the error message should be associated with the file input' do
-          expect(subject).to have_tag('input', with: { 'aria-describedby' => error_identifier })
-          expect(subject).to have_tag('span', with: {
-            class: 'govuk-error-message',
-            id: error_identifier
-          })
-        end
-      end
-
-      context 'when the attribute has no errors' do
-        let(:object) { Person.new(photo: 'me.jpeg') }
-
-        specify 'no error messages should be displayed' do
-          expect(subject).not_to have_tag('span', with: { class: 'govuk-error-message' })
-        end
-      end
+      let(:error_message) { /Must be a JPEG/ }
+      let(:error_class) { 'govuk-file-upload--error' }
+      let(:error_identifier) { 'person-photo-error' }
     end
 
     describe 'additional attributes' do

--- a/spec/govuk_design_system_formbuilder/builder/radios_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios_spec.rb
@@ -1,4 +1,7 @@
 describe GOVUKDesignSystemFormBuilder::FormBuilder do
+  let(:field_type) { 'input' }
+  let(:aria_described_by_target) { 'fieldset' }
+
   include_context 'setup builder'
   let(:attribute) { :favourite_colour }
   let(:label_text) { 'Cherished shade' }
@@ -18,7 +21,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       ]
     end
 
-    subject { builder.send(method, attribute, colours, :id, :name) }
+    let(:args) { [method, attribute, colours, :id, :name] }
+    subject { builder.send(*args) }
 
     specify 'output should be a form group containing a form group and fieldset' do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
@@ -26,142 +30,23 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
-    context 'fieldset options' do
-      context 'legend' do
-        let(:text) { 'Pick your favourite colour' }
-
-        context 'when supplied with custom text' do
-          subject { builder.send(method, attribute, colours, :id, :name, legend: { text: text }) }
-
-          specify 'should contain a fieldset header containing the supplied text' do
-            expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-              expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
-                expect(fs).to have_tag('h1', text: text, with: { class: 'govuk-fieldset__heading' })
-              end
-            end
-          end
-        end
-
-        context 'when no text is supplied' do
-          subject { builder.send(method, attribute, colours, :id, :name, legend: { text: nil }) }
-
-          specify 'output should not contain a header' do
-            expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-              expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
-                expect(fs).not_to have_tag('h1')
-              end
-            end
-          end
-        end
-
-        context 'when supplied with a custom tag' do
-          let(:tag) { 'h4' }
-          subject { builder.send(method, attribute, colours, :id, :name, legend: { text: text, tag: tag }) }
-
-          specify 'output fieldset should contain the specified tag' do
-            expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-              expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
-                expect(fs).to have_tag(tag, text: text)
-              end
-            end
-          end
-        end
-
-        context 'when supplied with a custom size' do
-          context 'with a valid size' do
-            let(:size) { 'm' }
-            subject { builder.send(method, attribute, colours, :id, :name, legend: { text: text, size: size }) }
-
-            specify 'output fieldset should contain the specified tag' do
-              expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-                expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
-                  expect(fs).to have_tag('h1', text: text, class: "govuk-fieldset__legend--#{size}")
-                end
-              end
-            end
-          end
-
-          context 'with an invalid size' do
-            let(:size) { 'miniscule' }
-            subject { builder.send(method, attribute, colours, :id, :name, legend: { text: text, size: size }) }
-
-            specify 'should raise an appropriate error' do
-              expect { subject }.to raise_error(/invalid size #{size}/)
-            end
-          end
-        end
-      end
+    it_behaves_like 'a field that supports a fieldset with legend' do
+      let(:legend_text) { 'Pick your favourite colour' }
     end
 
-    context 'when a hint is provided' do
-      let(:hint) { 'The colour of your favourite handkerchief' }
-      subject { builder.send(method, attribute, colours, :id, :name, hint_text: hint) }
-
-      specify 'output should contain a hint' do
-        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-          expect(fg).to have_tag('span', text: hint, with: { class: 'govuk-hint' })
-        end
-      end
-
-      specify 'output should also contain the fieldset' do
-        expect(subject).to have_tag('fieldset', with: { class: 'govuk-fieldset' })
-      end
-
-      specify 'the hint should be associated with the fieldset' do
-        expect(parsed_subject.at_css('.govuk-fieldset')['aria-describedby'].split).to include(
-          parsed_subject.at_css('.govuk-fieldset > .govuk-hint')['id']
-        )
-      end
+    it_behaves_like 'a field that supports hints' do
+      let(:hint_text) { 'The colour of your favourite handkerchief' }
     end
 
-    context 'errors' do
-      context 'when the attribute has errors' do
-        before { object.valid? }
-
-        specify 'form group should have error class' do
-          expect(subject).to have_tag('div', with: { class: 'govuk-form-group--error' })
-        end
-
-        specify 'should have error message' do
-          expect(subject).to have_tag('span', with: { class: 'govuk-error-message' }, text: /Choose a favourite colour/)
-        end
-
-        specify 'the error message should be associated with the fieldset' do
-          expect(parsed_subject.at_css('.govuk-fieldset')['aria-describedby'].split).to include(
-            parsed_subject.at_css('.govuk-fieldset > .govuk-error-message')['id']
-          )
-        end
-      end
+    it_behaves_like 'a field that supports errors' do
+      let(:error_message) { /Choose a favourite colour/ }
+      let(:error_class) { nil }
+      let(:error_identifier) { 'person-favourite-colour-error' }
     end
 
-    context 'when passed a block' do
-      let(:block_h1) { 'The quick brown fox' }
-      let(:block_h2) { 'Jumped over the' }
-      let(:block_p) { 'Lazy dog.' }
-      subject do
-        builder.send(method, attribute, colours, :id, :name) do
-          builder.safe_join([
-            builder.tag.h1(block_h1),
-            builder.tag.h2(block_h2),
-            builder.tag.p(block_p)
-          ])
-        end
-      end
-
-      specify 'should include block content' do
-        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-          expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
-            expect(fs).to have_tag('h1', text: block_h1)
-            expect(fs).to have_tag('h2', text: block_h2)
-            expect(fs).to have_tag('p', text: block_p)
-          end
-        end
-      end
-    end
+    it_behaves_like 'a field that accepts arbitrary blocks of HTML'
 
     context 'radio buttons' do
-      subject { builder.send(method, attribute, colours, :id, :name) }
-
       specify 'radio buttons should have the correct classes' do
         expect(subject).to have_tag('input', with: { class: %w(govuk-radios__input) })
       end
@@ -208,7 +93,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         let(:colours_with_descriptions) { colours.select { |c| c.description.present? } }
         let(:colours_without_descriptions) { colours.reject { |c| c.description.present? } }
 
-        subject { builder.send(method, attribute, colours, :id, :name, :description) }
+        subject { builder.send(*args.push(:description)) }
 
         specify 'the radio buttons with hints should contain hint text' do
           expect(subject).to have_tag('span', count: colours_with_descriptions.size, with: { class: 'govuk-hint govuk-radios__hint' })
@@ -280,44 +165,31 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
   describe '#govuk_radio_buttons_fieldset' do
     let(:method) { :govuk_radio_buttons_fieldset }
+    let(:args) { [method, attribute] }
+
+    subject do
+      builder.send(*args) do
+        builder.safe_join([
+          builder.govuk_radio_button(:favourite_colour, :red, label: { text: red_label }),
+          builder.govuk_radio_button(:favourite_colour, :green, label: { text: green_label })
+        ])
+      end
+    end
 
     context 'when no block is supplied' do
-      subject { builder.send(method, attribute) }
+      subject { builder.send(*args) }
       specify { expect { subject }.to raise_error(LocalJumpError, /no block given/) }
     end
 
-    context 'when a block is supplied' do
-      let(:block_h1) { 'The quick brown fox' }
-      let(:block_h2) { 'Jumped over the' }
-      let(:block_p) { 'Lazy dog.' }
+    it_behaves_like 'a field that accepts arbitrary blocks of HTML'
 
-      subject do
-        builder.send(method, attribute) do
-          builder.safe_join([
-            builder.tag.h1(block_h1),
-            builder.tag.h2(block_h2),
-            builder.tag.p(block_p)
-          ])
-        end
-      end
-
-      specify 'output should contain the contents of the block' do
-        expect(subject).to have_tag('h1', text: block_h1)
-        expect(subject).to have_tag('h2', text: block_h2)
-        expect(subject).to have_tag('p', text: block_p)
-      end
+    it_behaves_like 'a field that supports errors' do
+      let(:error_message) { /Choose a favourite colour/ }
+      let(:error_class) { nil }
+      let(:error_identifier) { 'person-favourite-colour-error' }
     end
 
     context 'when a block containing radio buttons is supplied' do
-      subject do
-        builder.send(method, attribute) do
-          builder.safe_join([
-            builder.govuk_radio_button(:favourite_colour, :red, label: { text: red_label }),
-            builder.govuk_radio_button(:favourite_colour, :green, label: { text: green_label })
-          ])
-        end
-      end
-
       specify 'output should be a form group containing a form group and fieldset' do
         expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
           expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' })
@@ -333,7 +205,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       context 'layout direction' do
         context 'when inline is specified in the options' do
           subject do
-            builder.send(method, attribute, inline: true) do
+            builder.send(*args.push(inline: true)) do
               builder.govuk_radio_button(:favourite_colour, :red, label: { text: red_label })
             end
           end
@@ -345,7 +217,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
         context 'when inline is not specified in the options' do
           subject do
-            builder.send(method, attribute) do
+            builder.send(*args) do
               builder.govuk_radio_button(:favourite_colour, :red, label: { text: red_label })
             end
           end
@@ -359,7 +231,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       context 'radio button size' do
         context 'when small is specified in the options' do
           subject do
-            builder.send(method, attribute, small: true) do
+            builder.send(*args.push(small: true)) do
               builder.govuk_radio_button(:favourite_colour, :red, label: { text: red_label })
             end
           end
@@ -371,7 +243,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
         context 'when small is not specified in the options' do
           subject do
-            builder.send(method, attribute) do
+            builder.send(*args) do
               builder.govuk_radio_button(:favourite_colour, :red, label: { text: red_label })
             end
           end
@@ -384,7 +256,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
       context 'dividers' do
         subject do
-          builder.send(method, attribute) do
+          builder.send(*args) do
             builder.govuk_radio_divider
           end
         end
@@ -406,34 +278,15 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           end
         end
       end
-
-      context 'errors' do
-        context 'when the attribute has errors' do
-          before { object.valid? }
-
-          specify 'form group should have error class' do
-            expect(subject).to have_tag('div', with: { class: 'govuk-form-group--error' })
-          end
-
-          specify 'should have error message' do
-            expect(subject).to have_tag('span', with: { class: 'govuk-error-message' }, text: /Choose a favourite colour/)
-          end
-
-          specify 'the error message should be associated with the fieldset' do
-            expect(parsed_subject.at_css('.govuk-fieldset')['aria-describedby'].split).to include(
-              parsed_subject.at_css('.govuk-fieldset > .govuk-error-message')['id']
-            )
-          end
-        end
-      end
     end
   end
 
   describe '#govuk_radio_button' do
     let(:method) { :govuk_radio_button }
     let(:value) { 'red' }
+    let(:args) { [method, attribute, value] }
 
-    subject { builder.send(method, attribute, value) }
+    subject { builder.send(*args) }
 
     specify 'output should contain a radio item group with a radio input' do
       expect(subject).to have_tag('div', with: { class: 'govuk-radios__item' }) do |ri|
@@ -441,62 +294,18 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
-    context 'label' do
-      context 'when a label is provided' do
-        context 'association with the input' do
-          let(:colour) { :red }
-          let(:identifier) { "person_favourite_colour_#{colour}" }
-
-          subject do
-            builder.govuk_radio_button(:favourite_colour, colour)
-          end
-
-          specify 'should contain a label with the correct text' do
-            expect(subject).to have_tag('input', with: { id: identifier })
-            expect(subject).to have_tag('label', with: { for: identifier })
-          end
-        end
-
-        context 'with default options' do
-          subject do
-            builder.govuk_radio_button(:favourite_colour, :red, label: { text: red_label })
-          end
-
-          specify 'should contain a label with the correct text' do
-            expect(subject).to have_tag('label', text: red_label)
-          end
-        end
-
-        context 'with additional options' do
-          subject do
-            builder.govuk_radio_button(:favourite_colour, :red, label: { text: red_label, size: 'l' })
-          end
-          specify 'should allow label to be configured' do
-            expect(subject).to have_tag('label', text: red_label, with: {
-              class: 'govuk-label govuk-label--l'
-            })
-          end
-        end
-      end
-
-      context 'when no label is provided' do
-        subject do
-          builder.govuk_radio_button(:favourite_colour, :red)
-        end
-
-        specify 'should contain a label with the correct text' do
-          expect(subject).to have_tag('label', text: 'Favourite_colour')
-        end
-      end
+    it_behaves_like 'a field that supports labels' do
+      let(:label_text) { 'Red' }
+      let(:field_type) { 'input' }
     end
 
-    context 'when a hint is provided' do
+    context 'radio button hints' do
       subject do
         builder.govuk_radio_button(:favourite_colour, :red, hint_text: red_hint)
       end
 
       specify 'should contain a label with the correct text' do
-        expect(subject).to have_tag('span', text: red_hint, with: { class: 'govuk-hint' })
+        expect(subject).to have_tag('span', text: red_hint, with: { class: %w(govuk-hint govuk-radios__hint) })
       end
     end
 

--- a/spec/govuk_design_system_formbuilder/builder/radios_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios_spec.rb
@@ -47,23 +47,37 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that accepts arbitrary blocks of HTML'
 
     context 'radio buttons' do
-      specify 'radio buttons should have the correct classes' do
-        expect(subject).to have_tag('input', with: { class: %w(govuk-radios__input) })
+      specify 'each radio button should have the correct classes' do
+        expect(subject).to have_tag('input', with: { class: %w(govuk-radios__input) }, count: colours.size)
       end
 
-      specify 'output should contain the correct number of radio buttons' do
+      specify 'each label should have the correct classes' do
+        expect(subject).to have_tag('label', count: colours.size, with: { class: %w(govuk-label govuk-radios__label) })
+      end
+
+      specify 'there should be the correct number' do
         expect(subject).to have_tag('input', count: colours.size, with: { type: 'radio' })
         expect(subject).to have_tag('label', count: colours.size)
       end
 
-      specify 'containing div should have attribute data-module="radios"' do
+      specify 'radio buttons should be surrounded by a radios module' do
         expect(subject).to have_tag('div', with: { 'data-module' => 'radios' }) do |dm|
           expect(dm).to have_tag('input', count: colours.size, with: { type: 'radio' })
         end
       end
 
-      specify 'labels should have the correct classes' do
-        expect(subject).to have_tag('label', count: colours.size, with: { class: %w(govuk-label govuk-radios__label) })
+      specify 'each radio button should have the correct id' do
+        colours.each do |colour|
+          "person_favourite_colour_#{colour.id}".tap do |association|
+            expect(subject).to have_tag('input', with: { id: association })
+          end
+        end
+      end
+
+      specify 'radio buttons should have the correct name' do
+        parsed_subject.css('input').each do |input|
+          expect(input['name']).to eql('person[favourite_colour]')
+        end
       end
 
       specify 'radio buttons should be associated with corresponding labels' do
@@ -75,21 +89,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
 
-      specify 'radio buttons should have the correct id' do
-        colours.each do |colour|
-          "person_favourite_colour_#{colour.id}".tap do |association|
-            expect(subject).to have_tag('input', with: { id: association })
-          end
-        end
-      end
-
-      specify 'radio buttons should have the correct id' do
-        parsed_subject.css('input').each do |input|
-          expect(input['name']).to eql('person[favourite_colour]')
-        end
-      end
-
-      context 'when hint_method attribute is present' do
+      context 'radio button hints' do
         let(:colours_with_descriptions) { colours.select { |c| c.description.present? } }
         let(:colours_without_descriptions) { colours.reject { |c| c.description.present? } }
 
@@ -116,48 +116,48 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           end
         end
       end
-    end
 
-    context 'layout direction' do
-      context 'when inline is specified in the options' do
-        subject do
-          builder.send(method, attribute, colours, :id, :name, :description, inline: true)
+      context 'layout direction' do
+        context 'when inline is specified in the options' do
+          subject do
+            builder.send(method, attribute, colours, :id, :name, :description, inline: true)
+          end
+
+          specify "should have the additional class 'govuk-radios--inline'" do
+            expect(subject).to have_tag('div', with: { class: %w(govuk-radios govuk-radios--inline) })
+          end
         end
 
-        specify "should have the additional class 'govuk-radios--inline'" do
-          expect(subject).to have_tag('div', with: { class: %w(govuk-radios govuk-radios--inline) })
-        end
-      end
+        context 'when inline is not specified in the options' do
+          subject do
+            builder.send(method, attribute, colours, :id, :name, :description, inline: false)
+          end
 
-      context 'when inline is not specified in the options' do
-        subject do
-          builder.send(method, attribute, colours, :id, :name, :description, inline: false)
-        end
-
-        specify "should not have the additional class 'govuk-radios--inline'" do
-          expect(parsed_subject.at_css('.govuk-radios')['class']).to eql('govuk-radios')
-        end
-      end
-    end
-
-    context 'radio button size' do
-      context 'when small is specified in the options' do
-        subject do
-          builder.send(method, attribute, colours, :id, :name, :description, small: true)
-        end
-
-        specify "should have the additional class 'govuk-radios--small'" do
-          expect(subject).to have_tag('div', with: { class: %w(govuk-radios govuk-radios--small) })
+          specify "should not have the additional class 'govuk-radios--inline'" do
+            expect(parsed_subject.at_css('.govuk-radios')['class']).to eql('govuk-radios')
+          end
         end
       end
 
-      context 'when small is not specified in the options' do
-        subject do
-          builder.send(method, attribute, colours, :id, :name, :description, small: false)
+      context 'radio button size' do
+        context 'when small is specified in the options' do
+          subject do
+            builder.send(method, attribute, colours, :id, :name, :description, small: true)
+          end
+
+          specify "should have the additional class 'govuk-radios--small'" do
+            expect(subject).to have_tag('div', with: { class: %w(govuk-radios govuk-radios--small) })
+          end
         end
 
-        specify "should not have the additional class 'govuk-radios--small'" do
-          expect(parsed_subject.at_css('.govuk-radios')['class']).to eql('govuk-radios')
+        context 'when small is not specified in the options' do
+          subject do
+            builder.send(method, attribute, colours, :id, :name, :description, small: false)
+          end
+
+          specify "should not have the additional class 'govuk-radios--small'" do
+            expect(parsed_subject.at_css('.govuk-radios')['class']).to eql('govuk-radios')
+          end
         end
       end
     end
@@ -197,7 +197,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       specify 'output should contain radio buttons' do
-        expect(subject).to have_tag('div', with: { class: 'govuk-radios' }) do
+        expect(subject).to have_tag('div', with: { class: 'govuk-radios', 'data-module' => 'radios' }) do
           expect(subject).to have_tag('input', with: { type: 'radio' }, count: 2)
         end
       end
@@ -222,7 +222,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             end
           end
 
-          specify "should not have the additional class 'govuk-radios--inline'" do
+          specify "should have no additional classes" do
             expect(parsed_subject.at_css('.govuk-radios')['class']).to eql('govuk-radios')
           end
         end
@@ -261,7 +261,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           end
         end
 
-        specify "should output a divider with default 'or' text" do
+        specify "should output a 'or' divider by default" do
           expect(subject).to have_tag('div', text: 'or', with: { class: %w(govuk-radios__divider) })
         end
 
@@ -273,7 +273,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             end
           end
 
-          specify "should output a divider with default 'or' text" do
+          specify "should output a divider containing the supplied text" do
             expect(subject).to have_tag('div', text: other_text, with: { class: %w(govuk-radios__divider) })
           end
         end
@@ -304,8 +304,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         builder.govuk_radio_button(:favourite_colour, :red, hint_text: red_hint)
       end
 
-      specify 'should contain a label with the correct text' do
-        expect(subject).to have_tag('span', text: red_hint, with: { class: %w(govuk-hint govuk-radios__hint) })
+      specify 'should contain a hint with the correct text' do
+        expect(subject).to have_tag('span', text: red_hint)
+      end
+
+      specify 'the hint should have the correct classes' do
+        expect(subject).to have_tag('span', with: { class: %w(govuk-hint govuk-radios__hint) })
       end
     end
 

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -30,6 +30,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:error_class) { nil }
     end
 
+    it_behaves_like 'a field that accepts arbitrary blocks of HTML'
+
     specify 'output should be a form group containing a label and select box' do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
         expect(fg).to have_tag('select')
@@ -56,32 +58,11 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
       subject { builder.send(*args.push(html_options: extract_args(extra_args, :provided))) }
 
-      specify 'input tag should have the extra attributes' do
-        input_tag = parsed_subject.at_css('select')
+      specify 'select tag should have the extra attributes' do
+        select_tag = parsed_subject.at_css('select')
         extract_args(extra_args, :output).each do |key, val|
-          expect(input_tag[key]).to eql(val)
+          expect(select_tag[key]).to eql(val)
         end
-      end
-    end
-
-    context 'when passed a block' do
-      let(:block_h1) { 'The quick brown fox' }
-      let(:block_h2) { 'Jumped over the' }
-      let(:block_p) { 'Lazy dog.' }
-      subject do
-        builder.send(*args) do
-          builder.safe_join([
-            builder.tag.h1(block_h1),
-            builder.tag.h2(block_h2),
-            builder.tag.p(block_p)
-          ])
-        end
-      end
-
-      specify 'should include block content' do
-        expect(subject).to have_tag('h1', text: block_h1)
-        expect(subject).to have_tag('h2', text: block_h2)
-        expect(subject).to have_tag('p', text: block_p)
       end
     end
   end

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -4,6 +4,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   describe '#govuk_collection_select' do
     let(:attribute) { :favourite_colour }
     let(:label_text) { 'Cherished shade' }
+    let(:hint_text) { 'The colour of your favourite handkerchief' }
     let(:method) { :govuk_collection_select }
     let(:colours) do
       [
@@ -13,8 +14,21 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         OpenStruct.new(id: 'yellow', name: 'Yellow')
       ]
     end
+    let(:args) { [method, attribute, colours, :id, :name] }
+    subject { builder.send(*args) }
 
-    subject { builder.send(method, attribute, colours, :id, :name) }
+    let(:field_type) { 'select' }
+    let(:aria_described_by_target) { 'select' }
+
+    it_behaves_like 'a field that supports labels'
+
+    it_behaves_like 'a field that supports hints'
+
+    it_behaves_like 'a field that supports errors' do
+      let(:error_message) { /Choose a favourite colour/ }
+      let(:error_identifier) { 'person-favourite-colour-error' }
+      let(:error_class) { nil }
+    end
 
     specify 'output should be a form group containing a label and select box' do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
@@ -32,56 +46,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
-    context 'labelling' do
-      subject { builder.send(method, attribute, colours, :id, :name, label: { text: label_text }) }
-
-      specify 'the select box should be labelled correctly' do
-        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-          expect(fg).to have_tag('label', text: label_text)
-        end
-      end
-
-      specify 'the label should be associated with the input' do
-        input_name = parsed_subject.at_css('select')['id']
-        label_for = parsed_subject.at_css('label')['for']
-        expect(input_name).to eql(label_for)
-      end
-
-      context 'when the label is supplied with a wrapping tag' do
-        let(:wrapping_tag) { 'h2' }
-        subject { builder.send(method, attribute, colours, :id, :name, label: { text: label_text, tag: wrapping_tag }) }
-
-        specify 'the label should be wrapped in by the wrapping tag' do
-          expect(subject).to have_tag(wrapping_tag, with: { class: %w(govuk-label-wrapper) }) do |wt|
-            expect(wt).to have_tag('label', text: label_text)
-          end
-        end
-      end
-    end
-
-    context 'when a hint is provided' do
-      let(:hint) { 'The colour of your favourite handkerchief' }
-      subject { builder.send(method, attribute, colours, :id, :name, hint_text: hint) }
-
-      specify 'output should contain a hint' do
-        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-          expect(fg).to have_tag('span', text: hint, with: { class: 'govuk-hint' })
-        end
-      end
-
-      specify 'output should also contain the label and select elements' do
-        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-          %w(label select).each { |element| expect(fg).to have_tag(element) }
-        end
-      end
-
-      specify 'the hint should be associated with the input' do
-        select_aria_describedby = parsed_subject.at_css('select')['aria-describedby'].split
-        hint_id = parsed_subject.at_css('span.govuk-hint')['id']
-        expect(select_aria_describedby).to include(hint_id)
-      end
-    end
-
     context 'extra attributes' do
       let(:extra_args) do
         {
@@ -90,7 +54,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         }
       end
 
-      subject { builder.send(method, attribute, colours, :id, :name, html_options: extract_args(extra_args, :provided)) }
+      subject { builder.send(*args.push(html_options: extract_args(extra_args, :provided))) }
 
       specify 'input tag should have the extra attributes' do
         input_tag = parsed_subject.at_css('select')
@@ -105,7 +69,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:block_h2) { 'Jumped over the' }
       let(:block_p) { 'Lazy dog.' }
       subject do
-        builder.send(method, attribute, colours, :id, :name) do
+        builder.send(*args) do
           builder.safe_join([
             builder.tag.h1(block_h1),
             builder.tag.h2(block_h2),

--- a/spec/support/shared/shared_block_examples.rb
+++ b/spec/support/shared/shared_block_examples.rb
@@ -1,0 +1,20 @@
+shared_examples 'a field that accepts arbitrary blocks of HTML' do
+  let(:block_h1) { 'The quick brown fox' }
+  let(:block_h2) { 'Jumped over the' }
+  let(:block_p) { 'Lazy dog.' }
+  subject do
+    builder.send(*args) do
+      builder.safe_join([
+        builder.tag.h1(block_h1),
+        builder.tag.h2(block_h2),
+        builder.tag.p(block_p)
+      ])
+    end
+  end
+
+  specify 'should include block content' do
+    expect(subject).to have_tag('h1', text: block_h1)
+    expect(subject).to have_tag('h2', text: block_h2)
+    expect(subject).to have_tag('p', text: block_p)
+  end
+end

--- a/spec/support/shared/shared_error_examples.rb
+++ b/spec/support/shared/shared_error_examples.rb
@@ -7,10 +7,12 @@ shared_examples 'a field that supports errors' do
     end
 
     specify 'the field element should have the correct error classes' do
-      expect(subject).to have_tag(field_type, with: { class: error_class })
+      if error_class.present?
+        expect(subject).to have_tag(field_type, with: { class: error_class })
+      end
     end
 
-    specify 'the error message should be associated with the field element' do
+    specify 'the error message should be associated with the correct element' do
       expect(subject).to have_tag(aria_described_by_target, with: { 'aria-describedby' => error_identifier })
       expect(subject).to have_tag('span', with: {
         class: 'govuk-error-message',

--- a/spec/support/shared/shared_error_examples.rb
+++ b/spec/support/shared/shared_error_examples.rb
@@ -1,0 +1,27 @@
+shared_examples 'a field that supports errors' do
+  context 'when the attribute has errors' do
+    before { object.valid? }
+
+    specify 'an error message should be displayed' do
+      expect(subject).to have_tag('span', with: { class: 'govuk-error-message' }, text: error_message)
+    end
+
+    specify 'the field element should have the correct error classes' do
+      expect(subject).to have_tag(field_type, with: { class: error_class })
+    end
+
+    specify 'the error message should be associated with the field element' do
+      expect(subject).to have_tag(aria_described_by_target, with: { 'aria-describedby' => error_identifier })
+      expect(subject).to have_tag('span', with: {
+        class: 'govuk-error-message',
+        id: error_identifier
+      })
+    end
+  end
+
+  context 'when the attribute has no errors' do
+    specify 'no error messages should be displayed' do
+      expect(subject).not_to have_tag('span', with: { class: 'govuk-error-message' })
+    end
+  end
+end

--- a/spec/support/shared/shared_hint_examples.rb
+++ b/spec/support/shared/shared_hint_examples.rb
@@ -1,0 +1,35 @@
+shared_examples 'a field that supports hints' do
+  context 'when a hint is provided' do
+    subject { builder.send(*args.push(hint_text: hint_text)) }
+
+    specify 'output should contain a hint' do
+      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
+        expect(fg).to have_tag('span', text: hint_text, with: { class: 'govuk-hint' })
+      end
+    end
+
+    specify 'output should also contain the label and field elements' do
+      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
+        ['label', field_type].each { |element| expect(fg).to have_tag(element) }
+      end
+    end
+
+    specify 'the hint should be associated with the input' do
+      input_aria_describedby = parsed_subject.at_css(aria_described_by_target)['aria-describedby'].split
+      hint_id = parsed_subject.at_css('span.govuk-hint')['id']
+      expect(input_aria_describedby).to include(hint_id)
+    end
+  end
+
+  context 'when a hint is not provided' do
+    subject { builder.send(*args) }
+
+    specify 'no hint should be present' do
+      expect(subject).not_to have_tag('span', with: { class: 'govuk-hint' })
+    end
+
+    specify 'output should have no empty aria-describedby attribute' do
+      expect(parsed_subject.at_css(field_type)['aria-describedby']).not_to be_present
+    end
+  end
+end

--- a/spec/support/shared/shared_label_examples.rb
+++ b/spec/support/shared/shared_label_examples.rb
@@ -1,0 +1,62 @@
+shared_examples 'a field that supports labels' do
+  context 'when a label is provided' do
+    subject { builder.send(*args.push(label: { text: label_text })) }
+
+    specify 'the label should be included' do
+      expect(subject).to have_tag('label', with: { class: 'govuk-label' }, text: label_text)
+    end
+
+    specify 'the label should be associated with the input' do
+      input_name = parsed_subject.at_css(field_type)['id']
+      label_for = parsed_subject.at_css('label')['for']
+      expect(input_name).to eql(label_for)
+    end
+
+    context 'when the label is supplied with a wrapping tag' do
+      let(:wrapping_tag) { 'h2' }
+      subject { builder.send(*args.push(label: { text: label_text, tag: wrapping_tag })) }
+
+      specify 'the label should be wrapped in by the wrapping tag' do
+        expect(subject).to have_tag(wrapping_tag, with: { class: %w(govuk-label-wrapper) }) do |wt|
+          expect(wt).to have_tag('label', text: label_text)
+        end
+      end
+    end
+
+    context 'label styling' do
+      context 'font size overrides' do
+        {
+          'xl' => 'govuk-label--xl',
+          'l'  => 'govuk-label--l',
+          'm'  => 'govuk-label--m',
+          's'  => 'govuk-label--s',
+          nil  => nil
+        }.each do |size_name, size_class|
+          context "#{size_name} labels" do
+            let(:size_name) { size_name }
+            let(:size_class) { size_class }
+            subject { builder.send(*args.push(label: { size: size_name })) }
+
+            if size_class.present?
+              specify "should have extra class '#{size_class}'" do
+                expect(extract_classes(parsed_subject, 'label')).to include(size_class)
+              end
+            else
+              specify 'should have no extra size classes' do
+                expect(extract_classes(parsed_subject, 'label')).to eql(%w(govuk-label))
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  context 'when no label is provided' do
+    subject { builder.send(*args) }
+
+    specify 'the label should have the default value' do
+      expect(subject).to have_tag('label', with: { class: 'govuk-label' }, text: attribute.capitalize)
+    end
+  end
+end

--- a/spec/support/shared/shared_label_examples.rb
+++ b/spec/support/shared/shared_label_examples.rb
@@ -25,13 +25,16 @@ shared_examples 'a field that supports labels' do
 
     context 'label styling' do
       context 'font size overrides' do
-        {
+        label_sizes = {
           'xl' => 'govuk-label--xl',
           'l'  => 'govuk-label--l',
           'm'  => 'govuk-label--m',
           's'  => 'govuk-label--s',
           nil  => nil
-        }.each do |size_name, size_class|
+        }
+        let(:label_sizes) { label_sizes }
+
+        label_sizes.each do |size_name, size_class|
           context "#{size_name} labels" do
             let(:size_name) { size_name }
             let(:size_class) { size_class }
@@ -43,7 +46,7 @@ shared_examples 'a field that supports labels' do
               end
             else
               specify 'should have no extra size classes' do
-                expect(extract_classes(parsed_subject, 'label')).to eql(%w(govuk-label))
+                expect(extract_classes(parsed_subject, 'label') & label_sizes.values).to be_empty
               end
             end
           end

--- a/spec/support/shared/shared_label_examples.rb
+++ b/spec/support/shared/shared_label_examples.rb
@@ -35,7 +35,7 @@ shared_examples 'a field that supports labels' do
         let(:label_sizes) { label_sizes }
 
         label_sizes.each do |size_name, size_class|
-          context "#{size_name} labels" do
+          context "#{size_name || 'no'} param" do
             let(:size_name) { size_name }
             let(:size_class) { size_class }
             subject { builder.send(*args.push(label: { size: size_name })) }
@@ -50,6 +50,12 @@ shared_examples 'a field that supports labels' do
               end
             end
           end
+        end
+
+        context 'when an invalid size is supplied' do
+          let(:size) { 'extra-medium' }
+          subject { builder.send(*args.push(label: { size: size })) }
+          specify { expect { subject }.to raise_error("invalid size '#{size}', must be xl, l, m, s or nil") }
         end
       end
     end

--- a/spec/support/shared/shared_legend_examples.rb
+++ b/spec/support/shared/shared_legend_examples.rb
@@ -1,0 +1,66 @@
+shared_examples 'a field that supports a fieldset with legend' do
+  context 'when a legend is supplied' do
+    context 'when text is supplied' do
+      subject { builder.send(*args.push(legend: { text: legend_text })) }
+
+      specify 'legend tag should be present' do
+        expect(subject).to have_tag('legend')
+      end
+    end
+
+    context 'when no text is supplied' do
+      subject { builder.send(*args.push(legend: { text: nil })) }
+
+      specify 'output should not contain a header' do
+        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
+          expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
+            expect(fs).not_to have_tag('h1')
+          end
+        end
+      end
+    end
+
+    context 'when text is supplied with a custom tag' do
+      let(:tag) { 'h4' }
+      subject { builder.send(*args.push(legend: { text: legend_text, tag: tag })) }
+
+      specify 'output fieldset should contain the specified tag' do
+        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
+          expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
+            expect(fs).to have_tag(tag, text: legend_text)
+          end
+        end
+      end
+    end
+
+    context 'when text is supplied with a custom size' do
+      context 'with a valid size' do
+        let(:size) { 'm' }
+        subject { builder.send(*args.push(legend: { text: legend_text, size: size })) }
+
+        specify 'output fieldset should contain the specified tag' do
+          expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
+            expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
+              expect(fs).to have_tag('h1', text: legend_text, class: "govuk-fieldset__legend--#{size}")
+            end
+          end
+        end
+      end
+
+      context 'with an invalid size' do
+        let(:size) { 'extra-medium' }
+        subject { builder.send(*args.push(legend: { text: legend_text, size: size })) }
+
+        specify 'should raise an error' do
+          expect { subject }.to raise_error("invalid size '#{size}', must be xl, l, m, s")
+        end
+      end
+    end
+  end
+
+  context 'when no legend is supplied' do
+    specify 'legend tag should not be present' do
+      expect(subject).not_to have_tag('legend')
+    end
+  end
+end


### PR DESCRIPTION
There was a fair amount of duplication across the various specs for methods that take common arguments (`label`, `hint_text`) and have common behaviours (errors and HTML blocks).

Much of this has been moved to `shared_example` blocks and the organisation and readability of the output has been significantly improved.