### PR TITLE
Traits refactor

### DIFF
--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -1,8 +1,14 @@
+require 'govuk_design_system_formbuilder/traits/collection_item'
+require 'govuk_design_system_formbuilder/traits/conditional'
+require 'govuk_design_system_formbuilder/traits/error'
+require 'govuk_design_system_formbuilder/traits/hint'
+require 'govuk_design_system_formbuilder/traits/label'
+require 'govuk_design_system_formbuilder/traits/localisation'
+require 'govuk_design_system_formbuilder/traits/supplemental'
+
 require 'govuk_design_system_formbuilder/version'
 require 'govuk_design_system_formbuilder/builder'
 require 'govuk_design_system_formbuilder/base'
-
-require 'govuk_design_system_formbuilder/traits/collection_item'
 
 require 'govuk_design_system_formbuilder/elements/hint'
 require 'govuk_design_system_formbuilder/elements/label'

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -11,6 +11,8 @@ module GOVUKDesignSystemFormBuilder
       @block_content  = capture { block.call } if block_given?
     end
 
+  private
+
     # returns the id value used for the input
     #
     # @note field_id is overridden so that the error summary can link to the
@@ -40,8 +42,6 @@ module GOVUKDesignSystemFormBuilder
     def described_by(*ids)
       ids.flatten.compact.join(' ').presence
     end
-
-  private
 
     # Builds the values used for HTML id attributes throughout the builder
     #

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -1,28 +1,14 @@
 module GOVUKDesignSystemFormBuilder
   class Base
+    include Traits::Localisation
+
     delegate :capture, :content_tag, :safe_join, :tag, :raw, :link_to, to: :@builder
 
     def initialize(builder, object_name, attribute_name, &block)
-      @builder = builder
-      @object_name = object_name
+      @builder        = builder
+      @object_name    = object_name
       @attribute_name = attribute_name
-      @block_content = capture { block.call } if block_given?
-    end
-
-    def hint_element
-      @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text)
-    end
-
-    def error_element
-      @error_element ||= Elements::ErrorMessage.new(@builder, @object_name, @attribute_name)
-    end
-
-    def label_element
-      @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, **@label)
-    end
-
-    def supplemental_content
-      @supplemental_content ||= Containers::Supplemental.new(@builder, @object_name, @attribute_name, @block_content)
+      @block_content  = capture { block.call } if block_given?
     end
 
     # returns the id value used for the input
@@ -46,45 +32,9 @@ module GOVUKDesignSystemFormBuilder
       end
     end
 
-    def hint_id
-      return nil if @hint_text.blank?
-
-      build_id('hint')
-    end
-
-    def error_id
-      return nil unless has_errors?
-
-      build_id('error')
-    end
-
-    def conditional_id
-      build_id('conditional')
-    end
-
-    def supplemental_id
-      return nil if @block_content.blank?
-
-      build_id('supplemental')
-    end
-
-    # Provides an id for use by the textual description of character and word limits.
-    #
-    # @note In order for the GOV.UK Frontend JavaScript to pick up this associated field
-    #   it has to have the same id as the text area with the additional suffix of '-info'
-    def limit_id
-      [field_id(link_errors: true), 'info'].join('-')
-    end
-
     def has_errors?
       @builder.object.errors.any? &&
         @builder.object.errors.messages.dig(@attribute_name).present?
-    end
-
-    def wrap_conditional(block)
-      content_tag('div', class: conditional_classes, id: conditional_id) do
-        capture { block.call }
-      end
     end
 
     def described_by(*ids)
@@ -92,20 +42,6 @@ module GOVUKDesignSystemFormBuilder
     end
 
   private
-
-    def localised_text(context)
-      key = localisation_key(context)
-
-      return nil unless I18n.exists?(key)
-
-      I18n.translate(key)
-    end
-
-    def localisation_key(context)
-      return nil unless @object_name.present? && @attribute_name.present?
-
-      ['helpers', context, @object_name, @attribute_name].join('.')
-    end
 
     # Builds the values used for HTML id attributes throughout the builder
     #

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -1,8 +1,9 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
-    class CheckBoxesFieldset < GOVUKDesignSystemFormBuilder::Base
+    class CheckBoxesFieldset < Base
       include Traits::Error
       include Traits::Hint
+
       def initialize(builder, object_name, attribute_name, hint_text:, legend:, small:, &block)
         super(builder, object_name, attribute_name, &block)
 

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -1,6 +1,8 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
     class CheckBoxesFieldset < GOVUKDesignSystemFormBuilder::Base
