### PR TITLE
Delegate common rails tag helpers to @builder

### DIFF
--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -1,10 +1,12 @@
 module GOVUKDesignSystemFormBuilder
   class Base
+    delegate :capture, :content_tag, :safe_join, :tag, :raw, :link_to, to: :@builder
+
     def initialize(builder, object_name, attribute_name, &block)
       @builder = builder
       @object_name = object_name
       @attribute_name = attribute_name
-      @block_content = @builder.capture { block.call } if block_given?
+      @block_content = capture { block.call } if block_given?
     end
 
     def hint_element
@@ -72,8 +74,8 @@ module GOVUKDesignSystemFormBuilder
     end
 
     def wrap_conditional(block)
-      @builder.content_tag('div', class: conditional_classes, id: conditional_id) do
-        @builder.capture { block.call }
+      content_tag('div', class: conditional_classes, id: conditional_id) do
+        capture { block.call }
       end
     end
 

--- a/lib/govuk_design_system_formbuilder/containers/character_count.rb
+++ b/lib/govuk_design_system_formbuilder/containers/character_count.rb
@@ -14,7 +14,7 @@ module GOVUKDesignSystemFormBuilder
       def html
         return yield unless limit?
 
-        @builder.content_tag(
+        content_tag(
           'div',
           class: 'govuk-character-count',
           data: { module: 'govuk-character-count' }.merge(**limit, **threshold).compact

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
@@ -7,7 +7,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        @builder.content_tag('div', class: check_boxes_classes, data: { module: 'govuk-checkboxes' }) do
+        content_tag('div', class: check_boxes_classes, data: { module: 'govuk-checkboxes' }) do
           yield
         end
       end

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -7,13 +7,13 @@ module GOVUKDesignSystemFormBuilder
         @legend        = legend
         @hint_text     = hint_text
         @small         = small
-        @block_content = @builder.capture { block.call }
+        @block_content = capture { block.call }
       end
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
           Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_element.error_id, hint_element.hint_id]).html do
