### PR TITLE
Move the hints belonging to radios/checkboxes up

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -24,8 +24,8 @@ module GOVUKDesignSystemFormBuilder
             Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
               safe_join(
                 [
-                  hint_element.html,
                   supplemental_content.html,
+                  hint_element.html,
                   error_element.html,
                   Containers::CheckBoxes.new(@builder, small: @small, classes: @classes).html do
                     build_collection

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -26,8 +26,8 @@ module GOVUKDesignSystemFormBuilder
             Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
               safe_join(
                 [
-                  hint_element.html,
                   supplemental_content.html,
+                  hint_element.html,
                   error_element.html,
                   Containers::Radios.new(@builder, inline: @inline, small: @small, classes: @classes).html do
                     safe_join(build_collection)


### PR DESCRIPTION
Following on from #112, also adjust hints order for radio buttons and checkboxes.