+      include Traits::Error
+      include Traits::Hint
       def initialize(builder, object_name, attribute_name, hint_text:, legend:, small:, &block)
         super(builder, object_name, attribute_name, &block)
 

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -1,6 +1,6 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
-    class Fieldset < GOVUKDesignSystemFormBuilder::Base
+    class Fieldset < Base
       LEGEND_DEFAULTS = { text: nil, tag: 'h1', size: 'm' }.freeze
       LEGEND_SIZES = %w(xl l m s).freeze
 

--- a/lib/govuk_design_system_formbuilder/containers/form_group.rb
+++ b/lib/govuk_design_system_formbuilder/containers/form_group.rb
@@ -1,6 +1,6 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
-    class FormGroup < GOVUKDesignSystemFormBuilder::Base
+    class FormGroup < Base
       def initialize(builder, object_name, attribute_name)
         super(builder, object_name, attribute_name)
       end

--- a/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
@@ -1,6 +1,6 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
-    class RadioButtonsFieldset < GOVUKDesignSystemFormBuilder::Base
+    class RadioButtonsFieldset < Base
       include Traits::Hint
       include Traits::Error
 

--- a/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
@@ -1,6 +1,9 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
     class RadioButtonsFieldset < GOVUKDesignSystemFormBuilder::Base
+      include Traits::Hint
+      include Traits::Error
+
       def initialize(builder, object_name, attribute_name, hint_text:, legend:, inline:, small:, &block)
         super(builder, object_name, attribute_name)
 

--- a/lib/govuk_design_system_formbuilder/containers/radios.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radios.rb
@@ -1,6 +1,8 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
-    class Radios < GOVUKDesignSystemFormBuilder::Base
+    class Radios < Base
+      include Traits::Hint
+
       def initialize(builder, inline:, small:)
         @builder = builder
         @inline  = inline

--- a/lib/govuk_design_system_formbuilder/containers/supplemental.rb
+++ b/lib/govuk_design_system_formbuilder/containers/supplemental.rb
@@ -1,6 +1,6 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
-    class Supplemental < GOVUKDesignSystemFormBuilder::Base
+    class Supplemental < Base
       def initialize(builder, object_name, attribute_name, content)
         @builder        = builder
         @object_name    = object_name

--- a/lib/govuk_design_system_formbuilder/containers/supplemental.rb
+++ b/lib/govuk_design_system_formbuilder/containers/supplemental.rb
@@ -2,10 +2,9 @@ module GOVUKDesignSystemFormBuilder
   module Containers
     class Supplemental < Base
       def initialize(builder, object_name, attribute_name, content)
-        @builder        = builder
-        @object_name    = object_name
-        @attribute_name = attribute_name
-        @content        = content
+        super(builder, object_name, attribute_name)
+
+        @content = content
       end
 
       def html

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -1,10 +1,11 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     module CheckBoxes
-      class Collection < GOVUKDesignSystemFormBuilder::Base
+      class Collection < Base
         include Traits::Error
         include Traits::Hint
         include Traits::Supplemental
+
         def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method: nil, hint_text:, legend:, small:, &block)
           super(builder, object_name, attribute_name, &block)
 

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -2,6 +2,9 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module CheckBoxes
       class Collection < GOVUKDesignSystemFormBuilder::Base
+        include Traits::Error
+        include Traits::Hint
+        include Traits::Supplemental
         def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method: nil, hint_text:, legend:, small:, &block)
           super(builder, object_name, attribute_name, &block)
 

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
@@ -3,6 +3,7 @@ module GOVUKDesignSystemFormBuilder
     module CheckBoxes
       class CollectionCheckBox < GOVUKDesignSystemFormBuilder::Base
         include Traits::CollectionItem
+        include Traits::Hint
 
         def initialize(builder, object_name, attribute_name, checkbox, hint_method = nil, link_errors: false)
           super(builder, object_name, attribute_name)

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
@@ -1,7 +1,7 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     module CheckBoxes
-      class CollectionCheckBox < GOVUKDesignSystemFormBuilder::Base
+      class CollectionCheckBox < Base
         include Traits::CollectionItem
         include Traits::Hint
 

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
@@ -7,6 +7,7 @@ module GOVUKDesignSystemFormBuilder
 
         def initialize(builder, object_name, attribute_name, checkbox, hint_method = nil, link_errors: false)
           super(builder, object_name, attribute_name)
