### PR TITLE
Version 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/fde73b5dc9476197281b/test_coverage)](https://codeclimate.com/github/DFE-Digital/govuk_design_system_formbuilder/test_coverage)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=DFE-Digital/govuk_design_system_formbuilder)](https://dependabot.com)
 [![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk_design_system_formbuilder)](https://github.com/DFE-Digital/govuk_design_system_formbuilder/blob/master/LICENSE)
-[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.3.0-brightgreen)](https://design-system.service.gov.uk)
+[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.4.0-brightgreen)](https://design-system.service.gov.uk)
 
 This gem provides a easy-to-use form builder that generates forms that are
-fully-compliant with version 3.3.0 of the [GOV.UK Design System](https://design-system.service.gov.uk/),
+fully-compliant with version 3.4.0 of the [GOV.UK Design System](https://design-system.service.gov.uk/),
 minimising the amount of markup you need to write.
 
 In addition to the basic markup, the more-advanced functionality of the Design

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/fde73b5dc9476197281b/test_coverage)](https://codeclimate.com/github/DFE-Digital/govuk_design_system_formbuilder/test_coverage)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=DFE-Digital/govuk_design_system_formbuilder)](https://dependabot.com)
 [![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk_design_system_formbuilder)](https://github.com/DFE-Digital/govuk_design_system_formbuilder/blob/master/LICENSE)
-[![GOV.UK Design System Version 2](https://img.shields.io/github/v/release/dfe-digital/govuk_design_system_formbuilder?label=govuk+design+system+v2)](https://github.com/DFE-Digital/govuk_design_system_formbuilder/releases/tag/v0.7.10)
-[![GOV.UK Design System Version 3](https://img.shields.io/github/v/release/dfe-digital/govuk_design_system_formbuilder?include_prereleases&label=govuk+design+system+v3)](https://github.com/DFE-Digital/govuk_design_system_formbuilder)
+[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.3.0-brightgreen)](https://design-system.service.gov.uk)
 
 This gem provides a easy-to-use form builder that generates forms that are
 fully-compliant with version 3.3.0 of the [GOV.UK Design System](https://design-system.service.gov.uk/),

--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@ This gem provides a easy-to-use form builder that generates forms that are
 fully-compliant with version 3.3.0 of the [GOV.UK Design System](https://design-system.service.gov.uk/),
 minimising the amount of markup you need to write.
 
-The latest version of this gem that supports GOV.UK Design System version 2 is
-[0.7.10](https://github.com/DFE-Digital/govuk_design_system_formbuilder/releases/tag/v0.7.10).
-
 In addition to the basic markup, the more-advanced functionality of the Design
 System is exposed via the API. Adding [JavaScript-enhanced word count
 checking](https://govuk-form-builder.netlify.com/form-elements/text-area/)
@@ -108,7 +105,7 @@ Now we can get started!
   = f.govuk_submit 'Away we go!'
 ```
 
-## Developing and running the tests 🧑🏼‍🔬
+## Developing and running the tests 👨🏻‍🏭
 
 The form builder is covered by RSpec, to run all the tests first ensure that
 all of the development and testing prerequisite gems are installed. At the root

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Now, if everything was successful, run RSpec:
 bundle exec rspec -fd
 ```
 
-## Contributing 🎁
+## Contributing 📦
 
 Bug reports and feature requests are most welcome, please raise an issue or
 submit a pull request.

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -16,7 +16,7 @@ dl.govuk-summary-list
       ul.govuk-list
         li
           span.govuk-tag
-            | Version 3.3.0
+            | Version 3.4.0
 
   div.govuk-summary-list__row
     dt.govuk-summary-list__key

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -18,13 +18,6 @@ dl.govuk-summary-list
           span.govuk-tag
             | Version 3.3.0
 
-      ul.govuk-list
-        li
-          span.govuk-hint
-            ' If you are using version 2 of the GOV.UK design system, the last compatible
-              version of this form builder was
-              #{link_to('0.7.10', version_supporting_design_system_v2).html_safe}.
-
   div.govuk-summary-list__row
     dt.govuk-summary-list__key
       | Ruby

--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "govuk-frontend": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.3.0.tgz",
-      "integrity": "sha512-ncOGTAV6mzz1CPBlr/UGETiG3IO6P3b0CvSI0wxBz7Uo0A/6jttLoxkvuYXju2oNA2yqRh2NjD1zJUOP3Q32CQ=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.4.0.tgz",
+      "integrity": "sha512-rmYPtcCtWgz92QBejYwOnfSxbPGYfvSruLwB4CBk/yJtySHRY0whG1e2/iFRRSj0pMx1Bu+zh/IqCTo+84hbFw=="
     }
   }
 }

--- a/guide/package.json
+++ b/guide/package.json
@@ -12,6 +12,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "govuk-frontend": "^3.3.0"
+    "govuk-frontend": "^3.4.0"
   }
 }

--- a/lib/govuk_design_system_formbuilder/version.rb
+++ b/lib/govuk_design_system_formbuilder/version.rb
@@ -1,3 +1,3 @@
 module GOVUKDesignSystemFormBuilder
-  VERSION = '0.9.8'.freeze
+  VERSION = '1.0.0'.freeze
 end


### PR DESCRIPTION
Now development on form builder has slowed and it implements the design system fully a stable release is due.

Since the 0.9 series there have been several major and dozens of minor improvements and fixes, so many that it no longer feels right to document the 0.7 series as _supported_. 0.7 support will be dropped unless there is a call for it, in which case it can be reviewed and if necessary, revived.

The plan is to wait for [the GOV.UK Design System 3.4.0 to be released](https://github.com/alphagov/govuk-frontend/issues/1632) before bumping and releasing 1.0.0.

In the meantime I'll create a roadmap for 1.1.0 that covers the main missing feature, support for automatically populating the labels, hints and legends via Rails' i18n functionality.