### PR TITLE
Enable use for plain ruby classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ guide/tmp
 guide/output
 guide/*.log
 guide/node_modules
+/node_modules
 
 crash.log

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -34,6 +34,8 @@ module GOVUKDesignSystemFormBuilder
     end
 
     def has_errors?
+      return unless @builder.object.respond_to?(:errors)
+
       @builder.object.errors.any? &&
         @builder.object.errors.messages.dig(@attribute_name).present?
     end

--- a/lib/govuk_design_system_formbuilder/elements/error_message.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_message.rb
@@ -8,7 +8,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        return nil unless has_errors?
+        return unless has_errors?
 
         content_tag('span', class: 'govuk-error-message', id: error_id) do
           safe_join(

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -10,7 +10,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        return nil unless object_has_errors?
+        return unless object_has_errors?
 
         content_tag('div', class: summary_class, **error_summary_attributes) do
           safe_join(
@@ -65,6 +65,8 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def object_has_errors?
+        return unless @builder.object.respond_to?(:errors)
+
         @builder.object.errors.any?
       end
 

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -289,5 +289,14 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         expect(subject).to be_nil
       end
     end
+
+    context 'when the object does not support errors' do
+      let(:object) { Guest.example }
+      subject { builder.send(method) }
+
+      specify 'no error should be raised' do
+        expect { subject }.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,9 +57,9 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
@@ -70,46 +70,45 @@ RSpec.configure do |config|
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
+  # config.example_status_persistence_file_path = "spec/examples.txt"
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:
   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
+  # config.disable_monkey_patching!
 
   # This setting enables warnings. It's recommended, but in some cases may
   # be too noisy due to issues in dependencies.
-  config.warnings = true
+  # config.warnings = true
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
   # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
+  # if config.files_to_run.one?
+  #   # Use the documentation formatter for detailed output,
+  #   # unless a formatter has already been configured
+  #   # (e.g. via a command-line flag).
+  #   config.default_formatter = "doc"
+  # end
 
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  # config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  config.order = :random
+  # config.order = :random
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # Kernel.srand config.seed
 
   config.include RSpecHtmlMatchers
 end

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -39,3 +39,15 @@ class Project
   include ActiveModel::Model
   attr_accessor(:id, :name, :description)
 end
+
+Guest = Struct.new(:name, :favourite_colour, :projects, :cv, :born_on, keyword_init: true) do
+  def self.example
+    new(
+      name: 'Minnie von Mouse',
+      favourite_colour: 'red',
+      projects: [4, 5, 6],
+      cv: 'Basic vocabulary',
+      born_on: Date.new(1974, 7, 1)
+    )
+  end
+end

--- a/spec/support/shared/shared_error_examples.rb
+++ b/spec/support/shared/shared_error_examples.rb
@@ -50,4 +50,12 @@ shared_examples 'a field that supports errors' do
       expect(subject).not_to have_tag('span', with: { class: 'govuk-error-message' })
     end
   end
+
+  context 'when the object does not support errors' do
+    let(:object) { Guest.example }
+
+    specify 'no error should be raised' do
+      expect { subject }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
#### What
Allow creation of GDS design system form components for plain ruby classes. [Issue](https://github.com/DFE-Digital/govuk_design_system_formbuilder/issues/88).

#### Why
Inline with standard rails form builder helpers and to facilitate creation of simple forms with no models associated.

For example to create a simple search form it would be nice to not have to create any model and just do something like 

```
# routes.rb
post 'search', action: :index, controller: :search
```

```
# app/controllers/search_controller.rb
class SearchController < ApplicationController
  def index
    @search_options = [[:opt1, 'Option 1'], [:opt2, 'Option 2']]
  end
end
```

```
# app/view/search/index.html.haml
= form_with url: search_path, local: true do |f|
  = f.govuk_collection_radio_buttons :search_option,
      @search_options,
      :first,
      :last,
      legend: { text: 'Choose a filter' },
      hint_text: 'Specify a filter for the search'
  = f.govuk_text_field(:query, label: { text: 'Find a thing' }, hint_text: 'enter thing to find' )
  = f.govuk_submit('Search')

```

Currently this is only prevented by the use of calls to `errors`, from what i can see.
