### PR TITLE
Providing procs to collection helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 
-cache: bundler
+# cache: bundler
 
 rvm:
   - 2.5.6

--- a/guide/content/css/rouge.sass
+++ b/guide/content/css/rouge.sass
@@ -4,7 +4,7 @@ pre > code
   &.highlight
     color: $text
 
-    .s,.s1,.s2,.vi
+    .s,.s1,.s2,.vi,.sx
       color: $pink
 
     .nt,.nf,.nc,.no

--- a/guide/content/form-elements/radios.slim
+++ b/guide/content/form-elements/radios.slim
@@ -92,4 +92,23 @@ section
         Any content passed into <code>#govuk_radio_button</code> as a block will
         be revealed when the radio button is selected.
 
+  == render('/partials/example-fig.*',
+    caption: "Populating values, labels and hints with procs",
+    localisation: radio_field_with_proc_labels_and_hints_locale,
+    code: radio_field_with_proc_labels_and_hints,
+    sample_data: laptops_data_raw,
+    display_data: true,
+    hide_html_output: true) do
+
+    p.govuk-body
+      | It's often convenient to hold label and hint text in locale or
+        configuration files. This approach allows content changes to be made in
+        the repository rather than modifying via data migrations.
+
+    p.govuk-body
+      | To support this behaviour the form builder allows #{link_to('Ruby Procs', ruby_proc_link).html_safe}
+        to be supplied for the <code>:value_method</code>, <code>:text_method</code> and
+        <code>:hint_method</code> parameters. They each take a single argument, <code>item</code>,
+        which is object representing the radio button.
+
 == render('/partials/related-info.*', links: radios_info)

--- a/guide/layouts/partials/example-fig.slim
+++ b/guide/layouts/partials/example-fig.slim
@@ -9,6 +9,14 @@ figure
 
   - display_data = defined?(hide_data) && hide_data
 
+  - if defined?(sample_data) && !display_data
+    section
+      h4.govuk-heading-s.example-subheading.data Data
+
+      pre.example-input
+        code.highlight.language-ruby
+          | #{sample_data}
+
   - if defined?(localisation)
     - I18n.backend.store_translations(:en, YAML.load(localisation))
 
@@ -19,13 +27,6 @@ figure
         code.highlight.language-yaml
           | #{localisation}
 
-  - if defined?(sample_data) && !display_data
-    section
-      h4.govuk-heading-s.example-subheading.data Data
-
-      pre.example-input
-        code.highlight.language-ruby
-          | #{sample_data}
 
   section
     h4.govuk-heading-s.example-subheading.input Input

--- a/guide/lib/examples/radios.rb
+++ b/guide/lib/examples/radios.rb
@@ -56,5 +56,41 @@ module Examples
               label: { text: 'Which department did you work in most recently?' }
       SNIPPET
     end
+
+    def radio_field_with_proc_labels_and_hints_locale
+      <<~LOCALE
+        laptops:
+          names:
+            thinkpad: Lenovo ThinkPad X1 Carbon
+            macbook_pro: MacBook Pro
+            xps: Dell XPS
+            zenbook: Asus ZenBook
+          descriptions:
+            macbook_pro: |-
+              The MacBook Pro is a line of Macintosh portable computers
+              introduced in January 2006, by Apple Inc.
+            thinkpad: |-
+              ThinkPad, known for their minimalist, black and boxy design, is a
+              line of business-oriented laptops designed, developed, marketed,
+              and sold by Lenovo (formerly IBM)
+            zenbook: |-
+              Zenbook are a family of ultrabooks – low-bulk laptop computers –
+              produced by Asus.
+            xps: |-
+              Dell XPS 'Xtreme Performance System' is a line of high
+              performance computers manufactured by Dell.
+      LOCALE
+    end
+
+    def radio_field_with_proc_labels_and_hints
+      <<~SNIPPET
+        = f.govuk_collection_radio_buttons :laptop,
+          laptops,
+          ->(option) { option },
+          ->(option) { I18n.t('laptops.names.' + option.to_s) },
+          ->(option) { I18n.t('laptops.descriptions.' + option.to_s) },
+          legend: { text: "Which laptop would you like to use?" }
+      SNIPPET
+    end
   end
 end

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -65,5 +65,9 @@ module Helpers
     def rails_localisation_link
       'https://guides.rubyonrails.org/i18n.html'
     end
