### PR TITLE
More-accessible blocks

### DIFF
--- a/guide/content/building-blocks/injecting-content.slim
+++ b/guide/content/building-blocks/injecting-content.slim
@@ -17,4 +17,13 @@ section
     caption: "A collection of radio buttons with a paragraph explaining what will happen when the form is submitted",
     code: text_area_with_injected_content,
     sample_data: departments_data_raw,
-    show_errors: true)
+    show_errors: true) do
+
+    p.govuk-body
+      | All content supplied via a block is considered supplementary to the label
+        and hint.
+
+    p.govuk-body
+      | It is automatically associated with the element via its
+        <code>aria-describedby</code> attribute allowing assistive technologies to
+        provide the user with a full explanation of what is required.

--- a/guide/content/css/_colours.sass
+++ b/guide/content/css/_colours.sass
@@ -7,4 +7,6 @@ $blue: #1d70b8
 $dark-blue: #003078
 $pink: darken(#d53880, 10%)
 $text: #0b0c0c
+$green: #00703c
 $light-grey: #f3f2f1
+$light-pink: lighten(#f499be, 20%)

--- a/guide/content/css/govuk-design-system-formbuilder-guide.sass
+++ b/guide/content/css/govuk-design-system-formbuilder-guide.sass
@@ -1,4 +1,5 @@
 @import 'colours'
+$tablet: 768px
 
 @font-face
   font-family: FiraMono
@@ -13,6 +14,13 @@
   border-left: 5px solid $blue
   padding: 0.5rem 1rem 0.5rem 2rem
 
+@mixin blue-top-border
+  padding: 2rem 0.2rem 0.5rem
+  margin: 2rem 0rem
+
+  &:not(:first-child)
+    border-top: 5px solid $blue
+
 @mixin light-grey-border
   border: 1px solid $light-grey
   padding: 2rem
@@ -21,7 +29,11 @@ article > pre
   @include blue-left-border
 
 figure
-  @include blue-left-border
+  @media screen and (max-width: $tablet)
+    @include blue-top-border
+  @media screen and (min-width: $tablet)
+    @include blue-left-border
+
   margin: 2.5rem 0rem 2.5rem
 
   h3.example-subheading
@@ -58,7 +70,8 @@ pre
 
 p, li, dt, dd, td, th
   > code
-    background-color: #fff0f6
+    background-color: $light-pink
     font-family: FiraMono, monospace
-    padding: 0.2rem 0.4rem
-    font-size: 0.9rem
+    padding: 0.1rem
+    font-size: 1rem
+    letter-spacing: -0.015rem

--- a/guide/content/css/rouge.sass
+++ b/guide/content/css/rouge.sass
@@ -10,5 +10,8 @@ pre > code
     .nt,.nf,.nc,.no
       color: $orange
 
-    .p,.k,.mi,.n,.o,.na,.ss
+    .n,.p,.k,.mi,.n,.o,.na,.ss
       color: $dark-blue
+
+    .kp
+      color: $green

--- a/guide/content/introduction/labels-hints-and-legends.slim
+++ b/guide/content/introduction/labels-hints-and-legends.slim
@@ -33,7 +33,7 @@ section
         code text
 
       dd.govuk-summary-list__value
-        | The label text
+        | The actual text that forms the label
 
     div.govuk-summary-list__row
       dt.govuk-summary-list__key
@@ -111,7 +111,7 @@ section
         code text
 
       dd.govuk-summary-list__value
-        | The legend text
+        | The actual text that forms the legend
 
     div.govuk-summary-list__row
       dt.govuk-summary-list__key

--- a/guide/lib/examples/fieldset.rb
+++ b/guide/lib/examples/fieldset.rb
@@ -3,10 +3,10 @@ module Examples
     def address_fieldset
       <<~SNIPPET
         = f.govuk_fieldset legend: { text: 'Where do you live?' } do
-          = f.govuk_text_field :address_one, width: 'one-half', label: { text: 'House number and street' }
-          = f.govuk_text_field :address_two, width: 'one-half', label: { text: 'Town', hidden: true }
-          = f.govuk_text_field :address_three, width: 'one-half', label: { text: 'City' }
-          = f.govuk_text_field :postcode, width: 'one-quarter', label: { text: 'Postcode' }
+          = f.govuk_text_field :address_one,   width: 'one-half',    label: { text: 'House number and street' }
+          = f.govuk_text_field :address_two,   width: 'one-half',    label: { text: 'Town', hidden: true }
+          = f.govuk_text_field :address_three, width: 'one-half',    label: { text: 'City' }
+          = f.govuk_text_field :postcode,      width: 'one-quarter', label: { text: 'Postcode' }
       SNIPPET
     end
   end

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -31,6 +31,7 @@ require 'govuk_design_system_formbuilder/containers/radios'
 require 'govuk_design_system_formbuilder/containers/radio_buttons_fieldset'
 require 'govuk_design_system_formbuilder/containers/check_boxes'
 require 'govuk_design_system_formbuilder/containers/character_count'
+require 'govuk_design_system_formbuilder/containers/supplemental'
 
 module GOVUKDesignSystemFormBuilder
   class FormBuilder < ActionView::Helpers::FormBuilder

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -1,9 +1,10 @@
 module GOVUKDesignSystemFormBuilder
   class Base
-    def initialize(builder, object_name, attribute_name)
+    def initialize(builder, object_name, attribute_name, &block)
       @builder = builder
       @object_name = object_name
       @attribute_name = attribute_name
+      @block_content = @builder.capture { block.call } if block_given?
     end
 
     def hint_element

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -19,6 +19,10 @@ module GOVUKDesignSystemFormBuilder
       @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, **@label)
     end
 
+    def supplemental_content
+      @supplemental_content ||= Containers::Supplemental.new(@builder, @object_name, @attribute_name, @block_content)
+    end
+
     # returns the id value used for the input
     #
     # @note field_id is overridden so that the error summary can link to the
@@ -54,6 +58,12 @@ module GOVUKDesignSystemFormBuilder
 
     def conditional_id
       build_id('conditional')
+    end
+
+    def supplemental_id
+      return nil unless supplemental_content.present?
+
+      build_id('supplemental')
     end
 
     def has_errors?

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -45,7 +45,7 @@ module GOVUKDesignSystemFormBuilder
     end
 
     def hint_id
-      return nil if @hint_text.blank?
+      return nil unless @hint_text.present?
 
       build_id('hint')
     end
@@ -61,7 +61,7 @@ module GOVUKDesignSystemFormBuilder
     end
 
     def supplemental_id
-      return nil unless supplemental_content.present?
+      return nil unless @block_content.present?
 
       build_id('supplemental')
     end

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -12,6 +12,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @option args [Hash] args additional arguments are applied as attributes to +input+ element
+    # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
     #
@@ -37,6 +38,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @option args [Hash] args additional arguments are applied as attributes to +input+ element
+    # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
     # @see https://design-system.service.gov.uk/patterns/telephone-numbers/ GOV.UK Telephone number patterns
@@ -63,6 +65,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @option args [Hash] args additional arguments are applied as attributes to +input+ element
+    # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
     # @see https://design-system.service.gov.uk/patterns/email-addresses/ GOV.UK Email address patterns
@@ -87,6 +90,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @option args [Hash] args additional arguments are applied as attributes to +input+ element
+    # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
     #
@@ -111,6 +115,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
+    # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
     #
@@ -141,6 +146,7 @@ module GOVUKDesignSystemFormBuilder
     # @param threshold [Integer] only show the +max_words+ and +max_chars+ warnings once a threshold (percentage) is reached
     # @param rows [Integer] sets the initial number of rows
     # @option args [Hash] args additional arguments are applied as attributes to the +textarea+ element
+    # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/character-count GOV.UK character count component
     # @note Setting +max_chars+ or +max_words+ will add a caption beneath the +textarea+ with a live count of words
@@ -166,6 +172,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
+    # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     def govuk_collection_select(attribute_name, collection, value_method, text_method, options: {}, html_options: {}, hint_text: nil, label: {}, &block)
       Elements::Select.new(

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -528,6 +528,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
     # @option args [Hash] args additional arguments are applied as attributes to +input+ element
+    # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     #
     # @example A photo upload field with file type specifier
     #   = f.govuk_file_field :photo, label: { text: 'Upload your photo' }, accept: 'image/*'
@@ -538,8 +539,8 @@ module GOVUKDesignSystemFormBuilder
     # @note Remember to set +multipart: true+ when creating a form with file
     #   uploads, {https://guides.rubyonrails.org/form_helpers.html#uploading-files see
     #   the Rails documentation} for more information
-    def govuk_file_field(attribute_name, label: {}, hint_text: nil, **args)
-      Elements::File.new(self, object_name, attribute_name, label: label, hint_text: hint_text, **args).html
+    def govuk_file_field(attribute_name, label: {}, hint_text: nil, **args, &block)
+      Elements::File.new(self, object_name, attribute_name, label: label, hint_text: hint_text, **args, &block).html
     end
   end
 end

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -21,8 +21,8 @@ module GOVUKDesignSystemFormBuilder
     #     hint_text: 'It says it on your birth certificate',
     #     required: true,
     #     placeholder: 'Ralph Wiggum'
-    def govuk_text_field(attribute_name, hint_text: nil, label: {}, width: nil, **args)
-      Elements::Input.new(self, object_name, attribute_name, attribute_type: :text, hint_text: hint_text, label: label, width: width, **args).html
+    def govuk_text_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
+      Elements::Input.new(self, object_name, attribute_name, attribute_type: :text, hint_text: hint_text, label: label, width: width, **args, &block).html
     end
 
     # Generates a input of type +tel+
@@ -47,8 +47,8 @@ module GOVUKDesignSystemFormBuilder
     #     hint_text: 'Include the dialling code',
     #     required: true,
     #     placeholder: '0123 456 789'
-    def govuk_phone_field(attribute_name, hint_text: nil, label: {}, width: nil, **args)
-      Elements::Input.new(self, object_name, attribute_name, attribute_type: :phone, hint_text: hint_text, label: label, width: width, **args).html
+    def govuk_phone_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
+      Elements::Input.new(self, object_name, attribute_name, attribute_type: :phone, hint_text: hint_text, label: label, width: width, **args, &block).html
     end
 
     # Generates a input of type +email+
@@ -71,8 +71,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_email_field :email_address,
     #     label: { text: 'Enter your email address' },
     #     placeholder: 'ralph.wiggum@springfield.edu'
-    def govuk_email_field(attribute_name, hint_text: nil, label: {}, width: nil, **args)
-      Elements::Input.new(self, object_name, attribute_name, attribute_type: :email, hint_text: hint_text, label: label, width: width, **args).html
+    def govuk_email_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
+      Elements::Input.new(self, object_name, attribute_name, attribute_type: :email, hint_text: hint_text, label: label, width: width, **args, &block).html
     end
 
     # Generates a input of type +url+
@@ -95,8 +95,8 @@ module GOVUKDesignSystemFormBuilder
     #     label: { text: 'Enter your favourite website' },
     #     placeholder: 'https://www.gov.uk',
     #     autocomplete: 'url'
-    def govuk_url_field(attribute_name, hint_text: nil, label: {}, width: nil, **args)
-      Elements::Input.new(self, object_name, attribute_name, attribute_type: :url, hint_text: hint_text, label: label, width: width, **args).html
+    def govuk_url_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
+      Elements::Input.new(self, object_name, attribute_name, attribute_type: :url, hint_text: hint_text, label: label, width: width, **args, &block).html
     end
 
     # Generates a input of type +number+
@@ -121,8 +121,8 @@ module GOVUKDesignSystemFormBuilder
     #     min: 80,
     #     max: 150,
     #     step: 5
-    def govuk_number_field(attribute_name, hint_text: nil, label: {}, width: nil, **args)
-      Elements::Input.new(self, object_name, attribute_name, attribute_type: :number, hint_text: hint_text, label: label, width: width, **args).html
+    def govuk_number_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
+      Elements::Input.new(self, object_name, attribute_name, attribute_type: :number, hint_text: hint_text, label: label, width: width, **args, &block).html
     end
 
     # Generates a +textarea+ element with a label, optional hint. Also offers
@@ -151,8 +151,8 @@ module GOVUKDesignSystemFormBuilder
     #     label: { text: 'Tell us about your work history' },
     #     rows: 8,
     #     max_words: 300
-    def govuk_text_area(attribute_name, hint_text: nil, label: {}, max_words: nil, max_chars: nil, rows: 5, threshold: nil, **args)
-      Elements::TextArea.new(self, object_name, attribute_name, hint_text: hint_text, label: label, max_words: max_words, max_chars: max_chars, rows: rows, threshold: threshold, **args).html
+    def govuk_text_area(attribute_name, hint_text: nil, label: {}, max_words: nil, max_chars: nil, rows: 5, threshold: nil, **args, &block)
+      Elements::TextArea.new(self, object_name, attribute_name, hint_text: hint_text, label: label, max_words: max_words, max_chars: max_chars, rows: rows, threshold: threshold, **args, &block).html
     end
 
     # Generates a +select+ element containing +option+ for each member in the provided collection

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -2,7 +2,7 @@ module GOVUKDesignSystemFormBuilder
   module Containers
     class CheckBoxesFieldset < GOVUKDesignSystemFormBuilder::Base
       def initialize(builder, object_name, attribute_name, hint_text:, legend:, small:, &block)
-        super(builder, object_name, attribute_name)
+        super(builder, object_name, attribute_name, &block)
 
         @legend        = legend
         @hint_text     = hint_text

--- a/lib/govuk_design_system_formbuilder/containers/supplemental.rb
+++ b/lib/govuk_design_system_formbuilder/containers/supplemental.rb
@@ -15,6 +15,10 @@ module GOVUKDesignSystemFormBuilder
           @content
         end
       end
+
+      def supplemental_id
+        build_id('supplemental')
+      end
     end
   end
 end

--- a/lib/govuk_design_system_formbuilder/containers/supplemental.rb
+++ b/lib/govuk_design_system_formbuilder/containers/supplemental.rb
@@ -1,0 +1,20 @@
+module GOVUKDesignSystemFormBuilder
+  module Containers
+    class Supplemental < GOVUKDesignSystemFormBuilder::Base
+      def initialize(builder, object_name, attribute_name, content)
+        @builder        = builder
+        @object_name    = object_name
+        @attribute_name = attribute_name
+        @content        = content
+      end
+
+      def html
+        return nil unless @content.present?
+
+        @builder.content_tag('div', id: supplemental_id) do
+          @content
+        end
+      end
+    end
+  end
+end

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -16,7 +16,7 @@ module GOVUKDesignSystemFormBuilder
 
         def html
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-            Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_element.error_id, hint_element.hint_id]).html do
+            Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
               @builder.safe_join(
                 [
                   hint_element.html,

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -12,7 +12,6 @@ module GOVUKDesignSystemFormBuilder
           @small         = small
           @legend        = legend
           @hint_text     = hint_text
-          @block_content = @builder.capture { block.call } if block_given?
         end
 
         def html
@@ -22,7 +21,7 @@ module GOVUKDesignSystemFormBuilder
                 [
                   hint_element.html,
                   error_element.html,
-                  @block_content,
+                  supplemental_content.html,
                   Containers::CheckBoxes.new(@builder, small: @small).html do
                     build_collection
                   end

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -3,7 +3,7 @@ module GOVUKDesignSystemFormBuilder
     module CheckBoxes
       class Collection < GOVUKDesignSystemFormBuilder::Base
         def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method: nil, hint_text:, legend:, small:, &block)
-          super(builder, object_name, attribute_name)
+          super(builder, object_name, attribute_name, &block)
 
           @collection    = collection
           @value_method  = value_method

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
@@ -18,7 +18,7 @@ module GOVUKDesignSystemFormBuilder
                 @checkbox.check_box(
                   id: field_id(link_errors: @link_errors),
                   class: "govuk-checkboxes__input",
-                  aria: { describedby: hint_element.hint_id }
+                  aria: { describedby: hint_id }
                 ),
                 label_element.html,
                 hint_element.html

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -4,11 +4,10 @@ module GOVUKDesignSystemFormBuilder
       SEGMENTS = { day: '3i', month: '2i', year: '1i' }.freeze
 
       def initialize(builder, object_name, attribute_name, legend:, hint_text:, date_of_birth: false, &block)
-        super(builder, object_name, attribute_name)
+        super(builder, object_name, attribute_name, &block)
         @legend = legend
         @hint_text = hint_text
         @date_of_birth = date_of_birth
-        @block_content = @builder.capture { block.call } if block_given?
       end
 
       def html

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -17,7 +17,7 @@ module GOVUKDesignSystemFormBuilder
               [
                 hint_element.html,
                 error_element.html,
-                @block_content,
+                supplemental_content.html,
                 @builder.content_tag('div', class: 'govuk-date-input') do
                   @builder.safe_join(
                     [

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -12,7 +12,7 @@ module GOVUKDesignSystemFormBuilder
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-          Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_element.error_id, hint_element.hint_id]).html do
+          Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
             @builder.safe_join(
               [
                 hint_element.html,

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -1,8 +1,8 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     class File < GOVUKDesignSystemFormBuilder::Base
-      def initialize(builder, object_name, attribute_name, hint_text:, label:, **extra_args)
-        super(builder, object_name, attribute_name)
+      def initialize(builder, object_name, attribute_name, hint_text:, label:, **extra_args, &block)
+        super(builder, object_name, attribute_name, &block)
 
         @label      = label
         @hint_text  = hint_text
@@ -16,11 +16,12 @@ module GOVUKDesignSystemFormBuilder
               label_element.html,
               hint_element.html,
               error_element.html,
+              supplemental_content.html,
               @builder.file_field(
                 @attribute_name,
                 id: field_id(link_errors: true),
                 class: file_classes,
-                aria: { describedby: described_by(hint_element.hint_id, error_element.error_id) },
+                aria: { describedby: described_by(hint_id, error_id, supplemental_id) },
                 **@extra_args
               )
             ]

--- a/lib/govuk_design_system_formbuilder/elements/input.rb
+++ b/lib/govuk_design_system_formbuilder/elements/input.rb
@@ -1,8 +1,8 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     class Input < GOVUKDesignSystemFormBuilder::Base
-      def initialize(builder, object_name, attribute_name, attribute_type:, hint_text:, label:, width:, **extra_args)
-        super(builder, object_name, attribute_name)
+      def initialize(builder, object_name, attribute_name, attribute_type:, hint_text:, label:, width:, **extra_args, &block)
+        super(builder, object_name, attribute_name, &block)
 
         @width          = width
         @extra_args     = extra_args

--- a/lib/govuk_design_system_formbuilder/elements/input.rb
+++ b/lib/govuk_design_system_formbuilder/elements/input.rb
@@ -24,7 +24,13 @@ module GOVUKDesignSystemFormBuilder
                 @attribute_name,
                 id: field_id(link_errors: true),
                 class: input_classes,
-                aria: { describedby: described_by(hint_element.hint_id, error_element.error_id) },
+                aria: {
+                  describedby: described_by(
+                    hint_id,
+                    error_id,
+                    supplemental_id
+                  )
+                },
                 **@extra_args
               )
             ]

--- a/lib/govuk_design_system_formbuilder/elements/input.rb
+++ b/lib/govuk_design_system_formbuilder/elements/input.rb
@@ -17,6 +17,7 @@ module GOVUKDesignSystemFormBuilder
             [
               label_element.html,
               hint_element.html,
+              supplemental_content.html,
               error_element.html,
               @builder.send(
                 @builder_method,

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -3,7 +3,7 @@ module GOVUKDesignSystemFormBuilder
     module Radios
       class Collection < GOVUKDesignSystemFormBuilder::Base
         def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method:, hint_text:, legend:, inline:, small:, bold_labels:, &block)
-          super(builder, object_name, attribute_name)
+          super(builder, object_name, attribute_name, &block)
 
           @collection    = collection
           @value_method  = value_method

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -18,7 +18,7 @@ module GOVUKDesignSystemFormBuilder
 
         def html
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-            Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_element.error_id, hint_element.hint_id]).html do
+            Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
               @builder.safe_join(
                 [
                   hint_element.html,

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -14,7 +14,6 @@ module GOVUKDesignSystemFormBuilder
           @legend        = legend
           @hint_text     = hint_text
           @bold_labels   = hint_method.present? || bold_labels
-          @block_content = @builder.capture { block.call } if block_given?
         end
 
         def html
@@ -24,7 +23,7 @@ module GOVUKDesignSystemFormBuilder
                 [
                   hint_element.html,
                   error_element.html,
-                  @block_content,
+                  supplemental_content.html,
                   Containers::Radios.new(@builder, inline: @inline, small: @small).html do
                     @builder.safe_join(build_collection)
                   end

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -11,7 +11,6 @@ module GOVUKDesignSystemFormBuilder
         @html_options  = html_options
         @label         = label
         @hint_text     = hint_text
-        @block_content = @builder.capture { block.call } if block_given?
       end
 
       def html
@@ -21,7 +20,7 @@ module GOVUKDesignSystemFormBuilder
               label_element.html,
               hint_element.html,
               error_element.html,
-              @block_content,
+              supplemental_content.html,
               @builder.collection_select(
                 @attribute_name,
                 @collection,

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -27,7 +27,7 @@ module GOVUKDesignSystemFormBuilder
                 @value_method,
                 @text_method,
                 @options,
-                build_html_options(hint_element, error_element)
+                build_html_options
               )
             ]
           )
@@ -36,7 +36,7 @@ module GOVUKDesignSystemFormBuilder
 
     private
 
-      def build_html_options(hint_element, error_element)
+      def build_html_options
         @html_options.deep_merge(
           id: field_id(link_errors: true),
           class: select_classes,

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -2,7 +2,7 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     class Select < GOVUKDesignSystemFormBuilder::Base
       def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, options: {}, html_options: {}, hint_text:, label:, &block)
-        super(builder, object_name, attribute_name)
+        super(builder, object_name, attribute_name, &block)
 
         @collection    = collection
         @value_method  = value_method

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -40,7 +40,7 @@ module GOVUKDesignSystemFormBuilder
         @html_options.deep_merge(
           id: field_id(link_errors: true),
           class: select_classes,
-          aria: { describedby: described_by(hint_element.hint_id, error_element.error_id) }
+          aria: { describedby: described_by(hint_id, error_id, supplemental_id) }
         )
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -1,8 +1,8 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     class TextArea < Base
-      def initialize(builder, object_name, attribute_name, hint_text:, label:, rows:, max_words:, max_chars:, threshold:, **extra_args)
-        super(builder, object_name, attribute_name)
+      def initialize(builder, object_name, attribute_name, hint_text:, label:, rows:, max_words:, max_chars:, threshold:, **extra_args, &block)
+        super(builder, object_name, attribute_name, &block)
         @label      = label
         @hint_text  = hint_text
         @extra_args = extra_args

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -22,7 +22,13 @@ module GOVUKDesignSystemFormBuilder
                   @attribute_name,
                   id: field_id(link_errors: true),
                   class: govuk_textarea_classes,
-                  aria: { describedby: described_by(hint_element.hint_id, error_element.error_id) },
+                  aria: {
+                    describedby: described_by(
+                      hint_id,
+                      error_id,
+                      supplemental_id
+                    )
+                  },
                   **@extra_args.merge(rows: @rows)
                 )
               ].flatten.compact

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -17,7 +17,7 @@ module GOVUKDesignSystemFormBuilder
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
             @builder.safe_join(
               [
-                [label_element, hint_element, error_element].map(&:html),
+                [label_element, hint_element, error_element, supplemental_content].map(&:html),
                 @builder.text_area(
                   @attribute_name,
                   id: field_id(link_errors: true),

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
@@ -31,7 +31,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:error_identifier) { 'person-projects-error' }
     end
 
-    it_behaves_like 'a field that accepts arbitrary blocks of HTML'
+    it_behaves_like 'a field that accepts arbitrary blocks of HTML' do
+      let(:described_element) { 'fieldset' }
+    end
 
     describe 'check boxes' do
       specify 'output should contain the correct number of check boxes' do

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
@@ -19,8 +19,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
-    it_behaves_like 'a field that accepts arbitrary blocks of HTML'
-
     it_behaves_like 'a field that supports errors' do
       let(:error_message) { /Select at least one project/ }
       let(:error_class) { nil }

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -35,6 +35,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that accepts arbitrary blocks of HTML' do
+      let(:described_element) { 'fieldset' }
+
       # the block content (p) should be between the hint (span) and the input container (div)
       context 'ordering' do
         let(:hint_span_selector) { 'span.govuk-hint' }

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -252,10 +252,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             end
           end
         end
-
-        def underscores_to_dashes(val)
-          val.to_s.tr('_', '-')
-        end
       end
     end
 

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -20,6 +20,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     it_behaves_like 'a field that supports labels'
 
+    it_behaves_like 'a field that accepts arbitrary blocks of HTML' do
+      let(:described_element) { 'input' }
+    end
+
     it_behaves_like 'a field that supports hints' do
       let(:aria_described_by_target) { 'input' }
     end

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -37,7 +37,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:error_identifier) { 'person-favourite-colour-error' }
     end
 
-    it_behaves_like 'a field that accepts arbitrary blocks of HTML'
+    it_behaves_like 'a field that accepts arbitrary blocks of HTML' do
+      let(:described_element) { 'fieldset' }
+    end
 
     context 'radio buttons' do
       specify 'each radio button should have the correct classes' do

--- a/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
@@ -23,8 +23,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       specify { expect { subject }.to raise_error(NoMethodError, /undefined method.*call/) }
     end
 
-    it_behaves_like 'a field that accepts arbitrary blocks of HTML'
-
     it_behaves_like 'a field that supports errors' do
       let(:error_message) { /Choose a favourite colour/ }
       let(:error_class) { nil }

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -23,7 +23,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:error_class) { nil }
     end
 
