### PR TITLE
Allow labels to be optionally hidden

### DIFF
--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -34,7 +34,7 @@ require 'govuk_design_system_formbuilder/containers/character_count'
 
 module GOVUKDesignSystemFormBuilder
   class FormBuilder < ActionView::Helpers::FormBuilder
-    delegate :content_tag, :tag, :safe_join, :safe_concat, :capture, :link_to, to: :@template
+    delegate :content_tag, :tag, :safe_join, :safe_concat, :capture, :link_to, :raw, to: :@template
 
     include GOVUKDesignSystemFormBuilder::Builder
   end

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -10,6 +10,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
+    # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @option args [Hash] args additional arguments are applied as attributes to +input+ element
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -34,6 +35,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
+    # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @option args [Hash] args additional arguments are applied as attributes to +input+ element
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -59,6 +61,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
+    # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @option args [Hash] args additional arguments are applied as attributes to +input+ element
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -82,6 +85,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
+    # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @option args [Hash] args additional arguments are applied as attributes to +input+ element
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -105,6 +109,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
+    # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -130,6 +135,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
+    # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @param max_words [Integer] adds the GOV.UK max word count
     # @param max_chars [Integer] adds the GOV.UK max characters count
     # @param threshold [Integer] only show the +max_words+ and +max_chars+ warnings once a threshold (percentage) is reached
@@ -159,6 +165,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
+    # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @return [ActiveSupport::SafeBuffer] HTML output
     def govuk_collection_select(attribute_name, collection, value_method, text_method, options: {}, html_options: {}, hint_text: nil, label: {}, &block)
       Elements::Select.new(
@@ -377,6 +384,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
+    # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @param multiple [Boolean] controls whether the check box is part of a collection or represents a single attribute
     # @param block [Block] any HTML passed in will form the contents of the fieldset
     # @return [ActiveSupport::SafeBuffer] HTML output
@@ -504,6 +512,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label text [String] the label text
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
+    # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
     # @option args [Hash] args additional arguments are applied as attributes to +input+ element
     #

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -1,10 +1,10 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     class Label < GOVUKDesignSystemFormBuilder::Base
-      def initialize(builder, object_name, attribute_name, text: nil, value: nil, size: nil, radio: false, checkbox: false, tag: nil)
+      def initialize(builder, object_name, attribute_name, text: nil, value: nil, size: nil, hidden: false, radio: false, checkbox: false, tag: nil)
         super(builder, object_name, attribute_name)
 
-        @text           = label_text(text)
+        @text           = label_text(text, hidden)
         @value          = value # used by field_id
         @size_class     = label_size_class(size)
         @radio_class    = radio_class(radio)
@@ -27,15 +27,22 @@ module GOVUKDesignSystemFormBuilder
       def build_label
         @builder.label(
           @attribute_name,
-          @text,
           value: @value,
           for: field_id(link_errors: true),
           class: %w(govuk-label).push(@size_class, @weight_class, @radio_class, @checkbox_class).compact
-        )
+        ) do
+          @text
+        end
       end
 
-      def label_text(option_text)
-        [option_text, @value, @attribute_name.capitalize].compact.first
+      def label_text(option_text, hidden)
+        text = [option_text, @value, @attribute_name.capitalize].compact.first
+
+        if hidden
+          @builder.tag.span(text, class: %w(govuk-visually-hidden))
+        else
+          @builder.raw(text)
+        end
       end
 
       def radio_class(radio)

--- a/spec/support/shared/shared_label_examples.rb
+++ b/spec/support/shared/shared_label_examples.rb
@@ -23,6 +23,16 @@ shared_examples 'a field that supports labels' do
       end
     end
 
+    context 'hidden labels' do
+      subject { builder.send(*args.push(label: { text: label_text, hidden: true })) }
+
+      specify 'the label should be wrapped in a visually-hidden span' do
+        expect(subject).to have_tag('label', text: label_text) do |label_element|
+          expect(label_element).to have_tag('span', text: label_text, with: { class: 'govuk-visually-hidden' })
+        end
+      end
+    end
+
     context 'label styling' do
       context 'font size overrides' do
         label_sizes = {


### PR DESCRIPTION
Sometimes labels add noise to a form and are unecessary. An example of
this is when capturing an address with multiple lines. The initial label
'Address' should make it obvious what lines 2-4 are for. The label
should still be present to keep the form accessible.

This change adds the ability to wrap the contents of a label in a span
that hides it visually. There is an example of this technique used in
the [fieldset section of the Design System documentation](https://design-system.service.gov.uk/components/fieldset/).