### PR TITLE
Allow bold radio button labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ build:
 	${prefix} gem build govuk_design_system_formbuilder.gemspec
 build_guide:
 	${guide_dir} ${prefix} nanoc
-make code-climate:
+docs-server:
+	yard server --reload
+code-climate:
 	codeclimate analyze {lib,spec,guide/lib}
 clean:
 	rm -rf guide/output/**/*

--- a/guide/content/form-elements/radios.slim
+++ b/guide/content/form-elements/radios.slim
@@ -44,6 +44,11 @@ section
         each option and if a description is present it will be displayed, if it is
         null or empty no hint will be rendered.
 
+    p.govuk-body
+      | When descriptions are enabled in a radio button collection the labels
+        are made <strong>bold</strong> by default. This provides additional
+        contrast and makes the labels stand out from the hint.
+
   == render('/partials/example-fig.*',
     caption: "Small radio buttons",
     code: small_radio_field,

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -185,8 +185,12 @@ module GOVUKDesignSystemFormBuilder
 
     # Generates a radio button for each item in the supplied collection
     #
-    # @note Unlike the Rails +collection_radio_buttons+ helper, this version can also insert
+    # @note Unlike the Rails +#collection_radio_buttons+ helper, this version can also insert
     #   hints per item in the collection by supplying a +:hint_method+
+    #
+    # @note +:bold_labels+, while false by default, is set to true when a
+    #   +:hint_method+ is provided. This is done to make the label stand out more
+    #   from the hint.
     #
     # @param attribute_name [Symbol] The name of the attribute
     # @param collection [Enumerable<Object>] Options to be added to the +select+ element
@@ -197,6 +201,7 @@ module GOVUKDesignSystemFormBuilder
     # @param legend [Hash] options for configuring the legend
     # @param inline [Boolean] controls whether the radio buttons are displayed inline or not
     # @param small [Boolean] controls whether small radio buttons are used instead of regular-sized ones
+    # @param bold_labels [Boolean] controls whether the radio button labels are bold
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+, defaults to +h1+
@@ -217,7 +222,7 @@ module GOVUKDesignSystemFormBuilder
     #    legend: { text: 'Pick your favourite colour', size: 'm' },
     #    hint_text: 'If you cannot find the exact match choose something close',
     #    inline: false
-    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, inline: false, small: false, &block)
+    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, inline: false, small: false, bold_labels: false, &block)
       Elements::Radios::Collection.new(
         self,
         object_name,
@@ -230,6 +235,7 @@ module GOVUKDesignSystemFormBuilder
         legend: legend,
         inline: inline,
         small: small,
+        bold_labels: bold_labels,
         &block
       ).html
     end

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -2,7 +2,7 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module Radios
       class Collection < GOVUKDesignSystemFormBuilder::Base
-        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method:, hint_text:, legend:, inline:, small:, &block)
+        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method:, hint_text:, legend:, inline:, small:, bold_labels:, &block)
           super(builder, object_name, attribute_name)
 
           @collection    = collection
@@ -13,6 +13,7 @@ module GOVUKDesignSystemFormBuilder
           @small         = small
           @legend        = legend
           @hint_text     = hint_text
+          @bold_labels   = hint_method.present? || bold_labels
           @block_content = @builder.capture { block.call } if block_given?
         end
 
@@ -45,7 +46,8 @@ module GOVUKDesignSystemFormBuilder
               value_method: @value_method,
               text_method: @text_method,
               hint_method: @hint_method,
-              link_errors: has_errors? && i.zero?
+              link_errors: has_errors? && i.zero?,
+              bold_labels: @bold_labels
             ).html
           end
         end

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
@@ -6,13 +6,14 @@ module GOVUKDesignSystemFormBuilder
         #   error summary requires that the id of the first radio is linked-to from the corresponding
         #   error message. As when the summary is built what happens later in the form is unknown, we
         #   need to control this to ensure the link is generated correctly
-        def initialize(builder, object_name, attribute_name, item, value_method:, text_method:, hint_method:, link_errors: false)
+        def initialize(builder, object_name, attribute_name, item, value_method:, text_method:, hint_method:, link_errors: false, bold_labels:)
           super(builder, object_name, attribute_name)
           @item        = item
           @value       = item.send(value_method)
           @text        = item.send(text_method)
           @hint_text   = item.send(hint_method) if hint_method.present?
           @link_errors = link_errors
+          @bold_labels = bold_labels
         end
 
         def html
@@ -40,7 +41,11 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def label_element
-          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, text: @text, value: @value, radio: true)
+          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, text: @text, value: @value, radio: true, size: label_size)
+        end
+
+        def label_size
+          @bold_labels.present? ? 's' : nil
         end
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
@@ -51,7 +51,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
 
         context 'when small is not specified in the options' do
-          subject { builder.send(method, attribute, projects, :id, :name) }
+          subject { builder.send(*args) }
 
           specify "should not have the additional class 'govuk-checkboxes--small'" do
             expect(parsed_subject.at_css('.govuk-checkboxes')['class']).to eql('govuk-checkboxes')

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -113,7 +113,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       context 'layout direction' do
         context 'when inline is specified in the options' do
           subject do
