### PR TITLE
Fix duplicate radio button hints

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -43,7 +43,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def hint_element
-          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text, radio: true)
+          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text, @value, radio: true)
         end
 
         def input

--- a/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
@@ -122,5 +122,26 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
     end
+
+    context 'with hint_text' do
+      subject do
+        builder.send(*args) do
+          builder.safe_join(
+            [
+              builder.govuk_radio_button(:favourite_colour, :red, label: { text: red_label }, hint_text: 'red'),
+              builder.govuk_radio_button(:favourite_colour, :green, label: { text: green_label }, hint_text: 'green')
+            ]
+          )
+        end
+      end
+
+      specify 'the hint should be associated with the correct radio button' do
+        %i[red green].each do |value|
+          hint_id = "person-favourite-colour-#{value}-hint"
+          expect(subject).to have_tag('input', with: { "aria-describedby" => hint_id })
+          expect(subject).to have_tag('span', with: { class: 'govuk-hint', id: hint_id })
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This is an attempt to fix a problem that was flagged in a usability/accessibility review of https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training. We have a couple of places where we use `govuk_radio_buttons_fieldset` and `govuk_radio_button` with the `hint_text` option. The problem is that the hint `span` elements end up with the same `id` so they can't be linked to the correct radio button for accessibility purposes.

This seems to be because `FieldsetRadioButton` doesn't pass it's `value` to it's child `Elements::Hint`. Fix is simply to pass the value in the constructor.

We found that `govuk_collection_radio_buttons` already does this. It's not applicable in one of the cases for us because we use a divider within the radio button fieldset.