### PR TITLE
Allow date input to capture only month and year

### DIFF
--- a/guide/content/form-elements/date-field.slim
+++ b/guide/content/form-elements/date-field.slim
@@ -41,6 +41,6 @@ section
       | When asking for dates that the user might not know exactly, such as
         their graduation date or their start date at a past job, the exact date
         might not be necessary. The day can be optionally omitted by providing
-        the <code>smallest_segment</code> parameter.
+        the <code>omit_day</code> parameter.
 
 == render('/partials/related-info.*', links: date_info)

--- a/guide/content/form-elements/date-field.slim
+++ b/guide/content/form-elements/date-field.slim
@@ -23,4 +23,24 @@ section
     caption: "Date field with legend and hint and birth date autocompletion",
     code: date_field)
 
+  == render('/partials/example-fig.*',
+    caption: "Month field",
+    code: month_field,
+    hide_html_output: true) do
+
+    .govuk-warning-text
+      span.govuk-warning-text__icon aria-hidden=true
+        | !
+      strong.govuk-warning-text__text
+        span.govuk-warning-text__assistive Warning
+
+        | Date inputs without a day field are not currently part of the GOV.UK Design
+          System
+
+    p.govuk-body
+      | When asking for dates that the user might not know exactly, such as
+        their graduation date or their start date at a past job, the exact date
+        might not be necessary. The day can be optionally omitted by providing
+        the <code>smallest_segment</code> parameter.
+
 == render('/partials/related-info.*', links: date_info)

--- a/guide/lib/examples/date.rb
+++ b/guide/lib/examples/date.rb
@@ -8,5 +8,13 @@ module Examples
           hint_text: "Check your passport if you're unsure"
       SNIPPET
     end
+
+    def month_field
+      <<~SNIPPET
+        = f.govuk_date_field :start_month,
+          smallest_segment: 'month',
+          legend: { text: 'When did you begin your current job?' }
+      SNIPPET
+    end
   end
 end

--- a/guide/lib/examples/date.rb
+++ b/guide/lib/examples/date.rb
@@ -12,7 +12,7 @@ module Examples
     def month_field
       <<~SNIPPET
         = f.govuk_date_field :start_month,
-          smallest_segment: 'month',
+          omit_day: true,
           legend: { text: 'When did you begin your current job?' }
       SNIPPET
     end

--- a/guide/lib/helpers/person.rb
+++ b/guide/lib/helpers/person.rb
@@ -53,7 +53,8 @@ class Person
 
   # date fields
   attr_accessor(
-    :date_of_birth
+    :date_of_birth,
+    :start_month
   )
 
   # labels, hints and legends

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -465,7 +465,7 @@ module GOVUKDesignSystemFormBuilder
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
-    # @param smallest_segment [Symbol,String] the smallest date part that will be displayed, can be either +day+ or +month+
+    # @param omit_day [Boolean] do not render a day input, only capture month and year
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input group
     # @param date_of_birth [Boolean] if +true+ {https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Values birth date auto completion attributes}
     #   will be added to the inputs
@@ -477,8 +477,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_date_field :starts_on,
     #     legend: { 'When does your event start?' },
     #     hint_text: 'Leave this field blank if you don't know exactly' }
-    def govuk_date_field(attribute_name, hint_text: nil, legend: {}, date_of_birth: false, smallest_segment: :day, &block)
-      Elements::Date.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, date_of_birth: date_of_birth, smallest_segment: smallest_segment, &block).html
+    def govuk_date_field(attribute_name, hint_text: nil, legend: {}, date_of_birth: false, omit_day: false, &block)
+      Elements::Date.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, date_of_birth: date_of_birth, omit_day: omit_day, &block).html
     end
 
     # Generates a summary of errors in the form, each linking to the corresponding

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -465,6 +465,7 @@ module GOVUKDesignSystemFormBuilder
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
+    # @param smallest_segment [Symbol,String] the smallest date part that will be displayed, can be either +day+ or +month+
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input group
     # @param date_of_birth [Boolean] if +true+ {https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Values birth date auto completion attributes}
     #   will be added to the inputs
@@ -476,8 +477,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_date_field :starts_on,
     #     legend: { 'When does your event start?' },
     #     hint_text: 'Leave this field blank if you don't know exactly' }
-    def govuk_date_field(attribute_name, hint_text: nil, legend: {}, date_of_birth: false, &block)
-      Elements::Date.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, date_of_birth: date_of_birth, &block).html
+    def govuk_date_field(attribute_name, hint_text: nil, legend: {}, date_of_birth: false, smallest_segment: :day, &block)
+      Elements::Date.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, date_of_birth: date_of_birth, smallest_segment: smallest_segment, &block).html
     end
 
     # Generates a summary of errors in the form, each linking to the corresponding

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -3,13 +3,13 @@ module GOVUKDesignSystemFormBuilder
     class Date < GOVUKDesignSystemFormBuilder::Base
       SEGMENTS = { day: '3i', month: '2i', year: '1i' }.freeze
 