+
+    def ruby_proc_link
+      'https://ruby-doc.org/core-2.6.5/Proc.html'
+    end
   end
 end

--- a/guide/lib/helpers/person.rb
+++ b/guide/lib/helpers/person.rb
@@ -33,7 +33,8 @@ class Person
     :lunch_id,
     :wednesday_lunch_id,
     :thursday_lunch_id,
-    :old_department_description
+    :old_department_description,
+    :laptop
   )
 
   # checkbox fields

--- a/guide/lib/setup/example_data.rb
+++ b/guide/lib/setup/example_data.rb
@@ -49,6 +49,12 @@ module Setup
       DATA
     end
 
+    def laptops_data_raw
+      <<~DATA
+        laptops = %i(thinkpad xps macbook_pro zenbook)
+      DATA
+    end
+
     # Yes, eval is bad, but when you want to display code in documentation as
     # well as run it, it's kind of necessary. Not considering this a security
     # threat as it's only used in the guide 👮
@@ -65,10 +71,19 @@ module Setup
     def primary_colours
       eval(primary_colours_raw)
     end
+
+    def laptops
+      eval(laptops_data_raw)
+    end
     # rubocop:enable Security/Eval
 
     def form_data
-      { departments: departments, lunch_options: lunch_options, primary_colours: primary_colours }
+      {
+        departments: departments,
+        lunch_options: lunch_options,
+        primary_colours: primary_colours,
+        laptops: laptops
+      }
     end
   end
 end

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -2,6 +2,8 @@ require 'govuk_design_system_formbuilder/version'
 require 'govuk_design_system_formbuilder/builder'
 require 'govuk_design_system_formbuilder/base'
 
+require 'govuk_design_system_formbuilder/traits/collection_item'
+
 require 'govuk_design_system_formbuilder/elements/hint'
 require 'govuk_design_system_formbuilder/elements/label'
 require 'govuk_design_system_formbuilder/elements/date'

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -201,9 +201,12 @@ module GOVUKDesignSystemFormBuilder
     #
     # @param attribute_name [Symbol] The name of the attribute
     # @param collection [Enumerable<Object>] Options to be added to the +select+ element
-    # @param value_method [Symbol] The method called against each member of the collection to provide the value
-    # @param text_method [Symbol] The method called against each member of the collection to provide the text
-    # @param hint_method [Symbol] The method called against each member of the collection to provide the hint text
+    # @param value_method [Symbol, Proc] The method called against each member of the collection to provide the value.
+    #   When a +Proc+ is provided it must take a single argument that is a single member of the collection
+    # @param text_method [Symbol, Proc] The method called against each member of the collection to provide the label text.
+    #   When a +Proc+ is provided it must take a single argument that is a single member of the collection
+    # @param hint_method [Symbol, Proc] The method called against each member of the collection to provide the hint text.
+    #   When a +Proc+ is provided it must take a single argument that is a single member of the collection
     # @param hint_text [String] The content of the fieldset hint. No hint will be injected if left +nil+
     # @param legend [Hash] options for configuring the legend
     # @param inline [Boolean] controls whether the radio buttons are displayed inline or not
@@ -214,7 +217,7 @@ module GOVUKDesignSystemFormBuilder
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+, defaults to +h1+
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
-    # @example A collection of radio buttons for favourite colours
+    # @example A collection of radio buttons for favourite colours, labels capitalised via a proc
     #
     #  @colours = [
     #    OpenStruct.new(id: 'red', name: 'Red', description: 'Roses are red'),
@@ -224,7 +227,7 @@ module GOVUKDesignSystemFormBuilder
     #  = f.govuk_collection_radio_buttons :favourite_colour,
     #    @colours,
     #    :id,
-    #    :name,
+    #    ->(option) { option.name.upcase },
     #    :description,
     #    legend: { text: 'Pick your favourite colour', size: 'm' },
     #    hint_text: 'If you cannot find the exact match choose something close',
