### PR TITLE
Add rubypants for smartypants-like quotes in guide

### DIFF
--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("htmlbeautifier", "~> 1.3.1")
   s.add_development_dependency("nanoc", "~> 4.11")
   s.add_development_dependency("rouge", "~> 3.13.0")
+  s.add_development_dependency("rubypants", "~> 0.7.0")
   s.add_development_dependency("sassc", "~> 2.2.1")
   s.add_development_dependency("sass")
   s.add_development_dependency("slim", "~> 4.0.1")

--- a/guide/Rules
+++ b/guide/Rules
@@ -7,6 +7,7 @@ end
 compile '/**/*.slim' do
   filter :slim
   filter :colorize_syntax, default_colorizer: :rouge
+  filter :rubypants
   layout '/default.*'
   write item.identifier.without_ext + '/index.html'
 end


### PR DESCRIPTION
Apply [Nanoc's rubypants filter](https://nanoc.ws/doc/reference/filters/#rubypants) throughout the guide. Rubypants, by default, doesn't affect
`pre` or `code` tags so the samples won't be affected.

| Before | After |
| ----- | ---- |
| ![Screenshot from 2019-12-22 18-17-55](https://user-images.githubusercontent.com/128088/71325643-968ba180-24e7-11ea-8d11-8ac03cb539c5.png) | ![Screenshot from 2019-12-22 18-17-34](https://user-images.githubusercontent.com/128088/71325647-9d1a1900-24e7-11ea-9c94-3a9786298672.png) |

