### PR TITLE
Make the error link only apply to the first label

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
@@ -30,7 +30,7 @@ module GOVUKDesignSystemFormBuilder
       private
 
         def label_element
-          @label_element ||= Label.new(@checkbox, @object_name, @attribute_name, value: @value)
+          @label_element ||= Label.new(@builder, @object_name, @attribute_name, @checkbox, value: @value, link_errors: @link_errors)
         end
 
         def hint_element

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/label.rb
@@ -2,13 +2,16 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module CheckBoxes
       class Label < GOVUKDesignSystemFormBuilder::Base
-        def initialize(builder, object_name, attribute_name, value:)
+        def initialize(builder, object_name, attribute_name, checkbox, value:, link_errors: true)
           super(builder, object_name, attribute_name)
-          @value = value
+
+          @checkbox    = checkbox
+          @value       = value
+          @link_errors = link_errors
         end
 
         def html
-          @builder.label(for: field_id, class: label_classes)
+          @checkbox.label(for: field_id(link_errors: @link_errors), class: label_classes)
         end
 
       private

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -1,7 +1,7 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     class Label < GOVUKDesignSystemFormBuilder::Base
-      def initialize(builder, object_name, attribute_name, text: nil, value: nil, size: nil, hidden: false, radio: false, checkbox: false, tag: nil)
+      def initialize(builder, object_name, attribute_name, text: nil, value: nil, size: nil, hidden: false, radio: false, checkbox: false, tag: nil, link_errors: true)
         super(builder, object_name, attribute_name)
 
         @text           = label_text(text, hidden)
@@ -10,6 +10,7 @@ module GOVUKDesignSystemFormBuilder
         @radio_class    = radio_class(radio)
         @checkbox_class = checkbox_class(checkbox)
         @tag            = tag
+        @link_errors    = link_errors
       end
 
       def html
@@ -28,7 +29,7 @@ module GOVUKDesignSystemFormBuilder
         @builder.label(
           @attribute_name,
           value: @value,
-          for: field_id(link_errors: true),
+          for: field_id(link_errors: @link_errors),
           class: %w(govuk-label).push(@size_class, @weight_class, @radio_class, @checkbox_class).compact
         ) do
           @text

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
@@ -41,7 +41,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def label_element
-          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, text: @text, value: @value, radio: true, size: label_size)
+          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, text: @text, value: @value, radio: true, size: label_size, link_errors: @link_errors)
         end
 
         def label_size

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -125,7 +125,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             end
 
             specify 'the radio button linked to should be first' do
-              expect(parsed_subject.css('input').first).to eql(parsed_subject.at_css('#' + identifier))
+              expect(parsed_subject.css('input').first['id']).to eql(identifier)
+              expect(parsed_subject.css('label').first['for']).to eql(identifier)
+            end
+
+            specify 'there should be a label associated with the error link target' do
+              expect(subject).to have_tag('label', with: { for: identifier }, count: 1)
             end
           end
 
@@ -184,7 +189,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             end
 
             specify 'the check box linked to should be first' do
-              expect(parsed_subject.css("input[type='checkbox']").first).to eql(parsed_subject.at_css('#' + identifier))
+              expect(parsed_subject.css("input[type='checkbox']").first['id']).to eql(identifier)
+              expect(parsed_subject.css('label').first['for']).to eql(identifier)
+            end
+
+            specify 'there should be a label associated with the error link target' do
+              expect(subject).to have_tag('label', with: { for: identifier }, count: 1)
             end
           end
 


### PR DESCRIPTION
Previously it was affecting all labels in the collection and causing
invalid markup. Now the first label is associated with the first
input and when errors are present on the attribute both id and for are
changed accordingly