### PR TITLE
Don’t wrap submit buttons in govuk-form-group

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -14,22 +14,20 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        content_tag('div', class: %w(govuk-form-group)) do
-          safe_join(
-            [
-              @builder.submit(
-                @text,
-                class: %w(govuk-button).push(
-                  warning_class,
-                  secondary_class,
-                  padding_class(@block_content.present?)
-                ).compact,
-                **extra_args
-              ),
-              @block_content
-            ]
-          )
-        end
+        safe_join(
+          [
+            @builder.submit(
+              @text,
+              class: %w(govuk-button).push(
+                warning_class,
+                secondary_class,
+                padding_class(@block_content.present?)
+              ).compact,
+              **extra_args
+            ),
+            @block_content
+          ]
+        )
       end
 
     private

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -7,10 +7,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     let(:args) { [method] }
     subject { builder.send(method, text) }
 
-    specify 'output should be a form group containing a submit input' do
-      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-        expect(fg).to have_tag('input', with: { type: 'submit' })
-      end
+    specify 'output should be a submit input' do
+      expect(subject).to have_tag('input', with: { type: 'submit' })
     end
 
     specify 'button should have the correct classes' do


### PR DESCRIPTION
Following discussion on DfE Slack, don't wrap `submit` elements in an unnecessary `govuk-form-group`.