### PR TITLE
Internationalisation

### DIFF
--- a/guide/content/building-blocks/localisation.slim
+++ b/guide/content/building-blocks/localisation.slim
@@ -1,0 +1,38 @@
+---
+title: Localisation
+---
+
+h1.govuk-heading-xl Localisation
+
+p.govuk-body
+  | The simplest way of adding textual information like labels and hints to
+    forms is to provide strings as arguments to the form helpers.
+
+.code-sample
+  pre
+    code.highlight.language-ruby
+      | = f.govuk_text_field :name, label: { text: "Your full name" }
+
+p.govuk-body
+  | On larger, more-complex projects, copy is spread throughout the application
+    and often duplicated, making it difficult for content designers to make
+    changes.
+
+p.govuk-body
+  | Many teams approach this problem by making use of
+    #{link_to("Rails' excellent localisation functionality", rails_localisation_link).html_safe},
+    allowing text to be stored in locale dictionaries. This allows editors to
+    make changes without the risk of breaking templates and having to learn
+    templating languages and hunt down content.
+
+section
+
+  == render('/partials/example-fig.*',
+    caption: "Populating label and hint text from the localisation data",
+    localisation: favourite_kind_of_hat_locale,
+    code: favourite_kind_of_hat) do
+
+    p.govuk-body
+      | Note that despite the <code>text</code> attribute being omitted from
+        the label options hash, the other display and formatting parameters
+        can be supplied and work in the normal manner.

--- a/guide/layouts/partials/example-fig.slim
+++ b/guide/layouts/partials/example-fig.slim
@@ -9,6 +9,16 @@ figure
 
   - display_data = defined?(hide_data) && hide_data
 
+  - if defined?(localisation)
+    - I18n.backend.store_translations(:en, YAML.load(localisation))
+
+    section
+      h4.govuk-heading-s.example-subheading.locale Localisation data
+
+      pre.example-input
+        code.highlight.language-yaml
+          | #{localisation}
+
   - if defined?(sample_data) && !display_data
     section
       h4.govuk-heading-s.example-subheading.data Data
@@ -22,8 +32,6 @@ figure
     pre.example-input
       code.highlight.language-slim
         | #{code}
-
-
 
   section
     - display_errors = defined?(show_errors) && show_errors

--- a/guide/layouts/partials/landing-page/links.slim
+++ b/guide/layouts/partials/landing-page/links.slim
@@ -16,6 +16,7 @@ section#links.govuk-width-container
       ul.govuk-list
         li== link_to 'Injecting content', '/building-blocks/injecting-content'
         li== link_to 'Fieldsets', '/building-blocks/fieldsets'
+        li== link_to 'Localisation', '/building-blocks/localisation'
 
     .govuk-grid-column-one-third
       h2.govuk-heading-m Form elements

--- a/guide/lib/examples/localisation.rb
+++ b/guide/lib/examples/localisation.rb
@@ -1,0 +1,23 @@
+module Examples
+  module Localisation
+    def favourite_kind_of_hat_locale
+      <<~LOCALE
+        helpers:
+          label:
+            person:
+              favourite_kind_of_hat: Which style of hat do you prefer?
+          hint:
+            person:
+              favourite_kind_of_hat: |-
+                Trilby, Stetson, Deerstalker, Fez, Top and Beret are
+                the most-fashionable
+      LOCALE
+    end
+
+    def favourite_kind_of_hat
+      <<~SNIPPET
+        = f.govuk_text_field :favourite_kind_of_hat, label: { size: 'm' }
+      SNIPPET
+    end
+  end
+end

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -27,6 +27,7 @@ use_helper Examples::LabelsHintsAndLegends
 use_helper Examples::File
 use_helper Examples::ErrorHandling
 use_helper Examples::InjectingContent
+use_helper Examples::Localisation
 
 use_helper Setup::FormBuilderObjects
 use_helper Setup::ExampleData

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -61,5 +61,9 @@ module Helpers
     def version_supporting_design_system_v2
       'https://rubygems.org/gems/govuk_design_system_formbuilder/versions/0.7.10'
     end
+
+    def rails_localisation_link
+      'https://guides.rubyonrails.org/i18n.html'
+    end
   end
 end

--- a/guide/lib/helpers/person.rb
+++ b/guide/lib/helpers/person.rb
@@ -91,4 +91,9 @@ class Person
   attr_accessor(
     :profile_photo
   )
+
+  # localisation
+  attr_accessor(
+    :favourite_kind_of_hat
+  )
 end

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -85,6 +85,18 @@ module GOVUKDesignSystemFormBuilder
 
   private
 
