### PR TITLE
Remove rails dependency and increase Ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache: bundler
 rvm:
   - 2.5.6
   - 2.6.3
+  - 2.6.4
 
 script:
   - make ruby-lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache: bundler
 
 rvm:
   - 2.5.6
-  - 2.6.3
   - 2.6.4
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ check: ruby-lint rspec nanoc-check
 nanoc-check: nanoc-check-all
 
 ruby-lint:
-	${prefix} govuk-lint-ruby lib spec guide/lib
+	${prefix} govuk-lint-ruby lib spec guide/lib util
 rspec:
 	${prefix} rspec --format progress
 nanoc-check-internal:

--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -1,6 +1,7 @@
 $:.push File.expand_path('lib', __dir__)
 
 require "govuk_design_system_formbuilder/version"
+require_relative "util/version_formatter"
 
 Gem::Specification.new do |s|
   s.name        = "govuk_design_system_formbuilder"
@@ -14,13 +15,12 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,lib}/**/*", "MIT-LICENSE", "README.md"]
 
-  rails_version_specified = ENV.has_key?("RAILS_VERSION")
-  rails_version = ENV.fetch("RAILS_VERSION") { "5.2.3" }
+  exact_rails_version = ENV.has_key?("RAILS_VERSION")
+  rails_version = ENV.fetch("RAILS_VERSION") { "6.0.0" }
 
-  s.add_dependency "rails", "%<symbol>s %<version>s" % {
-    symbol: rails_version_specified ? "~>" : ">=",
-    version: rails_version
-  }
+  %w(actionview activemodel activesupport).each do |lib|
+    s.add_dependency *VersionFormatter.new(lib, rails_version, exact_rails_version).to_a
+  end
 
   s.add_development_dependency "govuk-lint", "~> 0"
   s.add_development_dependency "pry", "~> 0.12.2"

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -35,7 +35,7 @@ dl.govuk-summary-list
             | 2.5.6
         li
           span.govuk-tag.govuk-tag-red
-            | 2.6.3
+            | 2.6.4
 
   div.govuk-summary-list__row
     dt.govuk-summary-list__key

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -38,7 +38,7 @@ module Helpers
     end
 
     def erb_link
-      'https://ruby-doc.org/stdlib-2.6.3/libdoc/erb/rdoc/ERB.html'
+      'https://ruby-doc.org/stdlib-2.6.4/libdoc/erb/rdoc/ERB.html'
     end
 
     def haml_link

--- a/util/version_formatter.rb
+++ b/util/version_formatter.rb
@@ -1,0 +1,36 @@
+class VersionFormatter
+  attr_accessor :lib, :version, :exact
+
+  def initialize(lib, version, exact)
+    self.lib     = lib
+    self.version = version
+    self.exact   = exact
+  end
+
+  def to_a
+    [lib, full_version, sub_version].compact
+  end
+
+private
+
+  # the 'exact' Rails version as set in the gemspec or
+  # RAILS_VERSION environment variable. Returns nil unless
+  # an exact version number is required
+  #
+  # eg (when RAILS_VERSION=6.0.0)
+  #   "~> 6.0.0"
+  def full_version
+    return nil unless exact
+
+    "~> ".concat(version)
+  end
+
+  # the sub version which is the first two parts of
+  # the three part number
+  #
+  # eg (when RAILS_VERSION=5.2.3)
+  #   ">= 5.2"
+  def sub_version
+    ">= ".concat(version.split('.').first(2).join('.'))
+  end
+end


### PR DESCRIPTION
The entirety of Rails isn't a _requirement_ of this gem, only certain parts are needed (#39). This PR slims down those requirements. Additionally, the Ruby version has been bumped.