### PR TITLE
Allow plain ruby objects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,5 @@ Style/TrailingCommaInHashLiteral:
   Enabled: false
 Style/TrailingCommaInArrayLiteral:
   Enabled: false
+Naming/MethodParameterName:
+  Enabled: false

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -34,7 +34,8 @@ module GOVUKDesignSystemFormBuilder
     end
 
     def has_errors?
-      @builder.object.errors.any? &&
+      @builder.object.respond_to?(:errors) &&
+        @builder.object.errors.any? &&
         @builder.object.errors.messages.dig(@attribute_name).present?
     end
 

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
@@ -38,6 +38,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports setting the legend via localisation'
     it_behaves_like 'a field that supports setting the hint via localisation'
 
+    it_behaves_like 'a field that accepts a plain ruby object' do
+      let(:described_element) { ['input', { with: { type: 'checkbox' }, count: projects.size }] }
+    end
+
     describe 'check boxes' do
       specify 'output should contain the correct number of check boxes' do
         expect(subject).to have_tag('div', with: { 'data-module' => 'govuk-checkboxes' }) do |cb|

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
@@ -28,6 +28,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports setting the hint via localisation'
     it_behaves_like 'a field that supports setting the legend via localisation'
 
+    it_behaves_like 'a field that accepts a plain ruby object' do
+      let(:described_element) { 'fieldset' }
+    end
+
     context 'when no block is supplied' do
       subject { builder.send(*args) }
       specify { expect { subject }.to raise_error(NoMethodError, /undefined method.*call/) }

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -62,6 +62,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports setting the legend via localisation'
     it_behaves_like 'a field that supports setting the hint via localisation'
 
+    it_behaves_like 'a field that accepts a plain ruby object' do
+      let(:described_element) { ['input', { count: 3 }] }
+    end
+
     specify 'should output a form group with fieldset, date group and 3 inputs and labels' do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
         expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -294,8 +294,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:object) { Guest.example }
       subject { builder.send(method) }
 
-      specify 'no error should be raised' do
-        expect { subject }.not_to raise_error
+      specify 'an error should be raised' do
+        expect { subject }.to raise_error(NoMethodError, /errors/)
       end
     end
   end

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -289,5 +289,14 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         expect(subject).to be_nil
       end
     end
+
+    context 'when the object does not support errors' do
+      let(:object) { Guest.example }
+      subject { builder.send(method) }
+
+      specify 'no error should be raised' do
+        expect { subject }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -40,6 +40,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports setting the label via localisation'
     it_behaves_like 'a field that supports setting the hint via localisation'
 
+    it_behaves_like 'a field that accepts a plain ruby object' do
+      let(:described_element) { ['input', with: { type: 'file' }] }
+    end
+
     describe 'additional attributes' do
       subject { builder.send(method, attribute, accept: 'image/*', multiple: true) }
 

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -44,6 +44,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports setting the hint via localisation'
     it_behaves_like 'a field that supports setting the legend via localisation'
 
+    it_behaves_like 'a field that accepts a plain ruby object' do
+      let(:described_element) { ['input', { with: { type: 'radio' }, count: colours.size }] }
+    end
+
     context 'radio buttons' do
       specify 'each radio button should have the correct classes' do
         expect(subject).to have_tag('input', with: { class: %w(govuk-radios__input) }, count: colours.size)

--- a/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
@@ -32,6 +32,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports setting the hint via localisation'
     it_behaves_like 'a field that supports setting the legend via localisation'
 
+    it_behaves_like 'a field that accepts a plain ruby object' do
+      subject { builder.send(*args) {} }
+
+      let(:described_element) { 'fieldset' }
+    end
+
     context 'when a block containing radio buttons is supplied' do
       specify 'output should be a form group containing a form group and fieldset' do
         expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -30,6 +30,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports setting the label via localisation'
     it_behaves_like 'a field that supports setting the hint via localisation'
 
+    it_behaves_like 'a field that accepts a plain ruby object' do
+      let(:described_element) { 'select' }
+    end
+
     specify 'output should be a form group containing a label and select box' do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
         expect(fg).to have_tag('select')

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -59,6 +59,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   it_behaves_like 'a field that supports setting the label via localisation'
   it_behaves_like 'a field that supports setting the hint via localisation'
 