-    it_behaves_like 'a field that accepts arbitrary blocks of HTML'
+    it_behaves_like 'a field that accepts arbitrary blocks of HTML' do
+      let(:described_element) { 'select' }
+    end
 
     specify 'output should be a form group containing a label and select box' do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -15,6 +15,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
   end
 
+  it_behaves_like 'a field that accepts arbitrary blocks of HTML'
+
   it_behaves_like 'a field that supports labels', 'textarea'
 
   it_behaves_like 'a field that supports hints' do

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -15,7 +15,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
   end
 
-  it_behaves_like 'a field that accepts arbitrary blocks of HTML'
+  it_behaves_like 'a field that accepts arbitrary blocks of HTML' do
+    let(:described_element) { 'textarea' }
+  end
 
   it_behaves_like 'a field that supports labels', 'textarea'
 

--- a/spec/support/shared/shared_block_examples.rb
+++ b/spec/support/shared/shared_block_examples.rb
@@ -9,7 +9,7 @@ shared_examples 'a field that accepts arbitrary blocks of HTML' do
     subject do
       builder.send(*args) do
         builder.safe_join(
-          [ builder.tag.h1(block_h1), builder.tag.h2(block_h2), builder.tag.p(block_p) ]
+          [builder.tag.h1(block_h1), builder.tag.h2(block_h2), builder.tag.p(block_p)]
         )
       end
     end

