### PR TITLE
Investigate broken character count behaviour

### DIFF
--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -68,6 +68,10 @@ module GOVUKDesignSystemFormBuilder
       build_id('supplemental')
     end
 
+    def limit_id
+      build_id('limit')
+    end
+
     def has_errors?
       @builder.object.errors.any? &&
         @builder.object.errors.messages.dig(@attribute_name).present?

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -68,8 +68,12 @@ module GOVUKDesignSystemFormBuilder
       build_id('supplemental')
     end
 
+    # Provides an id for use by the textual description of character and word limits.
+    #
+    # @note In order for the GOV.UK Frontend JavaScript to pick up this associated field
+    #   it has to have the same id as the text area with the additional suffix of '-info'
     def limit_id
-      build_id('limit')
+      [field_id(link_errors: true), 'info'].join('-')
     end
 
     def has_errors?

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -23,14 +23,11 @@ module GOVUKDesignSystemFormBuilder
                   id: field_id(link_errors: true),
                   class: govuk_textarea_classes,
                   aria: {
-                    describedby: described_by(
-                      hint_id,
-                      error_id,
-                      supplemental_id
-                    )
+                    describedby: described_by(hint_id, error_id, supplemental_id, limit_description_id)
                   },
                   **@extra_args.merge(rows: @rows)
-                )
+                ),
+                limit_description
               ].flatten.compact
             )
           end
@@ -48,6 +45,28 @@ module GOVUKDesignSystemFormBuilder
 
       def limit?
         @max_words || @max_chars
+      end
+
+      def limit_description
+        return nil unless limit?
+
+        content_tag('span', id: limit_id, class: %w(govuk-hint govuk-character-count__message), aria: { live: 'polite' }) do
+          "You can enter up to #{limit_quantity} #{limit_type}"
+        end
+      end
+
+      def limit_quantity
+        @max_words || @max_chars
+      end
+
+      def limit_type
+        @max_words.present? ? 'words' : 'characters'
+      end
+
+      def limit_description_id
+        return nil unless limit?
+
+        limit_id
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/version.rb
+++ b/lib/govuk_design_system_formbuilder/version.rb
@@ -1,3 +1,3 @@
 module GOVUKDesignSystemFormBuilder
-  VERSION = '1.0.0'.freeze
+  VERSION = '1.0.1'.freeze
 end

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -38,6 +38,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     expect(subject).to have_tag('textarea', with: { class: 'govuk-textarea' })
   end
 
+  specify 'should be no character count description when no limit is specified' do
+    expect(subject).not_to have_tag('span', with: { class: 'govuk-character-count__message' })
+  end
+
   describe 'limits' do
     context 'max words' do
       let(:max_words) { 20 }
@@ -56,6 +60,17 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
       specify 'should add govuk-js-character-count class to the textarea' do
         expect(subject).to have_tag('textarea', with: { class: 'govuk-js-character-count' })
+      end
+
+      context 'limit description' do
+        let(:message_selector) { { with: { class: 'govuk-character-count__message' } } }
+        specify 'should add a character count description' do
+          expect(subject).to have_tag('span', **message_selector)
+        end
+
+        specify 'the description should contain the correct limit and count type' do
+          expect(subject).to have_tag('span', **message_selector, text: /#{max_words} words/)
+        end
       end
     end
 
@@ -76,6 +91,17 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
       specify 'should add govuk-js-character-count class to the textarea' do
         expect(subject).to have_tag('textarea', with: { class: 'govuk-js-character-count' })
+      end
+
+      context 'limit description' do
+        let(:message_selector) { { with: { class: 'govuk-character-count__message' } } }
+        specify 'should add a character count description' do
+          expect(subject).to have_tag('span', **message_selector)
+        end
+
+        specify 'the description should contain the correct limit and count type' do
+          expect(subject).to have_tag('span', **message_selector, text: /#{max_chars} characters/)
+        end
       end
     end
 

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -9,6 +9,28 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   let(:field_type) { 'textarea' }
   subject { builder.send(*args) }
 
+
+  shared_context 'a text area that is associated with a character count description' do
+    context 'association with the text area' do
+      context 'when there are no errors on the field' do
+        specify "should have a id that matches the text area with additional suffix '-info'" do
+          text_area_id = parsed_subject.at_css('textarea')['id']
+
+          expect(subject).to have_tag('span', with: { id: text_area_id + "-info" })
+        end
+      end
+
+      context 'when there are errors on the field' do
+        before { object.valid? }
+        specify "should have a id that matches the text area with additional suffix '-info'" do
+          text_area_id = parsed_subject.at_css('textarea')['id']
+          expect(text_area_id).to end_with('-error')
+          expect(subject).to have_tag('span', with: { id: text_area_id + '-info' })
+        end
+      end
+    end
+  end
+
   specify 'should output a form group containing a textarea' do
     expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
       expect(fg).to have_tag('textarea')
@@ -64,6 +86,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
       context 'limit description' do
         let(:message_selector) { { with: { class: 'govuk-character-count__message' } } }
+
         specify 'should add a character count description' do
           expect(subject).to have_tag('span', **message_selector)
         end
@@ -71,6 +94,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         specify 'the description should contain the correct limit and count type' do
           expect(subject).to have_tag('span', **message_selector, text: /#{max_words} words/)
         end
+
+        it_behaves_like 'a text area that is associated with a character count description'
       end
     end
 
@@ -95,6 +120,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
       context 'limit description' do
         let(:message_selector) { { with: { class: 'govuk-character-count__message' } } }
+
         specify 'should add a character count description' do
           expect(subject).to have_tag('span', **message_selector)
         end
@@ -102,6 +128,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         specify 'the description should contain the correct limit and count type' do
           expect(subject).to have_tag('span', **message_selector, text: /#{max_chars} characters/)
         end
+
+        it_behaves_like 'a text area that is associated with a character count description'
       end
     end
 

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -8,7 +8,7 @@ class Person
   validates :name, presence: { message: 'Enter a name' }
   validates :favourite_colour, presence: { message: 'Choose a favourite colour' }
   validates :projects, presence: { message: 'Select at least one project' }
-  validates :cv, length: { maximum: 30 }
+  validates :cv, length: { maximum: 30 }, presence: true
 
   validate :born_on_must_be_in_the_past, if: -> { born_on.present? }
   validate :photo_must_be_jpeg, if: -> { photo.present? }


### PR DESCRIPTION
Fix bug where JavaScript counters stopped working. The behaviour had changed slightly since Design System 3.3.0 and it caused them to not work. The fact that the textual description of the limit (_You have 38 words remaining_) **must have** the same `id` as the text area except with a `-info` suffix is confusing and doesn't appear to be particularly well documented. We should probably raise this with the frontend team.

Thanks @dankmitchell  for the heads up - I missed this when checking the upgrade. Perhaps this is an indication that some more tests - perhaps Jasmine - are required 🤔