+  it_behaves_like 'a field that accepts a plain ruby object' do
+    let(:described_element) { 'textarea' }
+  end
+
   specify 'should have the correct classes' do
     expect(subject).to have_tag('textarea', with: { class: 'govuk-textarea' })
   end

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -39,3 +39,15 @@ class Project
   include ActiveModel::Model
   attr_accessor(:id, :name, :description)
 end
+
+Guest = Struct.new(:name, :favourite_colour, :projects, :cv, :born_on, keyword_init: true) do
+  def self.example
+    new(
+      name: 'Minnie von Mouse',
+      favourite_colour: 'red',
+      projects: [4, 5, 6],
+      cv: 'Basic vocabulary',
+      born_on: Date.new(1974, 7, 1)
+    )
+  end
+end

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -1,9 +1,25 @@
-class Person
+class Project
   include ActiveModel::Model
-  attr_accessor(:name, :born_on, :gender, :over_18, :favourite_colour, :favourite_colour_reason)
-  attr_accessor(:projects, :project_responsibilities)
-  attr_accessor(:cv)
-  attr_accessor(:photo)
+  attr_accessor(:id, :name, :description)
+end
+
+class Being
+  attr_accessor(
+    :name,
+    :born_on,
+    :gender,
+    :over_18,
+    :favourite_colour,
+    :favourite_colour_reason,
+    :projects,
+    :project_responsibilities,
+    :cv,
+    :photo
+  )
+end
+
+class Person < Being
+  include ActiveModel::Model
 
   validates :name, presence: { message: 'Enter a name' }
   validates :favourite_colour, presence: { message: 'Choose a favourite colour' }
@@ -35,12 +51,15 @@ private
   end
 end
 
-class Project
-  include ActiveModel::Model
-  attr_accessor(:id, :name, :description)
-end
+class Guest < Being
+  def initialize(name:, favourite_colour:, projects:, cv:, born_on:)
+    self.name             = name
+    self.favourite_colour = favourite_colour
+    self.projects         = projects
+    self.cv               = cv
+    self.born_on          = born_on
+  end
 
-Guest = Struct.new(:name, :favourite_colour, :projects, :cv, :born_on, keyword_init: true) do
   def self.example
     new(
       name: 'Minnie von Mouse',

--- a/spec/support/shared/shared_error_examples.rb
+++ b/spec/support/shared/shared_error_examples.rb
@@ -50,4 +50,12 @@ shared_examples 'a field that supports errors' do
       expect(subject).not_to have_tag('span', with: { class: 'govuk-error-message' })
     end
   end
+
+  context 'when the object does not support errors' do
+    let(:object) { Guest.example }
+
+    specify 'no error should be raised' do
+      expect { subject }.not_to raise_error
+    end
+  end
 end

--- a/spec/support/shared/shared_error_examples.rb
+++ b/spec/support/shared/shared_error_examples.rb
@@ -54,6 +54,10 @@ shared_examples 'a field that supports errors' do
   context 'when the object does not support errors' do
     let(:object) { Guest.example }
 
+    specify 'should correctly render the form group' do
+      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' })
+    end
+
     specify 'no error should be raised' do
       expect { subject }.not_to raise_error
     end

--- a/spec/support/shared/shared_plain_ruby_object_examples.rb
+++ b/spec/support/shared/shared_plain_ruby_object_examples.rb
@@ -1,0 +1,19 @@
+class Biscuit
+  attr_accessor :name, :weight, :calories
+
+  def initialize(name, weight, calories)
+    self.name     = name
+    self.weight   = weight
+    self.calories = calories
+  end
+end
+
+shared_examples 'a field that accepts a plain ruby object' do
+  let(:object) { Biscuit.new('Pick-up!', 28, 143) }
+  let(:object_name) { :biscuit }
+  let(:attribute) { :calories }
+
+  specify 'should render the element successfully' do
+    expect(subject).to have_tag(*described_element)
+  end
+end

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -40,6 +40,10 @@ shared_examples 'a regular input' do |method_identifier, field_type|
   it_behaves_like 'a field that supports setting the label via localisation'
   it_behaves_like 'a field that supports setting the hint via localisation'
 
+  it_behaves_like 'a field that accepts a plain ruby object' do
+    let(:described_element) { 'input' }
+  end
+
   context 'extra attributes' do
     let(:regular_args) { { label: { text: 'What should we call you?' } } }
 


### PR DESCRIPTION
Allow the form builder to operate with plain Ruby objects in addition to `ActiveModel` and `ActiveRecord` ones that support `#errors`. This is useful when performing transient operations like searching.