### PR TITLE
GOV.UK design system 3.3.0

### DIFF
--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -16,7 +16,7 @@ dl.govuk-summary-list
       ul.govuk-list
         li
           span.govuk-tag
-            | Version 3.2.0
+            | Version 3.3.0
 
       ul.govuk-list
         li

--- a/lib/govuk_design_system_formbuilder/version.rb
+++ b/lib/govuk_design_system_formbuilder/version.rb
@@ -1,3 +1,3 @@
 module GOVUKDesignSystemFormBuilder
-  VERSION = '0.9.6'.freeze
+  VERSION = '0.9.7'.freeze
 end


### PR DESCRIPTION
Upgrade to GOV.UK Design System version `3.3.0` and prep release `0.9.7`