+
           @checkbox  = checkbox
           @item      = checkbox.object
           @value     = checkbox.value

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -2,6 +2,8 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module CheckBoxes
       class FieldsetCheckBox < GOVUKDesignSystemFormBuilder::Base
+        include Traits::Hint
+        include Traits::Conditional
         def initialize(builder, object_name, attribute_name, value, label:, hint_text:, link_errors:, multiple:, &block)
           super(builder, object_name, attribute_name)
 

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -1,9 +1,10 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     module CheckBoxes
-      class FieldsetCheckBox < GOVUKDesignSystemFormBuilder::Base
+      class FieldsetCheckBox < Base
         include Traits::Hint
         include Traits::Conditional
+
         def initialize(builder, object_name, attribute_name, value, label:, hint_text:, link_errors:, multiple:, &block)
           super(builder, object_name, attribute_name)
 

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/hint.rb
@@ -2,6 +2,7 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module CheckBoxes
       class Hint < GOVUKDesignSystemFormBuilder::Base
+        include Traits::Hint
         def initialize(builder, object_name, attribute_name, hint_text, value:)
           super(builder, object_name, attribute_name)
 

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/hint.rb
@@ -1,8 +1,9 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     module CheckBoxes
-      class Hint < GOVUKDesignSystemFormBuilder::Base
+      class Hint < Base
         include Traits::Hint
+
         def initialize(builder, object_name, attribute_name, hint_text, value:)
           super(builder, object_name, attribute_name)
 

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/label.rb
@@ -1,7 +1,7 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     module CheckBoxes
-      class Label < GOVUKDesignSystemFormBuilder::Base
+      class Label < Base
         def initialize(builder, object_name, attribute_name, checkbox, value:, link_errors: true)
           super(builder, object_name, attribute_name)
 

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -1,6 +1,9 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     class Date < GOVUKDesignSystemFormBuilder::Base
+      include Traits::Error
+      include Traits::Hint
+      include Traits::Supplemental
       SEGMENTS = { day: '3i', month: '2i', year: '1i' }.freeze
 
       def initialize(builder, object_name, attribute_name, legend:, hint_text:, date_of_birth: false, omit_day:, &block)

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -1,9 +1,10 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
-    class Date < GOVUKDesignSystemFormBuilder::Base
+    class Date < Base
       include Traits::Error
       include Traits::Hint
       include Traits::Supplemental
+
       SEGMENTS = { day: '3i', month: '2i', year: '1i' }.freeze
 
       def initialize(builder, object_name, attribute_name, legend:, hint_text:, date_of_birth: false, omit_day:, &block)

--- a/lib/govuk_design_system_formbuilder/elements/error_message.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_message.rb
@@ -1,7 +1,8 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
-    class ErrorMessage < GOVUKDesignSystemFormBuilder::Base
+    class ErrorMessage < Base
       include Traits::Error
+
       def initialize(builder, object_name, attribute_name)
         super(builder, object_name, attribute_name)
       end

--- a/lib/govuk_design_system_formbuilder/elements/error_message.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_message.rb
@@ -1,6 +1,7 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     class ErrorMessage < GOVUKDesignSystemFormBuilder::Base
+      include Traits::Error
       def initialize(builder, object_name, attribute_name)
         super(builder, object_name, attribute_name)
       end

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -1,7 +1,8 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
-    class ErrorSummary < GOVUKDesignSystemFormBuilder::Base
+    class ErrorSummary < Base
       include Traits::Error
+
       def initialize(builder, object_name, title)
         @builder = builder
         @object_name = object_name

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -1,6 +1,7 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     class ErrorSummary < GOVUKDesignSystemFormBuilder::Base
+      include Traits::Error
       def initialize(builder, object_name, title)
         @builder = builder
         @object_name = object_name

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -1,6 +1,10 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     class File < GOVUKDesignSystemFormBuilder::Base
+      include Traits::Error
+      include Traits::Hint
+      include Traits::Label
+      include Traits::Supplemental
       def initialize(builder, object_name, attribute_name, hint_text:, label:, **extra_args, &block)
         super(builder, object_name, attribute_name, &block)
 

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -1,10 +1,11 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
-    class File < GOVUKDesignSystemFormBuilder::Base
+    class File < Base
       include Traits::Error
       include Traits::Hint
       include Traits::Label
       include Traits::Supplemental
