### PR TITLE
Move checkbox and radio button error messages next to inputs

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -25,8 +25,8 @@ module GOVUKDesignSystemFormBuilder
               safe_join(
                 [
                   hint_element.html,
-                  error_element.html,
                   supplemental_content.html,
+                  error_element.html,
                   Containers::CheckBoxes.new(@builder, small: @small, classes: @classes).html do
                     build_collection
                   end

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -27,8 +27,8 @@ module GOVUKDesignSystemFormBuilder
               safe_join(
                 [
                   hint_element.html,
-                  error_element.html,
                   supplemental_content.html,
+                  error_element.html,
                   Containers::Radios.new(@builder, inline: @inline, small: @small, classes: @classes).html do
                     safe_join(build_collection)
                   end

--- a/lib/govuk_design_system_formbuilder/version.rb
+++ b/lib/govuk_design_system_formbuilder/version.rb
@@ -1,3 +1,3 @@
 module GOVUKDesignSystemFormBuilder
-  VERSION = '1.1.5'.freeze
+  VERSION = '1.1.6'.freeze
 end


### PR DESCRIPTION
Previously error messages for checkbox and radio button collections were being rendered before the supplemental (injected) content, which meant they were potentially being displayed quite a
distance from the elements they referred to (see #102)

This change simply moves them beneath the supplemental content.

![Screenshot from 2020-03-27 13-39-11](https://user-images.githubusercontent.com/128088/77762112-ec18a280-7030-11ea-9812-0f531dc761df.png)