@@ -316,8 +319,9 @@ module GOVUKDesignSystemFormBuilder
     # @param attribute_name [Symbol] The name of the attribute
     # @param collection [Enumerable<Object>] Options to be added to the +select+ element
     # @param value_method [Symbol] The method called against each member of the collection to provide the value
-    # @param text_method [Symbol] The method called against each member of the collection to provide the text
-    # @param hint_method [Symbol] The method called against each member of the collection to provide the hint text
+    # @param text_method [Symbol] The method called against each member of the collection to provide the label text
+    # @param hint_method [Symbol, Proc] The method called against each member of the collection to provide the hint text.
+    #   When a +Proc+ is provided it must take a single argument that is a single member of the collection
     # @param hint_text [String] The content of the fieldset hint. No hint will be injected if left +nil+
     # @param small [Boolean] controls whether small check boxes are used instead of regular-sized ones
     # @param legend [Hash] options for configuring the legend

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
@@ -2,12 +2,14 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module CheckBoxes
       class CollectionCheckBox < GOVUKDesignSystemFormBuilder::Base
+        include Traits::CollectionItem
+
         def initialize(builder, object_name, attribute_name, checkbox, hint_method = nil, link_errors: false)
           super(builder, object_name, attribute_name)
           @checkbox  = checkbox
           @item      = checkbox.object
           @value     = checkbox.value
-          @hint_text = @item.send(hint_method) if hint_method.present?
+          @hint_text = retrieve(@item, hint_method)
           @link_errors = link_errors
         end
 

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
@@ -2,6 +2,8 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module Radios
       class CollectionRadioButton < Base
+        include Traits::CollectionItem
+
         # @param link_errors [Boolean] used to control the id generated for radio buttons. The
         #   error summary requires that the id of the first radio is linked-to from the corresponding
         #   error message. As when the summary is built what happens later in the form is unknown, we
@@ -9,9 +11,9 @@ module GOVUKDesignSystemFormBuilder
         def initialize(builder, object_name, attribute_name, item, value_method:, text_method:, hint_method:, link_errors: false, bold_labels:)
           super(builder, object_name, attribute_name)
           @item        = item
-          @value       = item.send(value_method)
-          @text        = item.send(text_method)
-          @hint_text   = item.send(hint_method) if hint_method.present?
+          @value       = retrieve(item, value_method)
+          @label_text  = retrieve(item, text_method)
+          @hint_text   = retrieve(item, hint_method)
           @link_errors = link_errors
           @bold_labels = bold_labels
         end
@@ -41,7 +43,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def label_element
-          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, text: @text, value: @value, radio: true, size: label_size, link_errors: @link_errors)
+          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, text: @label_text, value: @value, radio: true, size: label_size, link_errors: @link_errors)
         end
 
         def label_size

--- a/lib/govuk_design_system_formbuilder/traits/collection_item.rb
+++ b/lib/govuk_design_system_formbuilder/traits/collection_item.rb
@@ -1,0 +1,18 @@
+module GOVUKDesignSystemFormBuilder
+  module Elements
+    module Traits
+      module CollectionItem
+      private
+
+        def retrieve(item, text_method)
+          case text_method
+          when Symbol, String
+            item.send(text_method)
+          when Proc
+            text_method.call(item)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/govuk_design_system_formbuilder/traits/collection_item.rb
+++ b/lib/govuk_design_system_formbuilder/traits/collection_item.rb
@@ -4,12 +4,12 @@ module GOVUKDesignSystemFormBuilder
       module CollectionItem
       private
 
-        def retrieve(item, text_method)
-          case text_method
+        def retrieve(item, method)
+          case method
           when Symbol, String
-            item.send(text_method)
+            item.send(method)
           when Proc
-            text_method.call(item)
+            method.call(item)
           end
         end
       end

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
@@ -121,6 +121,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           end
         end
       end
+
+      it_behaves_like 'a field that allows the hint to be localised via a proc' do
+        let(:attribute) { :favourite_colour }
+        let(:i18n_proc) { ->(item) { I18n.t("colours.#{item.name.downcase}") } }
+        let(:args) { [method, attribute, colours, :id, :name].push(i18n_proc) }
+      end
     end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -87,6 +87,11 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
 
