### PR TITLE
Add a link_to helper that adds govuk-link class

### DIFF
--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -11,6 +11,7 @@ use_helper Nanoc::Helpers::Rendering
 use_helper Nanoc::Helpers::LinkTo
 
 use_helper Helpers::Formatters
+use_helper Helpers::GOVUKLinkTo
 use_helper Helpers::LinkHelpers
 use_helper Helpers::RelatedInfo
 

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -1,4 +1,12 @@
 module Helpers
+  module GOVUKLinkTo
+    def link_to(*args, **kwargs)
+      return super if kwargs.has_key?('class')
+
+      super(*args, **kwargs.merge(class: 'govuk-link'))
+    end
+  end
+
   module LinkHelpers
     def code_climate_report_link
       'https://codeclimate.com/github/DFE-Digital/govuk_design_system_formbuilder'


### PR DESCRIPTION
Links in the guide were missing the `govuk-link` class. Solve this by adding a helper that wraps `link_to` and, unless classes are provided, sets the class correctly