### PR TITLE
Prefixes birth date autocomplete values with bday

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -98,7 +98,7 @@ module GOVUKDesignSystemFormBuilder
       def date_of_birth_autocomplete_value(segment)
         return nil unless @date_of_birth
 
-        { day: 'bday-day', month: 'bday-month', year: 'bday-year' }.fetch(segment)
+        "bday bday-#{segment}"
       end
     end
   end

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -158,16 +158,16 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     context 'auto-completion' do
       context 'date of birth' do
         subject { builder.send(*args.push(date_of_birth: true)) }
-        specify "day field should have autocomplete attribute with value 'bday-day'" do
-          expect(subject).to have_tag('input', with: { autocomplete: 'bday-day' })
+        specify "day field should have autocomplete attribute with value 'bday bday-day'" do
+          expect(subject).to have_tag('input', with: { autocomplete: 'bday bday-day' })
         end
 
-        specify "month field should have autocomplete attribute with value 'bday-month'" do
-          expect(subject).to have_tag('input', with: { autocomplete: 'bday-month' })
+        specify "month field should have autocomplete attribute with value 'bday bday-month'" do
+          expect(subject).to have_tag('input', with: { autocomplete: 'bday bday-month' })
         end
 
-        specify "year field should have autocomplete attribute with value 'bday-year'" do
-          expect(subject).to have_tag('input', with: { autocomplete: 'bday-year' })
+        specify "year field should have autocomplete attribute with value 'bday bday-year'" do
+          expect(subject).to have_tag('input', with: { autocomplete: 'bday bday-year' })
         end
       end
     end


### PR DESCRIPTION
The [WhatWG specification for autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-bday-day) indicates that `bday-day`, `bday-month` and `bday-year` are nested beneath bday, although the document doesn't make that immediately obvious.

They are now prefixed in the `autocomplete` attribute by `bday`. Tested and working in Chrome and Firefox 👍🏽

Fixes #17