### PR TITLE
Add classes option to checkboxes collection component

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -350,6 +350,7 @@ module GOVUKDesignSystemFormBuilder
     #   When a +Proc+ is provided it must take a single argument that is a single member of the collection
     # @param hint_text [String] The content of the fieldset hint. No hint will be injected if left +nil+
     # @param small [Boolean] controls whether small check boxes are used instead of regular-sized ones
+    # @param classes [String] Classes to add to the checkbox container.
     # @param legend [Hash] options for configuring the legend
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
@@ -371,8 +372,9 @@ module GOVUKDesignSystemFormBuilder
     #    :description,
     #    legend: { text: 'What do you want in your sandwich?', size: 'm' },
     #    hint_text: "If it isn't listed here, tough luck",
-    #    inline: false
-    def govuk_collection_check_boxes(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, small: false, &block)
+    #    inline: false,
+    #    classes: 'app-overflow-scroll',
+    def govuk_collection_check_boxes(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, small: false, classes: nil, &block)
       Elements::CheckBoxes::Collection.new(
         self,
         object_name,
@@ -384,6 +386,7 @@ module GOVUKDesignSystemFormBuilder
         hint_text: hint_text,
         legend: legend,
         small: small,
+        classes: classes,
         &block
       ).html
     end

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
@@ -1,9 +1,10 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
     class CheckBoxes < Base
-      def initialize(builder, small:)
+      def initialize(builder, small:, classes: nil)
         @builder = builder
         @small   = small
+        @classes = classes
       end
 
       def html
@@ -17,6 +18,7 @@ module GOVUKDesignSystemFormBuilder
       def check_boxes_classes
         %w(govuk-checkboxes).tap do |c|
           c.push('govuk-checkboxes--small') if @small
+          c.push(@classes) if @classes
         end
       end
     end

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -6,7 +6,7 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Supplemental
 
-        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method: nil, hint_text:, legend:, small:, &block)
+        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method: nil, hint_text:, legend:, small:, classes:, &block)
           super(builder, object_name, attribute_name, &block)
 
           @collection    = collection
@@ -16,6 +16,7 @@ module GOVUKDesignSystemFormBuilder
           @small         = small
           @legend        = legend
           @hint_text     = hint_text
+          @classes       = classes
         end
 
         def html
@@ -26,7 +27,7 @@ module GOVUKDesignSystemFormBuilder
                   hint_element.html,
                   error_element.html,
                   supplemental_content.html,
-                  Containers::CheckBoxes.new(@builder, small: @small).html do
+                  Containers::CheckBoxes.new(@builder, small: @small, classes: @classes).html do
                     build_collection
                   end
                 ]

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
@@ -68,6 +68,16 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
 
+      context 'check box classes' do
+        context 'when extra css classes are specified in the options' do
+          subject { builder.send(*args, classes: 'foo') }
+
+          specify "should have the additional class 'foo'" do
+            expect(subject).to have_tag('div', with: { class: %w(govuk-checkboxes foo) })
+          end
+        end
+      end
+
       context 'check box labels' do
         specify 'labels should contain the correct content' do
           projects.map(&:name).each do |label_text|


### PR DESCRIPTION
The Design System allows you to pass in any number of CSS classes, it feels like we should do this as well.