### PR TITLE
GOV.UK Design System Version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/fde73b5dc9476197281b/test_coverage)](https://codeclimate.com/github/DFE-Digital/govuk_design_system_formbuilder/test_coverage)
 
 This gem provides a easy-to-use form builder that generates forms that are
-fully-compliant with the [GOV.UK Design System](https://design-system.service.gov.uk/),
+fully-compliant with version 3 of the [GOV.UK Design System](https://design-system.service.gov.uk/),
 minimising the amount of markup you need to write.
+
+The latest version of this gem that supports GOV.UK Design System version 2 is
+[0.7.10](https://github.com/DFE-Digital/govuk_design_system_formbuilder/releases/tag/v0.7.10).
 
 In addition to the basic markup, the more-advanced functionality of the Design
 System is exposed via the API. Adding [JavaScript-enhanced word count
@@ -103,7 +106,7 @@ bundle
 Now, if everything was successful, run RSpec:
 
 ```sh
-rspec -fd
+bundle exec rspec -fd
 ```
 
 ## Contributing

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
@@ -7,7 +7,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        @builder.content_tag('div', class: check_boxes_classes, data: { module: 'checkboxes' }) do
+        @builder.content_tag('div', class: check_boxes_classes, data: { module: 'govuk-checkboxes' }) do
           yield
         end
       end

--- a/lib/govuk_design_system_formbuilder/containers/radios.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radios.rb
@@ -8,7 +8,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        @builder.content_tag('div', class: radios_classes, data: { module: 'radios' }) do
+        @builder.content_tag('div', class: radios_classes, data: { module: 'govuk-radios' }) do
           yield
         end
       end

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -45,6 +45,7 @@ module GOVUKDesignSystemFormBuilder
         {
           formnovalidate: !@validate,
           data: {
+            module: 'govuk-button',
             'prevent-double-click' => @prevent_double_click
           }.select { |_k, v| v.present? }
         }

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -37,7 +37,7 @@ module GOVUKDesignSystemFormBuilder
       def govuk_textarea_classes
         %w(govuk-textarea).tap do |classes|
           classes.push('govuk-textarea--error') if has_errors?
-          classes.push('js-character-count') if limit?
+          classes.push('govuk-js-character-count') if limit?
         end
       end
 

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes_spec.rb
@@ -53,8 +53,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     describe 'check boxes' do
       specify 'output should contain the correct number of check boxes' do
-        expect(subject).to have_tag('input', count: projects.size, with: { type: 'checkbox' })
-        expect(subject).to have_tag('label', count: projects.size)
+        expect(subject).to have_tag('div', with: { 'data-module' => 'govuk-checkboxes' }) do |cb|
+          expect(cb).to have_tag('input', count: projects.size, with: { type: 'checkbox' })
+          expect(cb).to have_tag('label', count: projects.size)
+        end
       end
 
       context 'check box size' do
@@ -173,7 +175,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       specify 'output should contain check boxes' do
-        expect(subject).to have_tag('div', with: { class: 'govuk-checkboxes', 'data-module' => 'checkboxes' }) do
+        expect(subject).to have_tag('div', with: { class: 'govuk-checkboxes', 'data-module' => 'govuk-checkboxes' }) do
           expect(subject).to have_tag('input', with: { type: 'checkbox' }, count: 3)
         end
       end

--- a/spec/govuk_design_system_formbuilder/builder/radios_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios_spec.rb
@@ -57,7 +57,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       specify 'radio buttons should be surrounded by a radios module' do
-        expect(subject).to have_tag('div', with: { 'data-module' => 'radios' }) do |dm|
+        expect(subject).to have_tag('div', with: { 'data-module' => 'govuk-radios' }) do |dm|
           expect(dm).to have_tag('input', count: colours.size, with: { type: 'radio' })
         end
       end
@@ -193,7 +193,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       specify 'output should contain radio buttons' do
-        expect(subject).to have_tag('div', with: { class: 'govuk-radios', 'data-module' => 'radios' }) do
+        expect(subject).to have_tag('div', with: { class: 'govuk-radios', 'data-module' => 'govuk-radios' }) do
           expect(subject).to have_tag('input', with: { type: 'radio' }, count: 2)
         end
       end

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -20,6 +20,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       expect(subject).to have_tag('input', with: { value: text })
     end
 
+    specify 'button should have the govuk-button data-module' do
+      expect(subject).to have_tag('input', with: { 'data-module' => 'govuk-button' })
+    end
+
     describe 'button styles and colours' do
       context 'warning' do
         subject { builder.send(method, 'Create', warning: true) }

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -50,8 +50,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         )
       end
 
-      specify 'should add js-character-count class to the textarea' do
-        expect(subject).to have_tag('textarea', with: { class: 'js-character-count' })
+      specify 'should add govuk-js-character-count class to the textarea' do
+        expect(subject).to have_tag('textarea', with: { class: 'govuk-js-character-count' })
       end
 
       specify 'should add a character count message' do
@@ -78,8 +78,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         )
       end
 
-      specify 'should add js-character-count class to the textarea' do
-        expect(subject).to have_tag('textarea', with: { class: 'js-character-count' })
+      specify 'should add govuk-js-character-count class to the textarea' do
+        expect(subject).to have_tag('textarea', with: { class: 'govuk-js-character-count' })
       end
 
       specify 'should add a character count message' do


### PR DESCRIPTION
Version 3 of the [GOV.UK Design System](https://design-system.service.gov.uk/) was recently released and it contains several breaking changes, outlined in their [changelog document](https://github.com/alphagov/govuk-frontend/blob/master/CHANGELOG.md).

This PR aims to bring the form builder completely up to date with Version 3.