### PR TITLE
Allow the form builder's default values to be configured

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ build:
 	${prefix} gem build govuk_design_system_formbuilder.gemspec
 build_guide: npm-install
 	${guide_dir} ${prefix} nanoc
+watch_guide: npm-install
+	${guide_dir} ${prefix} nanoc view --live-reload --port 3006 --color
+keep_building_guide:
+	${guide_dir} fd -e rb -eslim -esass -ejs -p guide | entr nanoc
 docs-server:
 	yard server --reload
 code-climate:

--- a/guide/content/css/_colours.sass
+++ b/guide/content/css/_colours.sass
@@ -11,3 +11,4 @@ $green: #00703c
 $light-grey: #f3f2f1
 $light-pink: lighten(#f499be, 20%)
 $red: #d4351c
+$dark-green: #365e07

--- a/guide/content/css/rouge.sass
+++ b/guide/content/css/rouge.sass
@@ -7,11 +7,22 @@ pre > code
     .s,.s1,.s2,.vi,.sx
       color: $pink
 
-    .nt,.nf,.nc,.no
+    .nt,.nf,.nc
       color: $orange
 
     .n,.p,.k,.mi,.n,.o,.na,.ss
       color: $dark-blue
 
+    .k
+      font-weight: 600
+
+    .no
+      color: #0e5e5e
+
     .kp
       color: $green
+
+    // comments
+    .c1
+      color: $dark-green
+      font-style: italic

--- a/guide/content/introduction/configuration.slim
+++ b/guide/content/introduction/configuration.slim
@@ -1,0 +1,29 @@
+---
+title: Configuration
+---
+
+h1.govuk-heading-xl Configuration
+
+p.govuk-body
+  | The form builder's defaults follow the guidance specified in the
+    GOV.UK Design System documentation, but every project is different
+    and having to repeatedly override settings would soon become annoying.
+
+p.govuk-body
+  | To configure the builder for your project, just create an initialiser
+    in <code>config/initializers/govuk_design_system_formbuilder.rb</code>.
+
+.code-sample
+  pre
+    code.highlight.language-ruby
+      | GOVUKDesignSystemFormBuilder.configure do |conf|
+          conf.default_submit_button_text  = 'Apply'              # Continue
+          conf.default_error_summary_title = 'Uh-oh, spaghettios' # There is a problem
+          conf.default_legend_tag          = 'h3'                 # h1
+          conf.default_legend_size         = 'l'                  # m
+          conf.default_radio_divider_text  = 'how about'          # or
+        end
+
+p.govuk-body
+  | If there's anything you'd like to be able to set defaults for but can't,
+    #{link_to('raise an issue', project_new_issue_link).html_safe}.

--- a/guide/layouts/partials/landing-page/links.slim
+++ b/guide/layouts/partials/landing-page/links.slim
@@ -7,6 +7,7 @@ section#links.govuk-width-container
 
       ul.govuk-list
         li== link_to 'Getting started', '/introduction/getting-started'
+        li== link_to 'Configuration', '/introduction/configuration'
         li== link_to 'Supported versions', '/introduction/supported-versions'
         li== link_to 'Labels, hints and legends', '/introduction/labels-hints-and-legends'
         li== link_to 'Error handling', '/introduction/error-handling'

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -69,5 +69,9 @@ module Helpers
     def ruby_proc_link
       'https://ruby-doc.org/core-2.6.5/Proc.html'
     end
+
+    def project_new_issue_link
+      'https://github.com/DFE-Digital/govuk_design_system_formbuilder/issues'
+    end
   end
 end

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -56,7 +56,8 @@ module GOVUKDesignSystemFormBuilder
     default_legend_size: 'm',
     default_legend_tag: 'h1',
     default_submit_button_text: 'Continue',
-    default_radio_divider_text: 'or'
+    default_radio_divider_text: 'or',
+    default_error_summary_title: 'There is a problem'
   }.freeze
 
   DEFAULTS.keys.each { |k| config_accessor(k) { DEFAULTS[k] } }

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -1,3 +1,5 @@
+require 'active_support/configurable'
+
 require 'govuk_design_system_formbuilder/traits/collection_item'
 require 'govuk_design_system_formbuilder/traits/conditional'
 require 'govuk_design_system_formbuilder/traits/error'
@@ -48,6 +50,30 @@ require 'govuk_design_system_formbuilder/containers/character_count'
 require 'govuk_design_system_formbuilder/containers/supplemental'
 
 module GOVUKDesignSystemFormBuilder