--- a/spec/support/shared/shared_block_examples.rb
+++ b/spec/support/shared/shared_block_examples.rb
@@ -5,19 +5,37 @@ shared_examples 'a field that accepts arbitrary blocks of HTML' do
 
   let(:supplemental_id) { underscores_to_dashes([object_name, attribute, 'supplemental'].join('-')) }
 
-  subject do
-    builder.send(*args) do
-      builder.safe_join(
-        [ builder.tag.h1(block_h1), builder.tag.h2(block_h2), builder.tag.p(block_p) ]
-      )
+  context 'when a block is supplied' do
+    subject do
+      builder.send(*args) do
+        builder.safe_join(
+          [ builder.tag.h1(block_h1), builder.tag.h2(block_h2), builder.tag.p(block_p) ]
+        )
+      end
+    end
+
+    specify 'should be associated with the containing element' do
+      expect(subject).to have_tag(described_element, with: { 'aria-describedby' => supplemental_id })
+    end
+
+    specify 'should include block content wrapped in a div with correct supplemental id' do
+      expect(subject).to have_tag('div', with: { id: supplemental_id }) do |sup|
+        expect(sup).to have_tag('h1', text: block_h1)
+        expect(sup).to have_tag('h2', text: block_h2)
+        expect(sup).to have_tag('p', text: block_p)
+      end
     end
   end
 