+
       def initialize(builder, object_name, attribute_name, hint_text:, label:, **extra_args, &block)
         super(builder, object_name, attribute_name, &block)
 

--- a/lib/govuk_design_system_formbuilder/elements/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/hint.rb
@@ -1,6 +1,7 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     class Hint < GOVUKDesignSystemFormBuilder::Base
+      include Traits::Hint
       def initialize(builder, object_name, attribute_name, text, value = nil, radio: false, checkbox: false)
         super(builder, object_name, attribute_name)
 

--- a/lib/govuk_design_system_formbuilder/elements/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/hint.rb
@@ -1,7 +1,8 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
-    class Hint < GOVUKDesignSystemFormBuilder::Base
+    class Hint < Base
       include Traits::Hint
+
       def initialize(builder, object_name, attribute_name, text, value = nil, radio: false, checkbox: false)
         super(builder, object_name, attribute_name)
 

--- a/lib/govuk_design_system_formbuilder/elements/inputs/base.rb
+++ b/lib/govuk_design_system_formbuilder/elements/inputs/base.rb
@@ -2,6 +2,10 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module Inputs
       class Base < GOVUKDesignSystemFormBuilder::Base
+        include Traits::Error
+        include Traits::Hint
+        include Traits::Label
+        include Traits::Supplemental
         def initialize(builder, object_name, attribute_name, hint_text:, label:, width:, **extra_args, &block)
           super(builder, object_name, attribute_name, &block)
 

--- a/lib/govuk_design_system_formbuilder/elements/inputs/base.rb
+++ b/lib/govuk_design_system_formbuilder/elements/inputs/base.rb
@@ -6,6 +6,7 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Label
         include Traits::Supplemental
+
         def initialize(builder, object_name, attribute_name, hint_text:, label:, width:, **extra_args, &block)
           super(builder, object_name, attribute_name, &block)
 

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -1,6 +1,6 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
-    class Label < GOVUKDesignSystemFormBuilder::Base
+    class Label < Base
       def initialize(builder, object_name, attribute_name, text: nil, value: nil, size: nil, hidden: false, radio: false, checkbox: false, tag: nil, link_errors: true)
         super(builder, object_name, attribute_name)
 

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -2,6 +2,9 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module Radios
       class Collection < GOVUKDesignSystemFormBuilder::Base
+        include Traits::Error
+        include Traits::Hint
+        include Traits::Supplemental
         def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method:, hint_text:, legend:, inline:, small:, bold_labels:, &block)
           super(builder, object_name, attribute_name, &block)
 

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -1,10 +1,11 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     module Radios
-      class Collection < GOVUKDesignSystemFormBuilder::Base
+      class Collection < Base
         include Traits::Error
         include Traits::Hint
         include Traits::Supplemental
+
         def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method:, hint_text:, legend:, inline:, small:, bold_labels:, &block)
           super(builder, object_name, attribute_name, &block)
 

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
@@ -2,6 +2,7 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module Radios
       class CollectionRadioButton < Base
+        include Traits::Hint
         include Traits::CollectionItem
 
         # @param link_errors [Boolean] used to control the id generated for radio buttons. The

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
@@ -11,6 +11,7 @@ module GOVUKDesignSystemFormBuilder
         #   need to control this to ensure the link is generated correctly
         def initialize(builder, object_name, attribute_name, item, value_method:, text_method:, hint_method:, link_errors: false, bold_labels:)
           super(builder, object_name, attribute_name)
+
           @item        = item
           @value       = retrieve(item, value_method)
           @label_text  = retrieve(item, text_method)

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -2,6 +2,8 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module Radios
       class FieldsetRadioButton < Base
+        include Traits::Hint
+        include Traits::Conditional
         def initialize(builder, object_name, attribute_name, value, label:, hint_text:, link_errors:, &block)
           super(builder, object_name, attribute_name)
 

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -4,6 +4,7 @@ module GOVUKDesignSystemFormBuilder
       class FieldsetRadioButton < Base
         include Traits::Hint
         include Traits::Conditional
+
         def initialize(builder, object_name, attribute_name, value, label:, hint_text:, link_errors:, &block)
           super(builder, object_name, attribute_name)
 

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -1,10 +1,11 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
-    class Select < GOVUKDesignSystemFormBuilder::Base
+    class Select < Base
       include Traits::Error
       include Traits::Label
       include Traits::Hint
       include Traits::Supplemental