+  include ActiveSupport::Configurable
+
+  DEFAULTS = {
+    default_legend_size: 'm',
+    default_legend_tag: 'h1'
+  }.freeze
+
+  config_accessor(:default_legend_size) { DEFAULTS[:default_legend_size] }
+  config_accessor(:default_legend_tag)  { DEFAULTS[:default_legend_tag] }
+
+  class << self
+    def configure
+      yield(config)
+    end
+
+    # Resets each of the configurable values to its default, only really
+    # intended for use by the tests
+    def reset!
+      configure do |c|
+        DEFAULTS.each { |k, v| c.send("#{k}=", v) }
+      end
+    end
+  end
+
   class FormBuilder < ActionView::Helpers::FormBuilder
     delegate :content_tag, :tag, :safe_join, :safe_concat, :capture, :link_to, :raw, to: :@template
 

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -63,12 +63,22 @@ module GOVUKDesignSystemFormBuilder
   DEFAULTS.keys.each { |k| config_accessor(k) { DEFAULTS[k] } }
 
   class << self
+    # Configure the form builder in the usual manner. All of the
+    # keys in {DEFAULTS} can be configured as per the example below
+    #
+    # @example
+    #   GOVUKDesignSystemFormBuilder.configure do |conf|
+    #     conf.default_legend_size = 'xl'
+    #     conf.default_error_summary_title = 'OMG'
+    #   end
     def configure
       yield(config)
     end
 
-    # Resets each of the configurable values to its default, only really
-    # intended for use by the tests
+    # Resets each of the configurable values to its default
+    #
+    # @note This method is only really intended for use to clean up
+    #   during testing
     def reset!
       configure do |c|
         DEFAULTS.each { |k, v| c.send("#{k}=", v) }

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -55,7 +55,8 @@ module GOVUKDesignSystemFormBuilder
   DEFAULTS = {
     default_legend_size: 'm',
     default_legend_tag: 'h1',
-    default_submit_button_text: 'Continue'
+    default_submit_button_text: 'Continue',
+    default_radio_divider_text: 'or'
   }.freeze
 
   DEFAULTS.keys.each { |k| config_accessor(k) { DEFAULTS[k] } }

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -54,11 +54,11 @@ module GOVUKDesignSystemFormBuilder
 
   DEFAULTS = {
     default_legend_size: 'm',
-    default_legend_tag: 'h1'
+    default_legend_tag: 'h1',
+    default_submit_button_text: 'Continue'
   }.freeze
 
-  config_accessor(:default_legend_size) { DEFAULTS[:default_legend_size] }
-  config_accessor(:default_legend_tag)  { DEFAULTS[:default_legend_tag] }
+  DEFAULTS.keys.each { |k| config_accessor(k) { DEFAULTS[k] } }
 
   class << self
     def configure

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -3,6 +3,7 @@ module GOVUKDesignSystemFormBuilder
     include Traits::Localisation
 
     delegate :capture, :content_tag, :safe_join, :tag, :raw, :link_to, to: :@builder
+    delegate :config, to: GOVUKDesignSystemFormBuilder
 
     def initialize(builder, object_name, attribute_name, &block)
       @builder        = builder

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -311,7 +311,7 @@ module GOVUKDesignSystemFormBuilder
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @example A custom divider
     #   = govuk_radio_divider 'Alternatively'
-    def govuk_radio_divider(text = 'or')
+    def govuk_radio_divider(text = config.default_radio_divider_text)
       tag.div(text, class: %w(govuk-radios__divider))
     end
 

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -501,7 +501,7 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_error_summary 'Uh-oh, spaghettios'
     #
     # @see https://design-system.service.gov.uk/components/error-summary/ GOV.UK error summary
-    def govuk_error_summary(title = 'There is a problem')
+    def govuk_error_summary(title = config.default_error_summary_title)
       Elements::ErrorSummary.new(self, object_name, title).html
     end
 

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -454,7 +454,7 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_submit "Proceed", prevent_double_click: true do
     #     = link_to 'Cancel', some_other_path, class: 'govuk-button__secondary'
     #
-    def govuk_submit(text = 'Continue', warning: false, secondary: false, prevent_double_click: true, validate: false, &block)
+    def govuk_submit(text = nil, warning: false, secondary: false, prevent_double_click: true, validate: false, &block)
       Elements::Submit.new(self, text, warning: warning, secondary: secondary, prevent_double_click: prevent_double_click, validate: validate, &block).html
     end
 

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -1,5 +1,6 @@
 module GOVUKDesignSystemFormBuilder
   module Builder