-            @builder.safe_join(
+            safe_join(
               [
                 hint_element.html,
                 error_element.html,

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -11,8 +11,8 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        @builder.content_tag('fieldset', class: fieldset_classes, aria: { describedby: @described_by }) do
-          @builder.safe_join([build_legend, yield])
+        content_tag('fieldset', class: fieldset_classes, aria: { describedby: @described_by }) do
+          safe_join([build_legend, yield])
         end
       end
 
@@ -20,8 +20,8 @@ module GOVUKDesignSystemFormBuilder
 
       def build_legend
         if @legend.dig(:text).present?
-          @builder.content_tag('legend', class: legend_classes) do
-            @builder.tag.send(@legend.dig(:tag), @legend.dig(:text), class: legend_heading_classes)
+          content_tag('legend', class: legend_classes) do
+            tag.send(@legend.dig(:tag), @legend.dig(:text), class: legend_heading_classes)
           end
         end
       end

--- a/lib/govuk_design_system_formbuilder/containers/form_group.rb
+++ b/lib/govuk_design_system_formbuilder/containers/form_group.rb
@@ -6,7 +6,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        @builder.content_tag('div', class: form_group_classes) do
+        content_tag('div', class: form_group_classes) do
           yield
         end
       end

--- a/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
@@ -8,13 +8,13 @@ module GOVUKDesignSystemFormBuilder
         @small         = small
         @legend        = legend
         @hint_text     = hint_text
-        @block_content = @builder.capture { block.call }
+        @block_content = capture { block.call }
       end
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
           Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_element.error_id, hint_element.hint_id]).html do
-            @builder.safe_join(
+            safe_join(
               [
                 hint_element.html,
                 error_element.html,

--- a/lib/govuk_design_system_formbuilder/containers/radios.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radios.rb
@@ -8,7 +8,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        @builder.content_tag('div', class: radios_classes, data: { module: 'govuk-radios' }) do
+        content_tag('div', class: radios_classes, data: { module: 'govuk-radios' }) do
           yield
         end
       end

--- a/lib/govuk_design_system_formbuilder/containers/supplemental.rb
+++ b/lib/govuk_design_system_formbuilder/containers/supplemental.rb
@@ -11,7 +11,7 @@ module GOVUKDesignSystemFormBuilder
       def html
         return nil unless @content.present?
 
-        @builder.content_tag('div', id: supplemental_id) do
+        content_tag('div', id: supplemental_id) do
           @content
         end
       end

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -17,7 +17,7 @@ module GOVUKDesignSystemFormBuilder
         def html
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
             Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
-              @builder.safe_join(
+              safe_join(
                 [
                   hint_element.html,
                   error_element.html,

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
@@ -12,8 +12,8 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def html
-          @builder.content_tag('div', class: 'govuk-checkboxes__item') do
-            @builder.safe_join(
+          content_tag('div', class: 'govuk-checkboxes__item') do
+            safe_join(
               [
                 @checkbox.check_box(
                   id: field_id(link_errors: @link_errors),

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -18,10 +18,10 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def html
-          @builder.safe_join(
+          safe_join(
             [
-              @builder.content_tag('div', class: 'govuk-checkboxes__item') do
-                @builder.safe_join(
+              content_tag('div', class: 'govuk-checkboxes__item') do
+                safe_join(
                   [
                     input,
                     label_element.html,

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/hint.rb
@@ -12,7 +12,7 @@ module GOVUKDesignSystemFormBuilder
         def html
           return nil if @hint_text.blank?
 
-          @builder.tag.span(@hint_text, class: hint_classes, id: id)
+          tag.span(@hint_text, class: hint_classes, id: id)
         end
 
         def id

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -13,13 +13,13 @@ module GOVUKDesignSystemFormBuilder
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
           Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
-            @builder.safe_join(
+            safe_join(
               [
                 hint_element.html,
                 error_element.html,
                 supplemental_content.html,
-                @builder.content_tag('div', class: 'govuk-date-input') do
-                  @builder.safe_join(
+                content_tag('div', class: 'govuk-date-input') do
+                  safe_join(
                     [
                       date_input_item(:day, link_errors: true),
                       date_input_item(:month),
@@ -38,17 +38,17 @@ module GOVUKDesignSystemFormBuilder
       def date_input_item(segment, width: 2, link_errors: false)
         value = @builder.object.try(@attribute_name).try(segment)
 
-        @builder.content_tag('div', class: %w(govuk-date-input__item)) do
-          @builder.content_tag('div', class: %w(govuk-form-group)) do
-            @builder.safe_join(
+        content_tag('div', class: %w(govuk-date-input__item)) do
+          content_tag('div', class: %w(govuk-form-group)) do
+            safe_join(
               [
-                @builder.tag.label(
+                tag.label(
                   segment.capitalize,
                   class: date_input_label_classes,
                   for: date_attribute_id(segment, link_errors)
                 ),
 
-                @builder.tag.input(
+                tag.input(
                   id: date_attribute_id(segment, link_errors),
                   class: date_input_classes(width),
                   name: date_attribute_name(segment),

--- a/lib/govuk_design_system_formbuilder/elements/error_message.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_message.rb
@@ -8,10 +8,10 @@ module GOVUKDesignSystemFormBuilder
       def html
         return nil unless has_errors?
 
-        @builder.content_tag('span', class: 'govuk-error-message', id: error_id) do
-          @builder.safe_join(
+        content_tag('span', class: 'govuk-error-message', id: error_id) do
+          safe_join(
             [
-              @builder.tag.span('Error: ', class: 'govuk-visually-hidden'),
+              tag.span('Error: ', class: 'govuk-visually-hidden'),
               message
             ]
           )

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -10,13 +10,13 @@ module GOVUKDesignSystemFormBuilder
       def html
         return nil unless object_has_errors?
 
-        @builder.content_tag('div', class: summary_class, **error_summary_attributes) do
-          @builder.safe_join(
+        content_tag('div', class: summary_class, **error_summary_attributes) do
+          safe_join(
             [
-              @builder.tag.h2(@title, id: error_summary_title_id, class: summary_class('title')),
-              @builder.content_tag('div', class: summary_class('body')) do
-                @builder.content_tag('ul', class: ['govuk-list', summary_class('list')]) do
-                  @builder.safe_join(
+              tag.h2(@title, id: error_summary_title_id, class: summary_class('title')),
+              content_tag('div', class: summary_class('body')) do
+                content_tag('ul', class: ['govuk-list', summary_class('list')]) do
+                  safe_join(
                     @builder.object.errors.messages.map do |attribute, messages|
                       error_list_item(attribute, messages.first)
                     end
@@ -31,8 +31,8 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def error_list_item(attribute, message)
-        @builder.content_tag('li') do
-          @builder.link_to(
+        content_tag('li') do
+          link_to(
             message,
             same_page_link(field_id(attribute)),
             data: {

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -11,7 +11,7 @@ module GOVUKDesignSystemFormBuilder
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-          @builder.safe_join(
+          safe_join(
             [
               label_element.html,
               hint_element.html,

--- a/lib/govuk_design_system_formbuilder/elements/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/hint.rb
@@ -13,7 +13,7 @@ module GOVUKDesignSystemFormBuilder
       def html
         return nil if @hint_text.blank?
 
-        @builder.tag.span(@hint_text, class: hint_classes, id: hint_id)
+        tag.span(@hint_text, class: hint_classes, id: hint_id)
       end
 
     private

--- a/lib/govuk_design_system_formbuilder/elements/inputs/base.rb
+++ b/lib/govuk_design_system_formbuilder/elements/inputs/base.rb
@@ -13,7 +13,7 @@ module GOVUKDesignSystemFormBuilder
 
         def html
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-            @builder.safe_join(
+            safe_join(
               [
                 label_element.html,
                 hint_element.html,

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -17,7 +17,7 @@ module GOVUKDesignSystemFormBuilder
         return nil if @text.blank?
 
         if @tag.present?
-          @builder.content_tag(@tag, class: 'govuk-label-wrapper') { build_label }
+          content_tag(@tag, class: 'govuk-label-wrapper') { build_label }
         else
           build_label
         end
@@ -40,9 +40,9 @@ module GOVUKDesignSystemFormBuilder
         text = [option_text, @value, @attribute_name.capitalize].compact.first
 
         if hidden
-          @builder.tag.span(text, class: %w(govuk-visually-hidden))
+          tag.span(text, class: %w(govuk-visually-hidden))
         else
-          @builder.raw(text)
+          raw(text)
         end
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -19,13 +19,13 @@ module GOVUKDesignSystemFormBuilder
         def html
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
             Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
-              @builder.safe_join(
+              safe_join(
                 [
                   hint_element.html,
                   error_element.html,
                   supplemental_content.html,
                   Containers::Radios.new(@builder, inline: @inline, small: @small).html do
-                    @builder.safe_join(build_collection)
+                    safe_join(build_collection)
                   end
                 ]
               )

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
@@ -17,8 +17,8 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def html
-          @builder.content_tag('div', class: 'govuk-radios__item') do
-            @builder.safe_join(
+          content_tag('div', class: 'govuk-radios__item') do
+            safe_join(
               [
                 @builder.radio_button(
                   @attribute_name,

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -17,10 +17,10 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def html
-          @builder.safe_join(
+          safe_join(
             [
-              @builder.content_tag('div', class: 'govuk-radios__item') do
-                @builder.safe_join(
+              content_tag('div', class: 'govuk-radios__item') do
+                safe_join(
                   [
                     input,
                     label_element.html,

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -15,7 +15,7 @@ module GOVUKDesignSystemFormBuilder
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-          @builder.safe_join(
+          safe_join(
             [
               label_element.html,
               hint_element.html,

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -10,12 +10,12 @@ module GOVUKDesignSystemFormBuilder
         @warning              = warning
         @secondary            = secondary
         @validate             = validate
-        @block_content        = @builder.capture { block.call } if block_given?
+        @block_content        = capture { block.call } if block_given?
       end
 
       def html
-        @builder.content_tag('div', class: %w(govuk-form-group)) do
-          @builder.safe_join(
+        content_tag('div', class: %w(govuk-form-group)) do
+          safe_join(
             [
               @builder.submit(
                 @text,

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -15,7 +15,7 @@ module GOVUKDesignSystemFormBuilder
       def html
         Containers::CharacterCount.new(@builder, max_words: @max_words, max_chars: @max_chars, threshold: @threshold).html do
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-            @builder.safe_join(
+            safe_join(
               [
                 [label_element, hint_element, error_element, supplemental_content].map(&:html),
                 @builder.text_area(


### PR DESCRIPTION
This substantially reduces the amount of noise and duplication throughout the library