### PR TITLE
Fix alignment of conditional content beneath radio buttons and checkboxes

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -18,16 +18,20 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def html
-          @builder.content_tag('div', class: 'govuk-checkboxes__item') do
-            @builder.safe_join(
-              [
-                input,
-                label_element.html,
-                hint_element.html,
-                @conditional_content
-              ]
-            )
-          end
+          @builder.safe_join(
+            [
+              @builder.content_tag('div', class: 'govuk-checkboxes__item') do
+                @builder.safe_join(
+                  [
+                    input,
+                    label_element.html,
+                    hint_element.html,
+                  ]
+                )
+              end,
+              @conditional_content
+            ]
+          )
         end
 
       private

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -17,16 +17,20 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def html
-          @builder.content_tag('div', class: 'govuk-radios__item') do
-            @builder.safe_join(
-              [
-                input,
-                label_element.html,
-                hint_element.html,
-                @conditional_content
-              ]
-            )
-          end
+          @builder.safe_join(
+            [
+              @builder.content_tag('div', class: 'govuk-radios__item') do
+                @builder.safe_join(
+                  [
+                    input,
+                    label_element.html,
+                    hint_element.html,
+                  ]
+                )
+              end,
+              @conditional_content
+            ]
+          )
         end
 
       private

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
@@ -78,6 +78,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           end
         end
 
+        specify 'should place the conditional content at the same level as the form' do
+          expect(parsed_subject).to have_root_element_with_class('govuk-checkboxes__conditional')
+        end
+
         specify 'should include content provided in the block in a conditional div' do
           expect(subject).to have_tag('div', with: { class: 'govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden' }) do |cd|
             expect(cd).to have_tag('label', with: { class: 'govuk-label' }, text: 'Project_responsibilities')

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
@@ -78,7 +78,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           end
         end
 
-        specify 'should place the conditional content at the same level as the form' do
+        specify 'should place the conditional content at the same level as the checkbox container' do
           expect(parsed_subject).to have_root_element_with_class('govuk-checkboxes__conditional')
         end
 

--- a/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
@@ -47,6 +47,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           end
         end
 
+        specify 'should place the conditional content at the same level as the form' do
+          expect(parsed_subject).to have_root_element_with_class('govuk-radios__conditional')
+        end
+
         specify 'should include content provided in the block in a conditional div' do
           expect(subject).to have_tag('div', with: { class: 'govuk-radios__conditional govuk-radios__conditional--hidden' }) do |cd|
             expect(cd).to have_tag('label', with: { class: 'govuk-label' }, text: 'Favourite_colour_reason')

--- a/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
@@ -47,7 +47,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           end
         end
 
-        specify 'should place the conditional content at the same level as the form' do
+        specify 'should place the conditional content at the same level as the radio button container' do
           expect(parsed_subject).to have_root_element_with_class('govuk-radios__conditional')
         end
 

--- a/spec/support/html_helper.rb
+++ b/spec/support/html_helper.rb
@@ -1,5 +1,5 @@
-def extract_classes(nokogiri_document, selector)
-  nokogiri_document
+def extract_classes(nokogiri_fragment, selector)
+  nokogiri_fragment
     .at_css(selector)
     .attributes['class']
     .value

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,0 +1,18 @@
+require 'rspec/expectations'
+
+RSpec::Matchers.define :have_root_element_with_class do |class_name|
+  # We're using xpath here because there's no sane way (ie without wrapping
+  # everything in a useless element just for testing) of checking that elements
+  # appear at the root of the fragment
+  #
+  # Note that the ./* matches ANY element `*` at the root `./` of the fragment
+  match do |nokogiri_fragment|
+    !nokogiri_fragment.xpath(%(./*[contains(concat(" ", @class, " "), " #{class_name} ")])).empty?
+  end
+
+  #:nocov:
+  failure_message do |nokogiri_fragment|
+    "expected that #{class_name} would be a class of a root element in fragment: #{nokogiri_fragment}"
+  end
+  #:nocov:
+end

--- a/spec/support/shared/setup_builder.rb
+++ b/spec/support/shared/setup_builder.rb
@@ -4,5 +4,5 @@ shared_context 'setup builder' do
   let(:object) { Person.new(name: 'Joey') }
   let(:object_name) { :person }
   let(:builder) { described_class.new(object_name, object, helper, {}) }
-  let(:parsed_subject) { Nokogiri.parse(subject) }
+  let(:parsed_subject) { Nokogiri::HTML::DocumentFragment.parse(subject) }
 end


### PR DESCRIPTION
The conditional content, as explained in #48, was inserted in the wrong place causing it to render incorrectly. It has been moved so it's now in the correct position:

<img width="878" alt="Screenshot 2019-10-09 at 19 59 54" src="https://user-images.githubusercontent.com/128088/66511932-cbcf4880-eacf-11e9-8224-c59e1601aa49.png">

<img width="870" alt="Screenshot 2019-10-09 at 18 52 57" src="https://user-images.githubusercontent.com/128088/66511936-ceca3900-eacf-11e9-9f09-d167efc78980.png">