### PR TITLE
Display one error message per field in error summary

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/error_message.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_message.rb
@@ -19,7 +19,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def message
-        @builder.object.errors.messages.dig(@attribute_name)
+        @builder.object.errors.messages[@attribute_name]&.first
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -18,7 +18,7 @@ module GOVUKDesignSystemFormBuilder
                 @builder.content_tag('ul', class: ['govuk-list', summary_class('list')]) do
                   @builder.safe_join(
                     @builder.object.errors.messages.map do |attribute, messages|
-                      error_list_item(attribute, messages)
+                      error_list_item(attribute, messages.first)
                     end
                   )
                 end
@@ -30,10 +30,10 @@ module GOVUKDesignSystemFormBuilder
 
     private
 
-      def error_list_item(attribute, messages)
+      def error_list_item(attribute, message)
         @builder.content_tag('li') do
           @builder.link_to(
-            messages.join(', '),
+            message,
             same_page_link(field_id(attribute)),
             data: {
               turbolinks: false

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -31,18 +31,34 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         )
       end
 
-      specify 'the error summary should contain a list with all the errors included' do
-        expect(subject).to have_tag('ul', with: { class: %w(govuk-list govuk-error-summary__list) }) do
-          expect(subject).to have_tag('li', count: object.errors.count)
-        end
-      end
-
-      context 'error messages' do
+      describe 'error messages' do
         subject! { builder.send(method) }
 
+        context 'there are multiple errors each with one error message' do
+          let(:object) { Person.new(favourite_colour: nil, projects: []) }
+
+          specify 'the error summary should contain a list with one error message per field' do
+            expect(subject).to have_tag('ul', with: { class: %w(govuk-list govuk-error-summary__list) }) do
+              expect(subject).to have_tag('li', text: 'Choose a favourite colour')
+              expect(subject).to have_tag('li', text: 'Select at least one project')
+            end
+          end
+        end
+
+        context 'there are multiple errors and one has multiple error messages' do
+          let(:object) { Person.new(name: nil, favourite_colour: nil) }
+
+          specify 'the error summary should contain a list with one error message per field' do
+            expect(subject).to have_tag('ul', with: { class: %w(govuk-list govuk-error-summary__list) }) do
+              expect(subject).to have_tag('li', text: 'Choose a favourite colour')
+              expect(subject).to have_tag('li', text: 'Enter a name')
+            end
+          end
+        end
+
         specify 'the error message list should contain the correct messages' do
-          object.errors.messages.each do |_attribute, msg|
-            expect(subject).to have_tag('li', text: msg.join) do
+          object.errors.messages.each do |_attribute, message_list|
+            expect(subject).to have_tag('li', text: message_list.first) do
             end
           end
         end

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -12,6 +12,7 @@ class Person
 
   validate :born_on_must_be_in_the_past, if: -> { born_on.present? }
   validate :photo_must_be_jpeg, if: -> { photo.present? }
+  validates :name, length: { minimum: 2, message: 'Name should be longer than 1' }
 
   def self.valid_example
     new(

--- a/spec/support/shared/shared_error_examples.rb
+++ b/spec/support/shared/shared_error_examples.rb
@@ -19,6 +19,26 @@ shared_examples 'a field that supports errors' do
         id: error_identifier
       })
     end
+
+    context 'when there is more than one error' do
+      let(:first_error) { "It is totally wrong" }
+      let(:second_error) { "Very wrong indeed" }
+      let(:error_messages) { [first_error, second_error] }
+
+      before do
+        allow(object.errors.messages).to(
+          receive(:[]).and_return(error_messages)
+        )
+      end
+
+      specify 'the first error should be included' do
+        expect(subject).to have_tag('span', text: Regexp.new(first_error))
+      end
+
+      specify 'the second error should not be included' do
+        expect(subject).not_to have_tag('span', text: Regexp.new(second_error))
+      end
+    end
   end
 
   context 'when the attribute has no errors' do


### PR DESCRIPTION
### Context

The error summary displayed all field errors grouped on one line.

This commit changes the error summary to only display the first error for a field.

This PR is a draft as we would like to discuss the testing approach.

### Changes proposed in this pull request

Before
![Screenshot 2019-08-06 at 14 37 38](https://user-images.githubusercontent.com/47318392/62544526-d105e200-b857-11e9-829a-1ca6ace4a235.png)

----

After
![Screenshot 2019-08-06 at 14 35 06](https://user-images.githubusercontent.com/47318392/62544541-d7945980-b857-11e9-81f8-d0f4bdd3ac69.png)

### Guidance to review

To test this feature a model with two errors on one field was needed. 

We added an extra validation to the existing Person class.

We create an invalid person for these tests and then expect to see the correct message in the error summary. 

This feels brittle and we would like to discuss it.
