### PR TITLE
More refactoring, tidying and deduplication

### DIFF
--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -10,6 +10,18 @@ module GOVUKDesignSystemFormBuilder
       fail 'should be overridden'
     end
 
+    def hint_element
+      @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text)
+    end
+
+    def error_element
+      @error_element ||= Elements::ErrorMessage.new(@builder, @object_name, @attribute_name)
+    end
+
+    def label_element
+      @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, @label)
+    end
+
     # returns the id value used for the input
     #
     # @note field_id is overridden so that the error summary can link to the

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -58,6 +58,10 @@ module GOVUKDesignSystemFormBuilder
       end
     end
 
+    def described_by(*ids)
+      ids.flatten.compact.join(' ').presence
+    end
+
   private
 
     # Builds the values used for HTML id attributes throughout the builder

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -6,10 +6,6 @@ module GOVUKDesignSystemFormBuilder
       @attribute_name = attribute_name
     end
 
-    def html
-      fail 'should be overridden'
-    end
-
     def hint_element
       @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text)
     end

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -11,9 +11,6 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        hint_element  = Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text)
-        error_element = Elements::ErrorMessage.new(@builder, @object_name, @attribute_name)
-
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
           Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_element.error_id, hint_element.hint_id]).html do
             @builder.safe_join([

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -7,7 +7,7 @@ module GOVUKDesignSystemFormBuilder
       def initialize(builder, legend: {}, described_by: nil)
         @builder = builder
         @legend = LEGEND_DEFAULTS.merge(legend)
-        @described_by = descriptors(described_by)
+        @described_by = described_by(described_by)
       end
 
       def html
@@ -42,12 +42,6 @@ module GOVUKDesignSystemFormBuilder
 
       def legend_heading_classes
         %(govuk-fieldset__heading)
-      end
-
-      def descriptors(described_by)
-        return nil if described_by.blank?
-
-        described_by.compact.join(' ').presence
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
@@ -12,9 +12,6 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        hint_element  = Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text)
-        error_element = Elements::ErrorMessage.new(@builder, @object_name, @attribute_name)
-
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
           Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_element.error_id, hint_element.hint_id]).html do
             @builder.safe_join([

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -16,9 +16,6 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def html
-          hint_element  = Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text)
-          error_element = Elements::ErrorMessage.new(@builder, @object_name, @attribute_name)
-
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
             Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_element.error_id, hint_element.hint_id]).html do
               @builder.safe_join(

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
@@ -12,17 +12,29 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def html
-          hint = Hint.new(@builder, @object_name, @attribute_name, hint_text: @hint_text, value: @value)
-
           @builder.content_tag('div', class: 'govuk-checkboxes__item') do
             @builder.safe_join(
               [
-                @checkbox.check_box(id: field_id(link_errors: @link_errors), class: "govuk-checkboxes__input", aria: { describedby: hint.hint_id }),
-                Label.new(@checkbox, @object_name, @attribute_name, value: @value).html,
-                hint.html
+                @checkbox.check_box(
+                  id: field_id(link_errors: @link_errors),
+                  class: "govuk-checkboxes__input",
+                  aria: { describedby: hint_element.hint_id }
+                ),
+                label_element.html,
+                hint_element.html
               ]
             )
           end
+        end
+
+      private
+
+        def label_element
+          @label_element ||= Label.new(@checkbox, @object_name, @attribute_name, value: @value)
+        end
+
+        def hint_element
+          @hint_element ||= Hint.new(@builder, @object_name, @attribute_name, @hint_text, value: @value)
         end
       end
     end

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/hint.rb
@@ -2,7 +2,7 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module CheckBoxes
       class Hint < GOVUKDesignSystemFormBuilder::Base
-        def initialize(builder, object_name, attribute_name, hint_text:, value:)
+        def initialize(builder, object_name, attribute_name, hint_text, value:)
           super(builder, object_name, attribute_name)
 
           @value     = value

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -12,9 +12,6 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        hint_element  = Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text)
-        error_element = Elements::ErrorMessage.new(@builder, @object_name, @attribute_name)
-
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
           Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_element.error_id, hint_element.hint_id]).html do
             @builder.safe_join(

--- a/lib/govuk_design_system_formbuilder/elements/error_message.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_message.rb
@@ -9,10 +9,12 @@ module GOVUKDesignSystemFormBuilder
         return nil unless has_errors?
 
         @builder.content_tag('span', class: 'govuk-error-message', id: error_id) do
-          @builder.safe_join([
-            @builder.tag.span('Error: ', class: 'govuk-visually-hidden'),
-            message
-          ])
+          @builder.safe_join(
+            [
+              @builder.tag.span('Error: ', class: 'govuk-visually-hidden'),
+              message
+            ]
+          )
         end
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -10,10 +10,6 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        hint_element  = Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text)
-        label_element = Elements::Label.new(@builder, @object_name, @attribute_name, @label)
-        error_element = Elements::ErrorMessage.new(@builder, @object_name, @attribute_name)
-
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
           @builder.safe_join(
             [
@@ -24,12 +20,7 @@ module GOVUKDesignSystemFormBuilder
                 @attribute_name,
                 id: field_id(link_errors: true),
                 class: file_classes,
-                aria: {
-                  describedby: [
-                    hint_element.hint_id,
-                    error_element.error_id
-                  ].compact.join(' ').presence
-                },
+                aria: { describedby: described_by(hint_element.hint_id, error_element.error_id) },
                 **@extra_args
               )
             ]