+
       def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, options: {}, html_options: {}, hint_text:, label:, &block)
         super(builder, object_name, attribute_name, &block)
 

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -1,6 +1,10 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     class Select < GOVUKDesignSystemFormBuilder::Base
+      include Traits::Error
+      include Traits::Label
+      include Traits::Hint
+      include Traits::Supplemental
       def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, options: {}, html_options: {}, hint_text:, label:, &block)
         super(builder, object_name, attribute_name, &block)
 

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -1,6 +1,6 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
-    class Submit < GOVUKDesignSystemFormBuilder::Base
+    class Submit < Base
       def initialize(builder, text, warning:, secondary:, prevent_double_click:, validate:, &block)
         fail ArgumentError, 'buttons can be warning or secondary' if warning && secondary
 

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -43,6 +43,14 @@ module GOVUKDesignSystemFormBuilder
         end
       end
 
+      # Provides an id for use by the textual description of character and word limits.
+      #
+      # @note In order for the GOV.UK Frontend JavaScript to pick up this associated field
+      #   it has to have the same id as the text area with the additional suffix of '-info'
+      def limit_id
+        [field_id(link_errors: true), 'info'].join('-')
+      end
+
       def limit?
         @max_words || @max_chars
       end

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -1,6 +1,10 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     class TextArea < Base
+      include Traits::Error
+      include Traits::Hint
+      include Traits::Label
+      include Traits::Supplemental
       def initialize(builder, object_name, attribute_name, hint_text:, label:, rows:, max_words:, max_chars:, threshold:, **extra_args, &block)
         super(builder, object_name, attribute_name, &block)
         @label      = label

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -5,6 +5,7 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Hint
       include Traits::Label
       include Traits::Supplemental
+
       def initialize(builder, object_name, attribute_name, hint_text:, label:, rows:, max_words:, max_chars:, threshold:, **extra_args, &block)
         super(builder, object_name, attribute_name, &block)
         @label      = label

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -8,6 +8,7 @@ module GOVUKDesignSystemFormBuilder
 
       def initialize(builder, object_name, attribute_name, hint_text:, label:, rows:, max_words:, max_chars:, threshold:, **extra_args, &block)
         super(builder, object_name, attribute_name, &block)
+
         @label      = label
         @hint_text  = hint_text
         @extra_args = extra_args

--- a/lib/govuk_design_system_formbuilder/traits/collection_item.rb
+++ b/lib/govuk_design_system_formbuilder/traits/collection_item.rb
@@ -1,16 +1,14 @@
 module GOVUKDesignSystemFormBuilder
-  module Elements
-    module Traits
-      module CollectionItem
-      private
+  module Traits
+    module CollectionItem
+    private
 
-        def retrieve(item, method)
-          case method
-          when Symbol, String
-            item.send(method)
-          when Proc
-            method.call(item)
-          end
+      def retrieve(item, method)
+        case method
+        when Symbol, String
+          item.send(method)
+        when Proc
+          method.call(item)
         end
       end
     end

--- a/lib/govuk_design_system_formbuilder/traits/conditional.rb
+++ b/lib/govuk_design_system_formbuilder/traits/conditional.rb
@@ -1,6 +1,8 @@
 module GOVUKDesignSystemFormBuilder
   module Traits
     module Conditional
+    private
+
       def conditional_id
         build_id('conditional')
       end

--- a/lib/govuk_design_system_formbuilder/traits/conditional.rb
+++ b/lib/govuk_design_system_formbuilder/traits/conditional.rb
@@ -1,0 +1,15 @@
+module GOVUKDesignSystemFormBuilder
+  module Traits
+    module Conditional
+      def conditional_id
+        build_id('conditional')
+      end
+
+      def wrap_conditional(block)
+        content_tag('div', class: conditional_classes, id: conditional_id) do
+          capture { block.call }
+        end
+      end
+    end
+  end
+end

--- a/lib/govuk_design_system_formbuilder/traits/error.rb
+++ b/lib/govuk_design_system_formbuilder/traits/error.rb
@@ -1,14 +1,16 @@
 module GOVUKDesignSystemFormBuilder
   module Traits
     module Error
-      def error_element
-        @error_element ||= Elements::ErrorMessage.new(@builder, @object_name, @attribute_name)
-      end
-
       def error_id
         return nil unless has_errors?
 
         build_id('error')
