### PR TITLE
Add error classes to select when attribute invalid

### DIFF
--- a/guide/content/introduction/error-handling.slim
+++ b/guide/content/introduction/error-handling.slim
@@ -25,6 +25,8 @@ p.govuk-body
 == render('/partials/example-fig.*',
   caption: "A text field with an error",
   code: text_field_with_errors,
-  show_errors: true)
+  sample_data: departments_data_raw,
+  show_errors: true,
+  hide_data: true)
 
 == render('/partials/related-info.*', links: error_handling_info)

--- a/guide/lib/examples/error_handling.rb
+++ b/guide/lib/examples/error_handling.rb
@@ -6,27 +6,28 @@ module Examples
       <<~SNIPPET
         = f.govuk_error_summary
 
-        h2.govuk-heading-m
+        h2.govuk-heading-l
           | Register your interest in becoming a teacher
 
         = f.govuk_text_field :welcome_pack_reference_number,
           width: 10,
-          label: { text: 'What is your reference number?' }
+          label: { text: 'What is your reference number?', size: 's' }
 
         = f.govuk_date_field :welcome_pack_received_on,
-          legend: { text: 'When did you receive your welcome pack?' }
+          legend: { text: 'When did you receive your welcome pack?', size: 's' }
 
         = f.govuk_collection_select :department_id,
           departments,
           :id,
           :name,
-          label: { text: 'Which department will you work in?', size: 'm' }
+          label: { text: 'Which department will you work in?', size: 's' }
 
         = f.govuk_collection_radio_buttons :welcome_lunch_choice,
           lunch_options,
           :id,
           :name,
-          legend: { text: 'What would you like for lunch on your first day?' }
+          :description,
+          legend: { text: 'What would you like for lunch on your first day?', size: 's' }
       SNIPPET
     end
   end

--- a/guide/lib/examples/error_handling.rb
+++ b/guide/lib/examples/error_handling.rb
@@ -16,6 +16,12 @@ module Examples
         = f.govuk_date_field :welcome_pack_received_on,
           legend: { text: 'When did you receive your welcome pack?' }
 
+        = f.govuk_collection_select :department_id,
+          departments,
+          :id,
+          :name,
+          label: { text: 'Which department will you work in?', size: 'm' }
+
         = f.govuk_collection_radio_buttons :welcome_lunch_choice,
           lunch_options,
           :id,

--- a/guide/lib/helpers/person.rb
+++ b/guide/lib/helpers/person.rb
@@ -74,6 +74,7 @@ class Person
   validates :welcome_pack_reference_number, presence: { message: 'Enter the reference number you received in your welcome pack' }
   validates :welcome_pack_received_on, presence: { message: 'Enter the date you received your welcome pack' }
   validates :welcome_lunch_choice, presence: { message: 'Select a lunch choice for your first day' }
+  validates :department_id, presence: { message: "Choose the department you'll be working in" }
 
   # fieldset
   attr_accessor(

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -45,7 +45,9 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def select_classes
-        %w(govuk-select)
+        %w(govuk-select).tap do |classes|
+          classes.push('govuk-select--error') if has_errors?
+        end
       end
     end
   end

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -20,7 +20,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports errors' do
       let(:error_message) { /Choose a favourite colour/ }
       let(:error_identifier) { 'person-favourite-colour-error' }
-      let(:error_class) { nil }
+      let(:error_class) { 'govuk-select--error' }
     end
 
     it_behaves_like 'a field that accepts arbitrary blocks of HTML' do


### PR DESCRIPTION
It appears that GOV.UK select elements do have an error class - this previously hadn't been made obvious by the Design System docs.

This change adds them and adds an example to the [error handling page in the guide](https://govuk-form-builder.netlify.com/introduction/error-handling/).

See https://github.com/alphagov/govuk-design-system/issues/1049 for context