### PR TITLE
Upgrade to GOV.UK design system 3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/fde73b5dc9476197281b/test_coverage)](https://codeclimate.com/github/DFE-Digital/govuk_design_system_formbuilder/test_coverage)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=DFE-Digital/govuk_design_system_formbuilder)](https://dependabot.com)
 [![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk_design_system_formbuilder)](https://github.com/DFE-Digital/govuk_design_system_formbuilder/blob/master/LICENSE)
-[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.5.0-brightgreen)](https://design-system.service.gov.uk)
+[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.6.0-brightgreen)](https://design-system.service.gov.uk)
 
 This gem provides a easy-to-use form builder that generates forms that are
-fully-compliant with version 3.5.0 of the [GOV.UK Design System](https://design-system.service.gov.uk/),
+fully-compliant with version 3.6.0 of the [GOV.UK Design System](https://design-system.service.gov.uk/),
 minimising the amount of markup you need to write.
 
 In addition to the basic markup, the more-advanced functionality of the Design

--- a/guide/content/form-elements/text-field.slim
+++ b/guide/content/form-elements/text-field.slim
@@ -116,12 +116,17 @@ section
     code: text_field_with_label_and_hint)
 
   == render('/partials/example-fig.*',
-    caption: "Generating a text input with some extra attributes",
-    code: text_field_with_attributes) do
+    caption: "Numeric text fields",
+    code: text_field_with_numeric_attributes) do
 
     p.govuk-body
       | All values passed into the form helper that aren't among its
         named parameters will be set as HTML attributes.
+
+    p.govuk-body
+      | This feature is useful when requesting non-quantity values like
+        account numbers, payment card numbers and sort codes. There are
+        more details on the reasoning behind this decision in #{link_to("the accompanying blog post", input_types_for_numbers_link).html_safe}.
 
   == render('/partials/example-fig.*',
     caption: "Generating text inputs with custom widths",

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -16,7 +16,7 @@ dl.govuk-summary-list
       ul.govuk-list
         li
           span.govuk-tag
-            | Version 3.5.0
+            | Version 3.6.0
 
   div.govuk-summary-list__row
     dt.govuk-summary-list__key

--- a/guide/lib/examples/text_input.rb
+++ b/guide/lib/examples/text_input.rb
@@ -8,11 +8,12 @@ module Examples
       SNIPPET
     end
 
-    def text_field_with_attributes
+    def text_field_with_numeric_attributes
       <<~SNIPPET
-        = f.govuk_text_field :job_title,
-          placeholder: "Nuclear safety engineer",
-          autocomplete: "organization-title"
+        = f.govuk_text_field :account_number,
+        label: { text: "Account number" },
+        pattern: "[0-9]*",
+        inputmode: "numeric"
       SNIPPET
     end
 

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -46,6 +46,10 @@ module Helpers
       'https://design-system.service.gov.uk/components/button/#stop-users-from-accidentally-sending-information-more-than-once'
     end
 
+    def input_types_for_numbers_link
+      'https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/'
+    end
+
     def dfe_rails_boilerplate_link
       'https://github.com/DFE-Digital/govuk-rails-boilerplate'
     end

--- a/guide/lib/helpers/person.rb
+++ b/guide/lib/helpers/person.rb
@@ -7,7 +7,8 @@ class Person
     :first_name,
     :last_name,
     :job_title,
-    :postcode
+    :postcode,
+    :account_number
   )
 
   # width examples

--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "govuk-frontend": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.5.0.tgz",
-      "integrity": "sha512-4tNKgcChO1bMNsrTz2UsK4fDMmU9R87UDxy/KhKIMbnhsuJLVuArDveYLkZuUsZ6B3eaCbl5gmI8i/Q/Mi680A=="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.6.0.tgz",
+      "integrity": "sha512-wTxufdY8vFvKJ2EmmQKmarrQ7n30kzg+vvqgGib2dawl7c5Wst8dffkEJQpy9Zs99TE/yEEFgj0VUO4GRUO22A=="
     }
   }
 }

--- a/guide/package.json
+++ b/guide/package.json
@@ -12,6 +12,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "govuk-frontend": "^3.5.0"
+    "govuk-frontend": "^3.6.0"
   }
 }

--- a/lib/govuk_design_system_formbuilder/version.rb
+++ b/lib/govuk_design_system_formbuilder/version.rb
@@ -1,3 +1,3 @@
 module GOVUKDesignSystemFormBuilder
-  VERSION = '1.1.4'.freeze
+  VERSION = '1.1.5'.freeze
 end


### PR DESCRIPTION
The latest version of the design system doesn't add any new form functionality but _does_ update the guidance on capturing numbers using text fields with `inputmode` and `pattern` attributes.

Fixes #100 