+      end
+
+    private
+
+      def error_element
+        @error_element ||= Elements::ErrorMessage.new(@builder, @object_name, @attribute_name)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/traits/error.rb
+++ b/lib/govuk_design_system_formbuilder/traits/error.rb
@@ -1,0 +1,15 @@
+module GOVUKDesignSystemFormBuilder
+  module Traits
+    module Error
+      def error_element
+        @error_element ||= Elements::ErrorMessage.new(@builder, @object_name, @attribute_name)
+      end
+
+      def error_id
+        return nil unless has_errors?
+
+        build_id('error')
+      end
+    end
+  end
+end

--- a/lib/govuk_design_system_formbuilder/traits/hint.rb
+++ b/lib/govuk_design_system_formbuilder/traits/hint.rb
@@ -1,0 +1,15 @@
+module GOVUKDesignSystemFormBuilder
+  module Traits
+    module Hint
+      def hint_element
+        @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text)
+      end
+
+      def hint_id
+        return nil if @hint_text.blank?
+
+        build_id('hint')
+      end
+    end
+  end
+end

--- a/lib/govuk_design_system_formbuilder/traits/hint.rb
+++ b/lib/govuk_design_system_formbuilder/traits/hint.rb
@@ -1,14 +1,16 @@
 module GOVUKDesignSystemFormBuilder
   module Traits
     module Hint
-      def hint_element
-        @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text)
-      end
-
       def hint_id
         return nil if @hint_text.blank?
 
         build_id('hint')
+      end
+
+    private
+
+      def hint_element
+        @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/traits/label.rb
+++ b/lib/govuk_design_system_formbuilder/traits/label.rb
@@ -1,0 +1,9 @@
+module GOVUKDesignSystemFormBuilder
+  module Traits
+    module Label
+      def label_element
+        @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, **@label)
+      end
+    end
+  end
+end

--- a/lib/govuk_design_system_formbuilder/traits/label.rb
+++ b/lib/govuk_design_system_formbuilder/traits/label.rb
@@ -1,6 +1,8 @@
 module GOVUKDesignSystemFormBuilder
   module Traits
     module Label
+    private
+
       def label_element
         @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, **@label)
       end

--- a/lib/govuk_design_system_formbuilder/traits/localisation.rb
+++ b/lib/govuk_design_system_formbuilder/traits/localisation.rb
@@ -1,0 +1,19 @@
+module GOVUKDesignSystemFormBuilder
+  module Traits
+    module Localisation
+      def localised_text(context)
+        key = localisation_key(context)
+
+        return nil unless I18n.exists?(key)
+
+        I18n.translate(key)
+      end
+
+      def localisation_key(context)
+        return nil unless @object_name.present? && @attribute_name.present?
+
+        ['helpers', context, @object_name, @attribute_name].join('.')
+      end
+    end
+  end
+end

--- a/lib/govuk_design_system_formbuilder/traits/localisation.rb
+++ b/lib/govuk_design_system_formbuilder/traits/localisation.rb
@@ -1,6 +1,8 @@
 module GOVUKDesignSystemFormBuilder
   module Traits
     module Localisation
+    private
+
       def localised_text(context)
         key = localisation_key(context)
 

--- a/lib/govuk_design_system_formbuilder/traits/supplemental.rb
+++ b/lib/govuk_design_system_formbuilder/traits/supplemental.rb
@@ -1,14 +1,16 @@
 module GOVUKDesignSystemFormBuilder
   module Traits
     module Supplemental
-      def supplemental_content
-        @supplemental_content ||= Containers::Supplemental.new(@builder, @object_name, @attribute_name, @block_content)
-      end
-
       def supplemental_id
         return nil if @block_content.blank?
 
         build_id('supplemental')
+      end
+
+    private
+
+      def supplemental_content
+        @supplemental_content ||= Containers::Supplemental.new(@builder, @object_name, @attribute_name, @block_content)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/traits/supplemental.rb
+++ b/lib/govuk_design_system_formbuilder/traits/supplemental.rb
@@ -1,0 +1,15 @@
+module GOVUKDesignSystemFormBuilder
+  module Traits
+    module Supplemental
+      def supplemental_content
+        @supplemental_content ||= Containers::Supplemental.new(@builder, @object_name, @attribute_name, @block_content)
+      end
+
+      def supplemental_id
+        return nil if @block_content.blank?
+
+        build_id('supplemental')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a general tidying up of common behaviour that had accumulated in `GOVUKDesignSystemFormBuilder::Base`. The functions have been grouped by theme, moved to the `Traits` namespace and only included where necessary.