+      it_behaves_like 'a field that allows the label to be localised via a proc' do
+        let(:i18n_proc) { ->(item) { I18n.t("colours.#{item.name.downcase}") } }
+        let(:args) { [method, attribute, colours, :id, i18n_proc] }
+      end
+
       context 'radio button hints' do
         let(:colours_with_descriptions) { colours.select { |c| c.description.present? } }
         let(:colours_without_descriptions) { colours.reject { |c| c.description.present? } }
@@ -116,6 +121,11 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
         specify 'all labels should be bold when hints are enabled' do
           expect(subject).to have_tag('label', with: { class: 'govuk-label--s' }, count: colours.size)
+        end
+
+        it_behaves_like 'a field that allows the hint to be localised via a proc' do
+          let(:i18n_proc) { ->(item) { I18n.t("colours.#{item.name.downcase}") } }
+          let(:args) { [method, attribute, colours, :id, :name, i18n_proc] }
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'rspec-html-matchers'
 require 'action_view'
 require 'active_model'
+require 'active_support'
 require 'pry'
 require 'simplecov'
 

--- a/spec/support/locales/colours.de.yaml
+++ b/spec/support/locales/colours.de.yaml
@@ -1,0 +1,5 @@
+colours:
+  red: Rot
+  green: Grün
+  yellow: Gelb
+  blue: Blau

--- a/spec/support/localisation.rb
+++ b/spec/support/localisation.rb
@@ -1,7 +1,16 @@
-def with_localisations(localisations, locale: :en)
+DEFAULT_LOCALE = :en
+
+def with_localisations(localisations, locale: DEFAULT_LOCALE)
+  unless locale.eql?(DEFAULT_LOCALE)
+    I18n.available_locales = [DEFAULT_LOCALE, locale]
+    I18n.locale = locale
+  end
   I18n.backend.store_translations(locale, localisations[locale])
 
   yield
 ensure
+  I18n.available_locales = DEFAULT_LOCALE
+  I18n.locale = DEFAULT_LOCALE
+
   I18n.reload!
 end

--- a/spec/support/shared/shared_localisation_examples.rb
+++ b/spec/support/shared/shared_localisation_examples.rb
@@ -94,3 +94,49 @@ shared_examples 'a field that supports setting the legend via localisation' do
     end
   end
 end
+
+shared_examples 'a field that allows the label to be localised via a proc' do
+  let(:locale) { :de }
+  let(:localisations) do
+    YAML.load_file('spec/support/locales/colours.de.yaml')
+  end
+
+  context 'localising collection items using procs' do
+    subject { builder.send(*args) }
+
+    specify 'labels should be present and correctly-localised' do
+      with_localisations({ locale => localisations }, locale: locale) do
+        colours.each do |c|
+          expect(subject).to have_tag(
+            'label',
+            text: localisations.dig("colours", c.name.downcase),
+            with: { class: 'govuk-label' }
+          )
+        end
+      end
+    end
+  end
+end
+
+shared_examples 'a field that allows the hint to be localised via a proc' do
+  let(:locale) { :de }
+  let(:localisations) do
+    YAML.load_file('spec/support/locales/colours.de.yaml')
+  end
+
+  context 'localising collection items using procs' do
+    subject { builder.send(*args) }
+
+    specify 'hints should be present and correctly-localised' do
+      with_localisations({ locale => localisations }, locale: locale) do
+        colours.each do |c|
+          expect(subject).to have_tag(
+            'span',
+            text: localisations.dig("colours", c.name.downcase),
+            with: { class: 'govuk-hint' }
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change allows procs to be provided to the `#collection_radio_buttons` and `#collection_check_boxes` helpers' `:value_method`, `:text_method` and `hint_method` params. These could be used for simple operations like transforming (eg calling `#upcase`) on the retrieved string. Alternatively, it could be used in the following manner to allow the labels and hints to be fully localised

```ruby
->(item) { I18n.t("colours.#{item.name.downcase}") }
```

Refs #68 