-      def initialize(builder, object_name, attribute_name, legend:, hint_text:, date_of_birth: false, smallest_segment:, &block)
+      def initialize(builder, object_name, attribute_name, legend:, hint_text:, date_of_birth: false, omit_day:, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @legend           = legend
-        @hint_text        = hint_text
-        @date_of_birth    = date_of_birth
-        @smallest_segment = identify_smallest_segment(smallest_segment)
+        @legend        = legend
+        @hint_text     = hint_text
+        @date_of_birth = date_of_birth
+        @omit_day      = omit_day
       end
 
       def html
@@ -31,22 +31,22 @@ module GOVUKDesignSystemFormBuilder
 
     private
 
-      def day
-        return nil unless @smallest_segment == :day
+      def omit_day?
+        @omit_day
+      end
 
-        date_input_item(:day, link_errors: link_errors_on?(:day))
+      def day
+        return nil if omit_day?
+
+        date_input_item(:day, link_errors: true)
       end
 
       def month
-        date_input_item(:month, link_errors: link_errors_on?(:month))
+        date_input_item(:month, link_errors: omit_day?)
       end
 
       def year
         date_input_item(:year, width: 4)
-      end
-
-      def link_errors_on?(segment)
-        @smallest_segment.eql?(segment)
       end
 
       def date_input_item(segment, width: 2, link_errors: false)
@@ -112,12 +112,6 @@ module GOVUKDesignSystemFormBuilder
         return nil unless @date_of_birth
 
         { day: 'bday-day', month: 'bday-month', year: 'bday-year' }.fetch(segment)
-      end
-
-      def identify_smallest_segment(segment)
-        segment.to_sym.tap do |s|
-          fail(ArgumentError, "smallest_segment must be :day or :month") unless s.in?(%i(day month))
-        end
       end
     end
   end

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -125,16 +125,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     context 'showing only month and year inputs' do
-      subject { builder.send(*args.push(smallest_segment: 'month')) }
-
-      specify 'there be no day label and label' do
-        expect(subject).not_to have_tag('label', text: 'Day')
-      end
-
-      specify 'there should only be month and year labels' do
-        expect(subject).to have_tag('label', text: 'Month')
-        expect(subject).to have_tag('label', text: 'Year')
-      end
+      subject { builder.send(*args.push(omit_day: true)) }
 
       specify 'there should only be month and year inputs' do
         expect(subject).to have_tag('input', count: 2)
@@ -144,28 +135,13 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
 
-      context 'validating smallest segments' do
-        context 'valid arguments' do
-          %w(day month).each do |segment|
-            context segment.capitalize do
-              subject { builder.send(*args.push(smallest_segment: segment)) }
+      specify 'there be no day label' do
+        expect(subject).not_to have_tag('label', text: 'Day')
+      end
 
-              specify 'should return some HTML' do
-                expect(subject).to have_tag('div')
-              end
-            end
-          end
-        end
-
-        context 'the following arguments should be invalid' do
-          %w(DAY days year months MONTH).each do |invalid_segment|
-            subject { builder.send(*args.push(smallest_segment: invalid_segment)) }
-
-            specify "#{invalid_segment}" do
-              expect { subject }.to raise_error(ArgumentError, "smallest_segment must be :day or :month")
-            end
-          end
-        end
+      specify 'there should only be month and year labels' do
+        expect(subject).to have_tag('label', text: 'Month')
+        expect(subject).to have_tag('label', text: 'Year')
       end
     end
 

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -124,6 +124,51 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
+    context 'showing only month and year inputs' do
+      subject { builder.send(*args.push(smallest_segment: 'month')) }
+
+      specify 'there be no day label and label' do
+        expect(subject).not_to have_tag('label', text: 'Day')
+      end
+
+      specify 'there should only be month and year labels' do
+        expect(subject).to have_tag('label', text: 'Month')
+        expect(subject).to have_tag('label', text: 'Year')
+      end
+
+      specify 'there should only be month and year inputs' do
+        expect(subject).to have_tag('input', count: 2)
+
+        [month_multiparam_attribute, year_multiparam_attribute].each do |mpa|
+          expect(subject).to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{mpa})]" })
+        end
+      end
+
+      context 'validating smallest segments' do
+        context 'valid arguments' do
+          %w(day month).each do |segment|
+            context segment.capitalize do
+              subject { builder.send(*args.push(smallest_segment: segment)) }
+
+              specify 'should return some HTML' do
+                expect(subject).to have_tag('div')
+              end
+            end
+          end
+        end
+
+        context 'the following arguments should be invalid' do
+          %w(DAY days year months MONTH).each do |invalid_segment|
+            subject { builder.send(*args.push(smallest_segment: invalid_segment)) }
+
+            specify "#{invalid_segment}" do
+              expect { subject }.to raise_error(ArgumentError, "smallest_segment must be :day or :month")
+            end
+          end
+        end
+      end
+    end
+
     context 'default values' do
       let(:birth_day) { 3 }
       let(:birth_month) { 2 }


### PR DESCRIPTION
[Sometimes non-exact inputs are required](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/404) for dates that the user might not remember, such as their graduation date or when they started a new job. In this case, don't ask for the day - only the month and year.

I believe that Rails will automatically set the date to the first of the month so this approach _should just work_.

<img width="350" alt="Screenshot 2019-10-31 at 20 17 34" src="https://user-images.githubusercontent.com/128088/67982917-82c86b00-fc1b-11e9-9e24-ee21a2bf0deb.png">


* [x] Amend the date input so it can be rendered sans day
* [x] Check that the day-less input works ok with Rails and saves valid dates
* [x] Come up with a better name for the param than `smallest_segment` 🍰
* [x] Add some specs covering the behaviour of the error summary and linking directly to the month field when date is omitted

cc @chubberlisk @tvararu 

Fixes #56 