+    def localised_text(context)
+      key = localisation_key(context)
+
+      return nil unless I18n.exists?(key)
+
+      I18n.translate(key)
+    end
+
+    def localisation_key(context)
+      ['helpers', context, @object_name, @attribute_name].compact.join('.')
+    end
+
     # Builds the values used for HTML id attributes throughout the builder
     #
     # @param id_type [String] a description of the id's type, eg +hint+, +error+

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -94,7 +94,9 @@ module GOVUKDesignSystemFormBuilder
     end
 
     def localisation_key(context)
-      ['helpers', context, @object_name, @attribute_name].compact.join('.')
+      return nil unless @object_name.present? && @attribute_name.present?
+
+      ['helpers', context, @object_name, @attribute_name].join('.')
     end
 
     # Builds the values used for HTML id attributes throughout the builder

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -12,7 +12,7 @@ module GOVUKDesignSystemFormBuilder
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-          Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_element.error_id, hint_element.hint_id]).html do
+          Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, described_by: [error_element.error_id, hint_element.hint_id]).html do
             safe_join(
               [
                 hint_element.html,

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -4,10 +4,12 @@ module GOVUKDesignSystemFormBuilder
       LEGEND_DEFAULTS = { text: nil, tag: 'h1', size: 'm' }.freeze
       LEGEND_SIZES = %w(xl l m s).freeze
 
-      def initialize(builder, legend: {}, described_by: nil)
-        @builder = builder
-        @legend = LEGEND_DEFAULTS.merge(legend)
-        @described_by = described_by(described_by)
+      def initialize(builder, object_name = nil, attribute_name = nil, legend: {}, described_by: nil)
+        super(builder, object_name, attribute_name)
+
+        @legend         = LEGEND_DEFAULTS.merge(legend)
+        @described_by   = described_by(described_by)
+        @attribute_name = attribute_name
       end
 
       def html

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -19,11 +19,15 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def build_legend
-        if @legend.dig(:text).present?
+        if legend_text.present?
           content_tag('legend', class: legend_classes) do
-            tag.send(@legend.dig(:tag), @legend.dig(:text), class: legend_heading_classes)
+            tag.send(@legend.dig(:tag), legend_text, class: legend_heading_classes)
           end
         end
+      end
+
+      def legend_text
+        [@legend.dig(:text), localised_text('fieldset')].compact.first
       end
 
       def fieldset_classes

--- a/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
@@ -13,7 +13,7 @@ module GOVUKDesignSystemFormBuilder
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-          Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_element.error_id, hint_element.hint_id]).html do
+          Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, described_by: [error_element.error_id, hint_element.hint_id]).html do
             safe_join(
               [
                 hint_element.html,

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -16,7 +16,7 @@ module GOVUKDesignSystemFormBuilder
 
         def html
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-            Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
+            Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
               safe_join(
                 [
                   hint_element.html,

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -14,7 +14,7 @@ module GOVUKDesignSystemFormBuilder
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-          Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
+          Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
             safe_join(
               [
                 hint_element.html,

--- a/lib/govuk_design_system_formbuilder/elements/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/hint.rb
@@ -5,7 +5,7 @@ module GOVUKDesignSystemFormBuilder
         super(builder, object_name, attribute_name)
 
         @value          = value
-        @hint_text      = text
+        @hint_text      = hint_text(text)
         @radio_class    = radio_class(radio)
         @checkbox_class = checkbox_class(checkbox)
       end
@@ -17,6 +17,13 @@ module GOVUKDesignSystemFormBuilder
       end
 
     private
+
+      def hint_text(supplied)
+        [
+          supplied.presence,
+          localised_text('hint')
+        ].compact.first
+      end
 
       def hint_classes
         %w(govuk-hint).push(@radio_class, @checkbox_class).compact

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -37,7 +37,12 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def label_text(option_text, hidden)
-        text = [option_text, @value, @attribute_name.capitalize].compact.first
+        text = [
+          option_text,
+          @value,
+          localised_text('label'),
+          @attribute_name.capitalize
+        ].compact.first
 
         if hidden
           tag.span(text, class: %w(govuk-visually-hidden))

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -18,7 +18,7 @@ module GOVUKDesignSystemFormBuilder
 
         def html
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-            Containers::Fieldset.new(@builder, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
+            Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
               safe_join(
                 [
                   hint_element.html,

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
@@ -35,6 +35,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:described_element) { 'fieldset' }
     end
 
+    it_behaves_like 'a field that supports setting the legend via localisation'
+    it_behaves_like 'a field that supports setting the hint via localisation'
+
     describe 'check boxes' do
       specify 'output should contain the correct number of check boxes' do
         expect(subject).to have_tag('div', with: { 'data-module' => 'govuk-checkboxes' }) do |cb|

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
@@ -25,6 +25,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:error_identifier) { 'person-projects-error' }
     end
 
+    it_behaves_like 'a field that supports setting the hint via localisation'
+    it_behaves_like 'a field that supports setting the legend via localisation'
+
     context 'when no block is supplied' do
       subject { builder.send(*args) }
       specify { expect { subject }.to raise_error(NoMethodError, /undefined method.*call/) }

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -58,6 +58,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
+    it_behaves_like 'a field that supports setting the legend via localisation'
+    it_behaves_like 'a field that supports setting the hint via localisation'
+
     specify 'should output a form group with fieldset, date group and 3 inputs and labels' do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
         expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -37,6 +37,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:error_identifier) { 'person-photo-error' }
     end
 
+    it_behaves_like 'a field that supports setting the label via localisation'
+    it_behaves_like 'a field that supports setting the hint via localisation'
+
     describe 'additional attributes' do
       subject { builder.send(method, attribute, accept: 'image/*', multiple: true) }
 

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -41,6 +41,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:described_element) { 'fieldset' }
     end
 
+    it_behaves_like 'a field that supports setting the hint via localisation'
+    it_behaves_like 'a field that supports setting the legend via localisation'
+
     context 'radio buttons' do
       specify 'each radio button should have the correct classes' do
         expect(subject).to have_tag('input', with: { class: %w(govuk-radios__input) }, count: colours.size)

--- a/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
@@ -29,6 +29,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:error_identifier) { 'person-favourite-colour-error' }
     end
 
+    it_behaves_like 'a field that supports setting the hint via localisation'
+    it_behaves_like 'a field that supports setting the legend via localisation'
+
     context 'when a block containing radio buttons is supplied' do
       specify 'output should be a form group containing a form group and fieldset' do
         expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -27,6 +27,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:described_element) { 'select' }
     end
 
+    it_behaves_like 'a field that supports setting the label via localisation'
+    it_behaves_like 'a field that supports setting the hint via localisation'
+
     specify 'output should be a form group containing a label and select box' do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
         expect(fg).to have_tag('select')

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -34,6 +34,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     let(:error_identifier) { 'person-cv-error' }
   end
 
+  it_behaves_like 'a field that supports setting the label via localisation'
+  it_behaves_like 'a field that supports setting the hint via localisation'
+
   specify 'should have the correct classes' do
     expect(subject).to have_tag('textarea', with: { class: 'govuk-textarea' })
   end

--- a/spec/support/locales/sample.en.yaml
+++ b/spec/support/locales/sample.en.yaml
@@ -2,11 +2,20 @@ helpers:
   label:
     person:
       name: Who goes there?
+      cv: Tell us about your employment history
+      favourite_colour: What is your favourite colour?
+      photo: Upload a recent passport photo
   fieldset:
     person:
       favourite_colour: To which colours are you most partial?
+      born_on: What is your date of birth?
+      projects: What do you do all day at work?
   hint:
     person:
-      name: Check your birth certificate or passport
+      name: Enter your full name including middle names, nicknames and aliases
       favourite_colour: |-
         Yes, there are plenty of options but please pick the one you enjoy most
+      cv: Where did you work? What did you do?
+      photo: Make sure your face is clear and you are looking at the camera
+      born_on: Check your birth certificate or passport
+      projects: If you cannot remember check with your teammates or manager

--- a/spec/support/locales/sample.en.yaml
+++ b/spec/support/locales/sample.en.yaml
@@ -1,0 +1,12 @@
+helpers:
+  label:
+    person:
+      name: Who goes there?
+  fieldset:
+    person:
+      favourite_colour: To which colours are you most partial?
+  hint:
+    person:
+      name: Check your birth certificate or passport
+      favourite_colour: |-
+        Yes, there are plenty of options but please pick the one you enjoy most

--- a/spec/support/localisation.rb
+++ b/spec/support/localisation.rb
@@ -1,0 +1,7 @@
+def with_localisations(localisations, locale: :en)
+  I18n.backend.store_translations(locale, localisations[locale])
+
+  yield
+ensure
+  I18n.reload!
+end

--- a/spec/support/shared/shared_localisation_examples.rb
+++ b/spec/support/shared/shared_localisation_examples.rb
@@ -1,0 +1,96 @@
+LOCALISATIONS = {
+  en: YAML.load_file('spec/support/locales/sample.en.yaml')
+}.freeze
+
+shared_examples 'a field that supports setting the label via localisation' do
+  let(:localisations) { LOCALISATIONS }
+
+  context 'localising when no text is supplied' do
+    let(:expected_label) { I18n.translate("helpers.label.person.#{attribute}") }
+    subject { builder.send(*args) }
+
+    specify 'should set the label from the locales' do
+      with_localisations(localisations) do
+        expect(subject).to have_tag('label', text: expected_label)
+      end
+    end
+  end
+
+  context 'allowing localised text to be overridden' do
+    let(:expected_label) { "Yeah but, who are you really?" }
+
+    subject { builder.send(*args.push(label: { text: expected_label })) }
+
+    specify 'should use the supplied label text' do
+      with_localisations(localisations) do
+        expect(subject).to have_tag('label', text: expected_label)
+      end
+    end
+  end
+end
+
+shared_examples 'a field that supports setting the hint via localisation' do
+  let(:arbitrary_html_content) { builder.tag.p("a wild paragraph has appeared") }
+  let(:localisations) { LOCALISATIONS }
+
+  context 'localising when no text is supplied' do
+    let(:expected_hint) { I18n.translate("helpers.hint.person.#{attribute}") }
+
+    subject { builder.send(*args) { arbitrary_html_content } }
+
+    specify 'should set the hint from the locales' do
+      with_localisations(localisations) do
+        expect(subject).to have_tag('span', text: expected_hint, with: { class: 'govuk-hint' })
+      end
+    end
+  end
+
+  context 'allowing localised text to be overridden' do
+    let(:expected_hint) { "It's quite a straightforward question!" }
+
+    subject do
+      builder.send(*args.push(hint_text: expected_hint)) { arbitrary_html_content }
+    end
+
+    specify 'should use the supplied hint text' do
+      with_localisations(localisations) do
+        expect(subject).to have_tag('span', text: expected_hint, with: { class: 'govuk-hint' })
+      end
+    end
+  end
+end
+
+shared_examples 'a field that supports setting the legend via localisation' do
+  let(:arbitrary_html_content) { builder.tag.p("a wild paragraph has appeared") }
+  let(:localisations) { LOCALISATIONS }
+
+  context 'localising when no text is supplied' do
+    let(:expected_legend) { I18n.translate("helpers.fieldset.person.#{attribute}") }
+    subject { builder.send(*args) { arbitrary_html_content } }
+
+    specify 'should set the legend from the locales' do
+      with_localisations(localisations) do
+        expect(subject).to have_tag('fieldset') do
+          with_tag('legend', with: { class: 'govuk-fieldset__legend' }) do
+            with_tag('h1', text: expected_legend, with: { class: 'govuk-fieldset__heading' })
+          end
+        end
+      end
+    end
+  end
+
+  context 'allowing localised text to be overridden' do
+    let(:expected_legend) { "It is quite a straightforward question!" }
+    subject { builder.send(*args.push(legend: { text: expected_legend })) { arbitrary_html_content } }
+
+    specify 'should set the legend from the locales' do
+      with_localisations(localisations) do
+        expect(subject).to have_tag('fieldset') do
+          with_tag('legend', with: { class: 'govuk-fieldset__legend' }) do
+            with_tag('h1', text: expected_legend, with: { class: 'govuk-fieldset__heading' })
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -37,6 +37,9 @@ shared_examples 'a regular input' do |method_identifier, field_type|
     let(:error_identifier) { 'person-name-error' }
   end
 
+  it_behaves_like 'a field that supports setting the label via localisation'
+  it_behaves_like 'a field that supports setting the hint via localisation'
+
   context 'extra attributes' do
     let(:regular_args) { { label: { text: 'What should we call you?' } } }
 


### PR DESCRIPTION
Adds support for labels, fieldset legends and hints to be set from the locales file rather than be passed into the builder's helpers manually. When used, the order of precedence is passed-in, then localised and finally (in the case of labels) the default - which is the attribute name.

This should make the usage of the builder more familiar to people migrating from the [MoJ GOV.UK Elements Form Builder](https://github.com/ministryofjustice/govuk_elements_form_builder) and generally work in a more Rails-like fashion generally.

This isn't ready for merging just yet and is planned for version 1.1, there are still a few things to be ironed out in the corresponding ticket #68.

Fixes #68 