+    delegate :config, to: GOVUKDesignSystemFormBuilder
     # Generates a input of type +text+
     #
     # @param attribute_name [Symbol] The name of the attribute
@@ -454,7 +455,7 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_submit "Proceed", prevent_double_click: true do
     #     = link_to 'Cancel', some_other_path, class: 'govuk-button__secondary'
     #
-    def govuk_submit(text = nil, warning: false, secondary: false, prevent_double_click: true, validate: false, &block)
+    def govuk_submit(text = config.default_submit_button_text, warning: false, secondary: false, prevent_double_click: true, validate: false, &block)
       Elements::Submit.new(self, text, warning: warning, secondary: secondary, prevent_double_click: prevent_double_click, validate: validate, &block).html
     end
 

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -1,13 +1,12 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
     class Fieldset < Base
-      LEGEND_DEFAULTS = { text: nil, tag: 'h1', size: 'm' }.freeze
       LEGEND_SIZES = %w(xl l m s).freeze
 
       def initialize(builder, object_name = nil, attribute_name = nil, legend: {}, described_by: nil)
         super(builder, object_name, attribute_name)
 
-        @legend         = LEGEND_DEFAULTS.merge(legend)
+        @legend         = legend_defaults.merge(legend)
         @described_by   = described_by(described_by)
         @attribute_name = attribute_name
       end
@@ -19,6 +18,14 @@ module GOVUKDesignSystemFormBuilder
       end
 
     private
+
+      def legend_defaults
+        {
+          text: nil,
+          tag:  config.default_legend_tag,
+          size: config.default_legend_size
+        }
+      end
 
       def build_legend
         if legend_text.present?

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -5,7 +5,7 @@ module GOVUKDesignSystemFormBuilder
         fail ArgumentError, 'buttons can be warning or secondary' if warning && secondary
 
         @builder              = builder
-        @text                 = text
+        @text                 = submit_button_value(text)
         @prevent_double_click = prevent_double_click
         @warning              = warning
         @secondary            = secondary
@@ -33,6 +33,10 @@ module GOVUKDesignSystemFormBuilder
       end
 
     private
+
+      def submit_button_value(text)
+        text || config.default_submit_button_text
+      end
 
       def warning_class
         'govuk-button--warning' if @warning

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -5,7 +5,7 @@ module GOVUKDesignSystemFormBuilder
         fail ArgumentError, 'buttons can be warning or secondary' if warning && secondary
 
         @builder              = builder
-        @text                 = submit_button_value(text)
+        @text                 = text
         @prevent_double_click = prevent_double_click
         @warning              = warning
         @secondary            = secondary
@@ -33,10 +33,6 @@ module GOVUKDesignSystemFormBuilder
       end
 
     private
-
-      def submit_button_value(text)
-        text || config.default_submit_button_text
-      end
 
       def warning_class
         'govuk-button--warning' if @warning

--- a/spec/govuk_design_system_formbuilder/builder/configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration_spec.rb
@@ -86,8 +86,37 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
         subject { builder.send(*args) }
 
-        specify 'should use the default value when no override supplied' do
+        specify 'should use supplied value when overridden' do
           expect(subject).to have_tag('input', with: { type: 'submit', value: submit_button_text })
+        end
+      end
+    end
+
+    describe 'radio divider config' do
+      let(:method) { :govuk_radio_divider }
+      let(:args) { [method] }
+      let(:default_radio_divider_text) { 'Actually, on the other hand' }
+
+      subject { builder.send(*args) }
+
+      before do
+        GOVUKDesignSystemFormBuilder.configure do |conf|
+          conf.default_radio_divider_text = default_radio_divider_text
+        end
+      end
+
+      specify 'should use the default value when no override supplied' do
+        expect(subject).to have_tag('div', text: default_radio_divider_text, with: { class: 'govuk-radios__divider' })
+      end
+
+      context %(overriding with 'Engage') do
+        let(:radio_divider_text) { 'Alternatively' }
+        let(:args) { [method, radio_divider_text] }
+
+        subject { builder.send(*args) }
+
+        specify 'should use supplied text when overridden' do
+          expect(subject).to have_tag('div', text: radio_divider_text, with: { class: 'govuk-radios__divider' })
         end
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration_spec.rb
@@ -92,31 +92,33 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
-    describe 'radio divider config' do
-      let(:method) { :govuk_radio_divider }
+    describe 'error summary title' do
+      let(:method) { :govuk_error_summary }
       let(:args) { [method] }
