### PR TITLE
Add govuk_password_field helper

### DIFF
--- a/guide/content/form-elements/text-field.slim
+++ b/guide/content/form-elements/text-field.slim
@@ -73,6 +73,22 @@ p.govuk-body
 
       tr.govuk-table__row
         td.govuk-table__cell
+          code #govuk_password_field
+        td.govuk-table__cell
+          code password
+        td.govuk-table__cell
+          == link_to 'MDN', 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password'
+          span.govuk-visually-hidden
+            ' documentation for number inputs
+
+          ' ,
+
+          == link_to 'WHATWG', 'https://html.spec.whatwg.org/multipage/input.html#password-state-(type=password)'
+          span.govuk-visually-hidden
+            ' standard document for number inputs
+
+      tr.govuk-table__row
+        td.govuk-table__cell
           code #govuk_url_field
         td.govuk-table__cell
           code url

--- a/guide/lib/helpers/related_info.rb
+++ b/guide/lib/helpers/related_info.rb
@@ -64,6 +64,7 @@ module Helpers
         'Form builder documentation for number fields' => 'https://www.rubydoc.info/gems/govuk_design_system_formbuilder/GOVUKDesignSystemFormBuilder/Builder#govuk_number_field-instance_method',
         'Form builder documentation for telephone number fields' => 'https://www.rubydoc.info/gems/govuk_design_system_formbuilder/GOVUKDesignSystemFormBuilder/Builder#govuk_phone_field-instance_method',
         'Form builder documentation for email fields' => 'https://www.rubydoc.info/gems/govuk_design_system_formbuilder/GOVUKDesignSystemFormBuilder/Builder#govuk_email_field-instance_method',
+        'Form builder documentation for password fields' => 'https://www.rubydoc.info/gems/govuk_design_system_formbuilder/GOVUKDesignSystemFormBuilder/Builder#govuk_password_field-instance_method',
         'Form builder documentation for URL fields' => 'https://www.rubydoc.info/gems/govuk_design_system_formbuilder/GOVUKDesignSystemFormBuilder/Builder#govuk_url_field-instance_method',
 
         'GOV.UK design system text input' => 'https://design-system.service.gov.uk/components/text-input/',

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -80,6 +80,30 @@ module GOVUKDesignSystemFormBuilder
       Elements::Inputs::Email.new(self, object_name, attribute_name, hint_text: hint_text, label: label, width: width, **args, &block).html
     end
 
+    # Generates a input of type +password+
+    #
+    # @param attribute_name [Symbol] The name of the attribute
+    # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
+    # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
+    #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
+    # @param [Hash] label configures the associated label
+    # @option label text [String] the label text
+    # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
+    # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
+    # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
+    # @option args [Hash] args additional arguments are applied as attributes to +input+ element
+    # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
+    # @return [ActiveSupport::SafeBuffer] HTML output
+    # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
+    # @see https://design-system.service.gov.uk/patterns/passwords/ GOV.UK Password patterns
+    #
+    # @example A password field
+    #   = f.govuk_password_field :password,
+    #     label: { text: 'Enter your password' }
+    def govuk_password_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
+      Elements::Inputs::Password.new(self, object_name, attribute_name, hint_text: hint_text, label: label, width: width, **args, &block).html
+    end
+
     # Generates a input of type +url+
     #
     # @param attribute_name [Symbol] The name of the attribute

--- a/lib/govuk_design_system_formbuilder/elements/inputs/password.rb
+++ b/lib/govuk_design_system_formbuilder/elements/inputs/password.rb
@@ -1,0 +1,17 @@
+module GOVUKDesignSystemFormBuilder
+  module Elements
+    module Inputs
+      class Password < Base
+        include Traits::Input
+        include Traits::Error
+        include Traits::Hint
+        include Traits::Label
+        include Traits::Supplemental
+
+        def builder_method
+          :password_field
+        end
+      end
+    end
+  end
+end

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -80,6 +80,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           it_behaves_like 'an error summary linking directly to a form element', :govuk_phone_field
           it_behaves_like 'an error summary linking directly to a form element', :govuk_url_field
           it_behaves_like 'an error summary linking directly to a form element', :govuk_email_field
+          it_behaves_like 'an error summary linking directly to a form element', :govuk_password_field
           it_behaves_like 'an error summary linking directly to a form element', :govuk_file_field
           it_behaves_like 'an error summary linking directly to a form element', :govuk_text_area, 'textarea'
 

--- a/spec/govuk_design_system_formbuilder/builder/text_field_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_field_spec.rb
@@ -1,9 +1,10 @@
 describe GOVUKDesignSystemFormBuilder::FormBuilder do
   include_context 'setup builder'
 
-  describe('#govuk_text_field')   { it_behaves_like 'a regular input', 'text', 'text' }
-  describe('#govuk_phone_field')  { it_behaves_like 'a regular input', 'phone', 'tel' }
-  describe('#govuk_email_field')  { it_behaves_like 'a regular input', 'email', 'email' }
-  describe('#govuk_url_field')    { it_behaves_like 'a regular input', 'url', 'url' }
-  describe('#govuk_number_field') { it_behaves_like 'a regular input', 'number', 'number' }
+  describe('#govuk_text_field')     { it_behaves_like 'a regular input', 'text', 'text' }
+  describe('#govuk_phone_field')    { it_behaves_like 'a regular input', 'phone', 'tel' }
+  describe('#govuk_email_field')    { it_behaves_like 'a regular input', 'email', 'email' }
+  describe('#govuk_password_field') { it_behaves_like 'a regular input', 'password', 'password' }
+  describe('#govuk_url_field')      { it_behaves_like 'a regular input', 'url', 'url' }
+  describe('#govuk_number_field')   { it_behaves_like 'a regular input', 'number', 'number' }
 end


### PR DESCRIPTION
#### What
add a `govuk_password_helper` to the form builder

#### Why
For me this makes sense to have alongside the `govuk_email_field`
when you are implementing, for example, authentication - for consistency
if nothing else.

```
# example for typical `devise` sign in page
= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
  = f.govuk_error_summary
  = f.govuk_email_field(:email, label: { text: 'Email' }, autofocus: true, autocomplete: 'email')
  = f.govuk_password_field(:password, label: { text: 'Password' }, autocomplete: 'current-password')
```