### PR TITLE
Switch from govuk-lint to rubocop-govuk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,9 @@
+# .rubocop.yml
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rails.yml
+
 AllCops:
   Exclude:
     - govuk_design_system_formbuilder.gemspec

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ check: ruby-lint rspec nanoc-check
 nanoc-check: nanoc-check-all
 
 ruby-lint:
-	${prefix} govuk-lint-ruby lib spec guide/lib util
+	${prefix} rubocop lib spec guide/lib util
 rspec:
 	${prefix} rspec --format progress
 npm-install:

--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
     s.add_dependency(*VersionFormatter.new(lib, rails_version, exact_rails_version).to_a)
   end
 
-  s.add_development_dependency("govuk-lint", "~> 4")
+  s.add_development_dependency("rubocop-govuk", "~> 2")
   s.add_development_dependency("pry", "~> 0.12.2")
   s.add_development_dependency("pry-byebug", "~> 3.7", ">= 3.7.0")
   s.add_development_dependency("rspec-html-matchers", "~> 0")

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -47,7 +47,5 @@ module GOVUKDesignSystemFormBuilder
   end
 
   # Disable Rails' div.field_with_error wrapper
-  ActionView::Base.field_error_proc = Proc.new do |html_tag, _instance|
-    html_tag.html_safe
-  end
+  ActionView::Base.field_error_proc = ->(html_tag, _instance) { html_tag }
 end

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -47,7 +47,7 @@ module GOVUKDesignSystemFormBuilder
     end
 
     def hint_id
-      return nil unless @hint_text.present?
+      return nil if @hint_text.blank?
 
       build_id('hint')
     end
@@ -63,7 +63,7 @@ module GOVUKDesignSystemFormBuilder
     end
 
     def supplemental_id
-      return nil unless @block_content.present?
+      return nil if @block_content.blank?
 
       build_id('supplemental')
     end

--- a/lib/govuk_design_system_formbuilder/containers/supplemental.rb
+++ b/lib/govuk_design_system_formbuilder/containers/supplemental.rb
@@ -9,7 +9,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        return nil unless @content.present?
+        return nil if @content.blank?
 
         content_tag('div', id: supplemental_id) do
           @content

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -37,12 +37,12 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def label_text(option_text, hidden)
-        text = [option_text, @value, @attribute_name.capitalize].compact.first
+        text = [option_text, @value, @attribute_name.capitalize].compact.first.to_s
 
         if hidden
           tag.span(text, class: %w(govuk-visually-hidden))
         else
-          raw(text)
+          text
         end
       end
 


### PR DESCRIPTION
The `govuk-lint` gem is now displaying deprecation warnings on every run, it has been replaced by the new `rubocop-govuk` gem.