### PR TITLE
Make fieldset error link apply to first label

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -48,7 +48,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def label_element
-          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, checkbox: true, value: @value, **@label)
+          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, checkbox: true, value: @value, **@label, link_errors: @link_errors)
         end
 
         def hint_element

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -32,7 +32,7 @@ module GOVUKDesignSystemFormBuilder
       private
 
         def label_element
-          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, radio: true, value: @value, **@label)
+          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, radio: true, value: @value, **@label, link_errors: @link_errors)
         end
 
         def hint_element

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -163,7 +163,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             end
 
             specify 'the radio button linked to should be first' do
-              expect(parsed_subject.css('input').first).to eql(parsed_subject.at_css('#' + identifier))
+              expect(parsed_subject.css('input').first['id']).to eql(identifier)
+              expect(parsed_subject.css('label').first['for']).to eql(identifier)
+            end
+
+            specify 'there should be a label associated with the error link target' do
+              expect(subject).to have_tag('label', with: { for: identifier }, count: 1)
             end
           end
 
@@ -227,7 +232,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             end
 
             specify 'the radio button linked to should be first' do
-              expect(parsed_subject.css('input').first).to eql(parsed_subject.at_css('#' + identifier))
+              expect(parsed_subject.css('input').first['id']).to eql(identifier)
+              expect(parsed_subject.css('label').first['for']).to eql(identifier)
+            end
+
+            specify 'there should be a label associated with the error link target' do
+              expect(subject).to have_tag('label', with: { for: identifier }, count: 1)
             end
           end
 


### PR DESCRIPTION
Similar to #43, this fixes a bug with fieldsets with errors where all
labels were associated with the first input.