-  specify 'should include block content wrapped in a div with correct supplemental id' do
-    expect(subject).to have_tag('div', with: { id: supplemental_id }) do |sup|
-      expect(sup).to have_tag('h1', text: block_h1)
-      expect(sup).to have_tag('h2', text: block_h2)
-      expect(sup).to have_tag('p', text: block_p)
+  context 'when no block is supplied' do
+    subject { builder.send(*args) }
+
+    specify 'should be no supplemental container' do
+      expect(subject).not_to have_tag('div', with: { id: supplemental_id })
+    end
+
+    specify 'should be no association with the supplemental container' do
+      expect(subject).not_to have_tag(described_element, with: { 'aria-describedby' => supplemental_id })
     end
   end
 end

--- a/spec/support/shared/shared_block_examples.rb
+++ b/spec/support/shared/shared_block_examples.rb
@@ -2,21 +2,22 @@ shared_examples 'a field that accepts arbitrary blocks of HTML' do
   let(:block_h1) { 'The quick brown fox' }
   let(:block_h2) { 'Jumped over the' }
   let(:block_p) { 'Lazy dog.' }
+
+  let(:supplemental_id) { underscores_to_dashes([object_name, attribute, 'supplemental'].join('-')) }
+
   subject do
     builder.send(*args) do
       builder.safe_join(
-        [
-          builder.tag.h1(block_h1),
-          builder.tag.h2(block_h2),
-          builder.tag.p(block_p)
-        ]
+        [ builder.tag.h1(block_h1), builder.tag.h2(block_h2), builder.tag.p(block_p) ]
       )
     end
   end
 
