### PR TITLE
Reorder elements of other inputs

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -19,9 +19,9 @@ module GOVUKDesignSystemFormBuilder
           safe_join(
             [
               label_element.html,
+              supplemental_content.html,
               hint_element.html,
               error_element.html,
-              supplemental_content.html,
               @builder.file_field(
                 @attribute_name,
                 id: field_id(link_errors: true),

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -23,9 +23,9 @@ module GOVUKDesignSystemFormBuilder
           safe_join(
             [
               label_element.html,
+              supplemental_content.html,
               hint_element.html,
               error_element.html,
-              supplemental_content.html,
               @builder.collection_select(
                 @attribute_name,
                 @collection,

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -23,7 +23,12 @@ module GOVUKDesignSystemFormBuilder
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
             safe_join(
               [
-                [label_element, hint_element, error_element, supplemental_content].map(&:html),
+                [
+                  label_element,
+                  supplemental_content,
+                  hint_element,
+                  error_element
+                ].map(&:html),
                 @builder.text_area(
                   @attribute_name,
                   id: field_id(link_errors: true),

--- a/lib/govuk_design_system_formbuilder/traits/input.rb
+++ b/lib/govuk_design_system_formbuilder/traits/input.rb
@@ -15,8 +15,8 @@ module GOVUKDesignSystemFormBuilder
           safe_join(
             [
               label_element.html,
-              hint_element.html,
               supplemental_content.html,
+              hint_element.html,
               error_element.html,
               @builder.send(
                 builder_method,


### PR DESCRIPTION
As suggested in #111, standardise the order of labels, legends, supplemental content, hints, errors and form inputs throughout all helpers.