--- a/lib/govuk_design_system_formbuilder/elements/input.rb
+++ b/lib/govuk_design_system_formbuilder/elements/input.rb
@@ -12,10 +12,6 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        hint_element  = Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text)
-        label_element = Elements::Label.new(@builder, @object_name, @attribute_name, @label)
-        error_element = Elements::ErrorMessage.new(@builder, @object_name, @attribute_name)
-
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
           @builder.safe_join(
             [

--- a/lib/govuk_design_system_formbuilder/elements/input.rb
+++ b/lib/govuk_design_system_formbuilder/elements/input.rb
@@ -27,12 +27,7 @@ module GOVUKDesignSystemFormBuilder
                 @attribute_name,
                 id: field_id(link_errors: true),
                 class: input_classes,
-                aria: {
-                  describedby: [
-                    hint_element.hint_id,
-                    error_element.error_id
-                  ].compact.join(' ').presence
-                },
+                aria: { describedby: described_by(hint_element.hint_id, error_element.error_id) },
                 **@extra_args
               )
             ]

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -17,9 +17,6 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def html
-          hint_element  = Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text)
-          error_element = Elements::ErrorMessage.new(@builder, @object_name, @attribute_name)
-
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
             Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_element.error_id, hint_element.hint_id]).html do
               @builder.safe_join(
@@ -30,7 +27,7 @@ module GOVUKDesignSystemFormBuilder
                   Containers::Radios.new(@builder, inline: @inline, small: @small).html do
                     @builder.safe_join(build_collection)
                   end
-                ].compact
+                ]
               )
             end
           end

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
@@ -26,11 +26,21 @@ module GOVUKDesignSystemFormBuilder
                   aria: { describedby: hint_id },
                   class: %w(govuk-radios__input)
                 ),
-                Elements::Label.new(@builder, @object_name, @attribute_name, text: @text, value: @value, radio: true).html,
-                Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text, @value, radio: true).html,
-              ].compact
+                label_element.html,
+                hint_element.html
+              ]
             )
           end
+        end
+
+      private
+
+        def hint_element
+          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text, @value, radio: true)
+        end
+
+        def label_element
+          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, text: @text, value: @value, radio: true)
         end
       end
     end

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -21,8 +21,8 @@ module GOVUKDesignSystemFormBuilder
             @builder.safe_join(
               [
                 input,
-                Elements::Label.new(@builder, @object_name, @attribute_name, radio: true, value: @value, **@label).html,
-                Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text, radio: true).html,
+                label_element.html,
+                hint_element.html,
                 @conditional_content
               ]
             )
@@ -30,6 +30,14 @@ module GOVUKDesignSystemFormBuilder
         end
 
       private
+
+        def label_element
+          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, radio: true, value: @value, **@label)
+        end
+
+        def hint_element
+          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text, radio: true)
+        end
 
         def input
           @builder.radio_button(

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -43,12 +43,7 @@ module GOVUKDesignSystemFormBuilder
         @html_options.deep_merge(
           id: field_id(link_errors: true),
           class: select_classes,
-          aria: {
-            describedby: [
-              hint_element.hint_id,
-              error_element.error_id
-            ].compact.join(' ').presence
-          }
+          aria: { describedby: described_by(hint_element.hint_id, error_element.error_id) }
         )
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -15,10 +15,6 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        label_element = Elements::Label.new(@builder, @object_name, @attribute_name, @label)
-        hint_element  = Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text)
-        error_element = Elements::ErrorMessage.new(@builder, @object_name, @attribute_name)
-
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
           @builder.safe_join([
             label_element.html,

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -46,7 +46,7 @@ module GOVUKDesignSystemFormBuilder
           formnovalidate: !@validate,
           data: {
             'prevent-double-click' => @prevent_double_click
-          }.select { |_k, v| v }
+          }.select { |_k, v| v.present? }
         }
       end
     end

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -22,12 +22,7 @@ module GOVUKDesignSystemFormBuilder
                   @attribute_name,
                   id: field_id(link_errors: true),
                   class: govuk_textarea_classes,
-                  aria: {
-                    describedby: [
-                      hint_element.hint_id,
-                      error_element.error_id
-                    ].compact.join(' ').presence
-                  },
+                  aria: { describedby: described_by(hint_element.hint_id, error_element.error_id) },
                   **@extra_args.merge(rows: @rows)
                 ),
                 character_count_info

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -34,18 +34,6 @@ module GOVUKDesignSystemFormBuilder
 
     private
 
-      def hint_element
-        @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text)
-      end
-
-      def label_element
-        @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, @label)
-      end
-
-      def error_element
-        @error_element ||= Elements::ErrorMessage.new(@builder, @object_name, @attribute_name)
-      end
-
       def govuk_textarea_classes
         %w(govuk-textarea).tap do |classes|
           classes.push('govuk-textarea--error') if has_errors?


### PR DESCRIPTION
There was some duplication across the element helpers in creating labels, hints and errors - these have been moved to `Base` where possible. Similarly, the duplicate building of `aria-describedby` code has been removed.