-  specify 'should include block content' do
-    expect(subject).to have_tag('h1', text: block_h1)
-    expect(subject).to have_tag('h2', text: block_h2)
-    expect(subject).to have_tag('p', text: block_p)
+  specify 'should include block content wrapped in a div with correct supplemental id' do
+    expect(subject).to have_tag('div', with: { id: supplemental_id }) do |sup|
+      expect(sup).to have_tag('h1', text: block_h1)
+      expect(sup).to have_tag('h2', text: block_h2)
+      expect(sup).to have_tag('p', text: block_p)
+    end
   end
 end

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -25,6 +25,8 @@ shared_examples 'a regular input' do |method_identifier, field_type|
 
   it_behaves_like 'a field that supports hints'
 
+  it_behaves_like 'a field that accepts arbitrary blocks of HTML'
+
   it_behaves_like 'a field that supports errors' do
     let(:object) { Person.new(name: nil) }
 

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -25,7 +25,9 @@ shared_examples 'a regular input' do |method_identifier, field_type|
 
   it_behaves_like 'a field that supports hints'
 
-  it_behaves_like 'a field that accepts arbitrary blocks of HTML'
+  it_behaves_like 'a field that accepts arbitrary blocks of HTML' do
+    let(:described_element) { 'input' }
+  end
 
   it_behaves_like 'a field that supports errors' do
     let(:object) { Person.new(name: nil) }

--- a/spec/support/utility.rb
+++ b/spec/support/utility.rb
@@ -9,3 +9,7 @@
 def extract_args(args, subkey)
   args.each.with_object({}) { |(k, v), h| h[k] = v[subkey] }
 end
+
+def underscores_to_dashes(val)
+  val.to_s.tr('_', '-')
+end


### PR DESCRIPTION
Currently blocks of HTML passed into helpers are rendered between the hint and the input element. They can be used to further-describe why an field is required or how the data might be used. Currently they aren't _semantically_ linked and won't be made clear to users of assistive technology.

This PR improves the situation by:

* Using `aria-describedby` to associate the element (`input`, `textarea`, `select` or `fieldset`, depending on the helper) with a `div` containing the passed-in content
* Adding block-handling behaviour to fields that didn't have it before, `govuk_text_field`, `govuk_phone_field`, `govuk_url_field`, `govuk_email_field`, `govuk_number_field`, `govuk_text_area` and `govuk_field_field`
* Describing the new functionality in the guide
* Improving the look and feel of the guide on mobile 📱