-      let(:default_radio_divider_text) { 'Actually, on the other hand' }
+      let(:default_error_summary_title) { 'Huge, huge problems here' }
 
       subject { builder.send(*args) }
 
       before do
         GOVUKDesignSystemFormBuilder.configure do |conf|
-          conf.default_radio_divider_text = default_radio_divider_text
+          conf.default_error_summary_title = default_error_summary_title
         end
       end
 
+      before { object.valid? }
+
       specify 'should use the default value when no override supplied' do
-        expect(subject).to have_tag('div', text: default_radio_divider_text, with: { class: 'govuk-radios__divider' })
+        expect(subject).to have_tag('h2', text: default_error_summary_title, with: { class: 'govuk-error-summary__title' })
       end
 
       context %(overriding with 'Engage') do
-        let(:radio_divider_text) { 'Alternatively' }
-        let(:args) { [method, radio_divider_text] }
+        let(:error_summary_title) { %(We've been hit!) }
+        let(:args) { [method, error_summary_title] }
 
         subject { builder.send(*args) }
 
         specify 'should use supplied text when overridden' do
-          expect(subject).to have_tag('div', text: radio_divider_text, with: { class: 'govuk-radios__divider' })
+          expect(subject).to have_tag('h2', text: error_summary_title, with: { class: 'govuk-error-summary__title' })
         end
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration_spec.rb
@@ -62,5 +62,34 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
     end
+
+    describe 'submit config' do
+      let(:method) { :govuk_submit }
+      let(:args) { [method] }
+      let(:default_submit_button_text) { 'Make it so, number one' }
+
+      subject { builder.send(*args) }
+
+      before do
+        GOVUKDesignSystemFormBuilder.configure do |conf|
+          conf.default_submit_button_text = default_submit_button_text
+        end
+      end
+
+      specify 'should use the default value when no override supplied' do
+        expect(subject).to have_tag('input', with: { type: 'submit', value: default_submit_button_text })
+      end
+
+      context %(overriding with 'Engage') do
+        let(:submit_button_text) { 'Engage' }
+        let(:args) { [method, submit_button_text] }
+
+        subject { builder.send(*args) }
+
+        specify 'should use the default value when no override supplied' do
+          expect(subject).to have_tag('input', with: { type: 'submit', value: submit_button_text })
+        end
+      end
+    end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration_spec.rb
@@ -64,30 +64,71 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     describe 'submit config' do
-      let(:method) { :govuk_submit }
-      let(:args) { [method] }
-      let(:default_submit_button_text) { 'Make it so, number one' }
-
-      subject { builder.send(*args) }
-
-      before do
-        GOVUKDesignSystemFormBuilder.configure do |conf|
-          conf.default_submit_button_text = default_submit_button_text
-        end
+      specify %(the default should be 'Continue') do
+        expect(GOVUKDesignSystemFormBuilder.config.default_submit_button_text).to eql('Continue')
       end
 
-      specify 'should use the default value when no override supplied' do
-        expect(subject).to have_tag('input', with: { type: 'submit', value: default_submit_button_text })
-      end
-
-      context %(overriding with 'Engage') do
-        let(:submit_button_text) { 'Engage' }
-        let(:args) { [method, submit_button_text] }
+      context 'overriding with custom text' do
+        let(:method) { :govuk_submit }
+        let(:args) { [method] }
+        let(:default_submit_button_text) { 'Make it so, number one' }
 
         subject { builder.send(*args) }
 
-        specify 'should use supplied value when overridden' do
-          expect(subject).to have_tag('input', with: { type: 'submit', value: submit_button_text })
+        before do
+          GOVUKDesignSystemFormBuilder.configure do |conf|
+            conf.default_submit_button_text = default_submit_button_text
+          end
+        end
+
+        specify 'should use the default value when no override supplied' do
+          expect(subject).to have_tag('input', with: { type: 'submit', value: default_submit_button_text })
+        end
+
+        context %(overriding with 'Engage') do
+          let(:submit_button_text) { 'Engage' }
+          let(:args) { [method, submit_button_text] }
+
+          subject { builder.send(*args) }
+
+          specify 'should use supplied value when overridden' do
+            expect(subject).to have_tag('input', with: { type: 'submit', value: submit_button_text })
+          end
+        end
+      end
+    end
+
+    describe 'radio divider config' do
+      specify %(the default should be 'or') do
+        expect(GOVUKDesignSystemFormBuilder.config.default_radio_divider_text).to eql('or')
+      end
+
+      context 'overriding with custom text' do
+        let(:method) { :govuk_radio_divider }
+        let(:args) { [method] }
+        let(:default_radio_divider_text) { 'Actually, on the other hand' }
+
+        subject { builder.send(*args) }
+
+        before do
+          GOVUKDesignSystemFormBuilder.configure do |conf|
+            conf.default_radio_divider_text = default_radio_divider_text
+          end
+        end
+
+        specify 'should use the default value when no override supplied' do
+          expect(subject).to have_tag('div', text: default_radio_divider_text, with: { class: 'govuk-radios__divider' })
+        end
+
+        context %(overriding with 'Engage') do
+          let(:radio_divider_text) { 'Alternatively' }
+          let(:args) { [method, radio_divider_text] }
+
+          subject { builder.send(*args) }
+
+          specify 'should use supplied text when overridden' do
+            expect(subject).to have_tag('div', text: radio_divider_text, with: { class: 'govuk-radios__divider' })
+          end
         end
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration_spec.rb
@@ -1,0 +1,66 @@
+describe GOVUKDesignSystemFormBuilder::FormBuilder do
+  include_context 'setup builder'
+  include_context 'setup examples'
+
+  describe 'configuration' do
+    after { GOVUKDesignSystemFormBuilder.reset! }
+
+    describe 'legend config' do
+      include_context 'setup radios'
+      let(:method) { :govuk_collection_radio_buttons }
+      let(:colours) { Array.wrap(OpenStruct.new(id: 'red', name: 'Red')) }
+      let(:args) { [method, attribute, colours, :id, :name, legend: { text: legend_text }] }
+      let(:legend_text) { 'Choose a colour' }
+
+      subject { builder.send(*args) }
+
+      describe 'legend tag' do
+        specify 'the default tag should be h1' do
+          expect(GOVUKDesignSystemFormBuilder.config.default_legend_tag).to eql('h1')
+        end
+
+        context 'overriding with h6' do
+          let(:configured_tag) { 'h6' }
+
+          before do
+            GOVUKDesignSystemFormBuilder.configure do |conf|
+              conf.default_legend_tag = configured_tag
+            end
+          end
+
+          specify 'should create a legend header wrapped in a h6 tag' do
+            expect(subject).to have_tag(
+              configured_tag,
+              with: {
+                class: 'govuk-fieldset__heading'
+              },
+              text: legend_text,
+            )
+          end
+        end
+      end
+
+      describe 'legend size' do
+        specify 'the default size should be m' do
+          expect(GOVUKDesignSystemFormBuilder.config.default_legend_size).to eql('m')
+        end
+
+        context 'overriding with s' do
+          let(:configured_size) { 's' }
+
+          before do
+            GOVUKDesignSystemFormBuilder.configure do |conf|
+              conf.default_legend_size = configured_size
+            end
+          end
+
+          specify 'should create a legend header with the small class' do
+            expect(subject).to have_tag('fieldset') do
+              with_tag('legend', with: { class: "govuk-fieldset__legend--#{configured_size}" })
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -25,6 +25,14 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       expect(subject).to have_tag('input', with: { 'data-module' => 'govuk-button' })
     end
 
+    context 'when no value is passed in' do
+      subject { builder.send(method) }
+
+      specify %(it should default to 'Continue) do
+        expect(subject).to have_tag('input', with: { value: 'Continue' })
+      end
+    end
+
     describe 'button styles and colours' do
       context 'warning' do
         subject { builder.send(*args.push('Create'), warning: true) }

--- a/spec/support/shared/setup_radios.rb
+++ b/spec/support/shared/setup_radios.rb
@@ -1,5 +1,5 @@
 shared_context 'setup radios' do
-  let(:field_type) { 'input' }
+  let(:field_type) { %s(input[type='radio']) }
   let(:aria_described_by_target) { 'fieldset' }
   let(:attribute) { :favourite_colour }
   let(:label_text) { 'Cherished shade' }


### PR DESCRIPTION
Add the ability to configure various default behaviours provided by the form builder.

Config can be set in a Rails initialiser in the normal fashion:

```ruby
GOVUKDesignSystemFormBuilder.configure do |conf|
  conf.default_submit_button_text  = 'Apply'              # Continue
  conf.default_error_summary_title = 'Uh-oh, spaghettios' # There is a problem
  conf.default_legend_tag          = 'h3'                 # h1
  conf.default_legend_size         = 'l'                  # m
  conf.default_radio_divider_text  = 'how about'          # or
end
```

Fixes #73 