-            builder.send(method, attribute, colours, :id, :name, :description, inline: true)
+            builder.send(*args.push(:description), inline: true)
           end
 
           specify "should have the additional class 'govuk-radios--inline'" do
@@ -123,7 +123,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
         context 'when inline is not specified in the options' do
           subject do
-            builder.send(method, attribute, colours, :id, :name, :description, inline: false)
+            builder.send(*args.push(:description), inline: false)
           end
 
           specify "should not have the additional class 'govuk-radios--inline'" do
@@ -135,7 +135,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       context 'radio button size' do
         context 'when small is specified in the options' do
           subject do
-            builder.send(method, attribute, colours, :id, :name, :description, small: true)
+            builder.send(*args.push(:description), small: true)
           end
 
           specify "should have the additional class 'govuk-radios--small'" do
@@ -145,7 +145,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
         context 'when small is not specified in the options' do
           subject do
-            builder.send(method, attribute, colours, :id, :name, :description, small: false)
+            builder.send(*args.push(:description), small: false)
           end
 
           specify "should not have the additional class 'govuk-radios--small'" do

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -108,6 +108,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             end
           end
         end
+
+        specify 'all labels should be bold when hints are enabled' do
+          expect(subject).to have_tag('label', with: { class: 'govuk-label--s' }, count: colours.size)
+        end
       end
 
       context 'layout direction' do
@@ -150,6 +154,26 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
           specify "should not have the additional class 'govuk-radios--small'" do
             expect(parsed_subject.at_css('.govuk-radios')['class']).to eql('govuk-radios')
+          end
+        end
+      end
+
+      context 'bold labels' do
+        let(:bold_label_class) { 'govuk-label--s' }
+
+        context 'when bold labels are specified in the options' do
+          subject do
+            builder.send(*args.push(:description), bold_labels: true)
+          end
+
+          specify 'all labels should be bold when hints are enabled' do
+            expect(subject).to have_tag('label', with: { class: bold_label_class }, count: colours.size)
+          end
+        end
+
+        context 'when bold labels are not specified in the options' do
+          specify 'no labels should be bold when hints are enabled' do
+            expect(subject).not_to have_tag('label', with: { class: bold_label_class })
           end
         end
       end

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -4,6 +4,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   describe '#submit' do
     let(:method) { :govuk_submit }
     let(:text) { 'Create' }
+    let(:args) { [method] }
     subject { builder.send(method, text) }
 
     specify 'output should be a form group containing a submit input' do
@@ -26,7 +27,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     describe 'button styles and colours' do
       context 'warning' do
-        subject { builder.send(method, 'Create', warning: true) }
+        subject { builder.send(*args.push('Create'), warning: true) }
 
         specify 'button should have the warning class' do
           expect(subject).to have_tag('input', with: { class: %w(govuk-button govuk-button--warning) })
@@ -34,7 +35,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       context 'secondary' do
-        subject { builder.send(method, 'Create', secondary: true) }
+        subject { builder.send(*args.push('Create'), secondary: true) }
 
         specify 'button should have the secondary class' do
           expect(subject).to have_tag('input', with: { class: %w(govuk-button govuk-button--secondary) })
@@ -42,7 +43,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       context 'warning and secondary' do
-        subject { builder.send(method, 'Create', secondary: true, warning: true) }
+        subject { builder.send(*args.push('Create'), secondary: true, warning: true) }
 
         specify 'should fail' do
           expect { subject }.to raise_error(ArgumentError, /buttons can be warning or secondary/)
@@ -56,7 +57,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       context 'when disabled' do
-        subject { builder.send(method, text, prevent_double_click: false) }
+        subject { builder.send(*args.push(text), prevent_double_click: false) }
 
         specify 'data attribute should not be present by default' do
           expect(
@@ -86,7 +87,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     describe 'preventing client-side validation' do
       context 'should be novalidate by default' do
-        subject { builder.send(method) }
+        subject { builder.send(*args) }
 
         specify 'should have attribute formnovalidate' do
           expect(subject).to have_tag('input', with: { type: 'submit', formnovalidate: 'formnovalidate' })
@@ -94,7 +95,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       context 'when validate is false' do
-        subject { builder.send(method, validate: false) }
+        subject { builder.send(*args, validate: false) }
 
         specify 'should have attribute formnovalidate' do
           expect(subject).to have_tag('input', with: { type: 'submit', formnovalidate: 'formnovalidate' })
@@ -102,7 +103,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       context 'when validate is true' do
-        subject { builder.send(method, validate: true) }
+        subject { builder.send(*args, validate: true) }
 
         specify 'should have attribute formnovalidate' do
           expect(parsed_subject.at_css('input').attributes.keys).not_to include('formnovalidate')

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -76,7 +76,7 @@ shared_examples 'a regular input' do |method_identifier, field_type|
         context "when the width is #{identifier}" do
           let(:identifier) { identifier }
           let(:width_class) { width_class }
-          subject { builder.send(method, :name, width: identifier) }
+          subject { builder.send(*args, width: identifier) }
 
           specify "should have the correct class of #{width_class}" do
             expect(parsed_subject.at_css('input')['class']).to include(width_class)


### PR DESCRIPTION
Allow radio button collections to set **bold** labels. When the `:hint_method` argument is provided this will always be set to true so there is a visual distinction between the hint and the label.