### PR TITLE
Reorder the elements in govuk_date_field

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -21,9 +21,9 @@ module GOVUKDesignSystemFormBuilder
           Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
             safe_join(
               [
+                supplemental_content.html,
                 hint_element.html,
                 error_element.html,
-                supplemental_content.html,
                 content_tag('div', class: 'govuk-date-input') do
                   safe_join([day, month, year])
                 end

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -54,7 +54,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         specify 'the block content should be between the hint and the date inputs' do
           expect(
             parsed_subject.css([hint_span_selector, block_paragraph_selector, govuk_date_selector].join(',')).map(&:name)
-          ).to eql(%w(span p div))
+          ).to eql(%w(p span div))
         end
       end
     end


### PR DESCRIPTION
The injected content being rendered immediately above the inputs didn't make sense and it increased the distance between the hint/errors and input elements.

The new order is:

0. fieldset legend
1. injected content
2. hint
3. error (if invalid)
4. date part inputs

Fixes #110