### PR TITLE
Improve the single checkbox example

### DIFF
--- a/guide/lib/examples/checkboxes.rb
+++ b/guide/lib/examples/checkboxes.rb
@@ -61,12 +61,26 @@ module Examples
 
     def single_checkbox
       <<~SNIPPET
-        .govuk-form-group
+
+        = f.govuk_check_boxes_fieldset :terms_and_conditions_agreed,
+          legend: { text: 'Terms and conditions', size: 'l' } do
+
+          = f.hidden_field :terms_and_conditions_agreed, value: false
+
+          p.govuk-body
+            | Our terms and conditions contain important information about:
+
+          ul.govuk-list.govuk-list--bullet
+            li the application process
+            li contacting us
+            li our use of your data
+            li checking you're safe to work with children
+
           = f.govuk_check_box :terms_and_conditions_agreed,
             true,
             multiple: false,
-            label: { text: 'Do you agree with the terms and conditions?' },
-            hint_text: "You won't be able to proceed to the next stage unless you do"
+            link_errors: true,
+            label: { text: 'I agree to the terms and conditions' }
       SNIPPET
     end
   end


### PR DESCRIPTION
The previous example was not wrapped in a fieldset so didn't include the ability to display error messages. Now it's properly constructed wrapped and the `link_errors` parameter is provided so it will correctly link with the `govuk_error_summary`.