### PR TITLE
Fix bug where translations missing errors shown

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,3 +19,7 @@ Style/TrailingCommaInArrayLiteral:
   Enabled: false
 Naming/MethodParameterName:
   Enabled: false
+Style/PercentLiteralDelimiters:
+  Enabled: false
+Layout/HashAlignment:
+  Enabled: false

--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
     s.add_dependency(*VersionFormatter.new(lib, rails_version, exact_rails_version).to_a)
   end
 
-  s.add_development_dependency("rubocop-govuk", "~> 3")
+  s.add_development_dependency("rubocop-govuk", "~> 3.7")
   s.add_development_dependency("pry", "~> 0.13.0")
   s.add_development_dependency("pry-byebug", "~> 3.9", ">= 3.9.0")
   s.add_development_dependency("rspec-html-matchers", "~> 0")

--- a/guide/lib/helpers/formatters.rb
+++ b/guide/lib/helpers/formatters.rb
@@ -5,10 +5,10 @@ module Helpers
     end
 
     def format_slim(raw, **args)
-      # FIXME investigate pretty slim
-      # FIXME not sure why when we're several
-      #       blocks deep we need to unescape more
-      #       than once
+      # FIXME: investigate pretty slim
+      # FIXME: not sure why when we're several
+      #        blocks deep we need to unescape more
+      #        than once
       beautify(
         CGI.unescapeHTML(
           CGI.unescapeHTML(
@@ -31,7 +31,7 @@ module Helpers
             .gsub("\<\/", "\n\<\/")
             .gsub(/\>\s+\<\/textarea\>/, "></textarea>")
             .strip
-      )
+        )
     end
   end
 end

--- a/lib/govuk_design_system_formbuilder/traits/localisation.rb
+++ b/lib/govuk_design_system_formbuilder/traits/localisation.rb
@@ -6,7 +6,9 @@ module GOVUKDesignSystemFormBuilder
       def localised_text(context)
         key = localisation_key(context)
 
-        return nil unless I18n.exists?(key)
+        # `I18n.exists?(nil)` returns true when `config.i18n.fallbacks` is
+        # enabled, so only proceed if the key is present too
+        return nil unless key.present? && I18n.exists?(key)
 
         I18n.translate(key)
       end

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -9,7 +9,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   let(:field_type) { 'textarea' }
   subject { builder.send(*args) }
 
-
   shared_context 'a text area that is associated with a character count description' do
     context 'association with the text area' do
       context 'when there are no errors on the field' do

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -82,7 +82,6 @@ shared_examples 'a regular input' do |method_identifier, field_type|
         'one-half'       => 'govuk-!-width-one-half',
         'one-third'      => 'govuk-!-width-one-third',
         'one-quarter'    => 'govuk-!-width-one-quarter'
-
       }.each do |identifier, width_class|
         context "when the width is #{identifier}" do
           let(:identifier) { identifier }


### PR DESCRIPTION
When Rails is configured with [`config.i18n.fallbacks = true`](https://guides.rubyonrails.org/v6.0.0/configuring.html#configuring-i18n) the behaviour of `I18n.exists?` [is unclear](https://github.com/ruby-i18n/i18n/issues/365). It returns true when passed `nil` because fallbacks are considered.

This could be fixed by [specifying `fallback: false` as a keyword arg to `I18n.exists?`](https://github.com/ruby-i18n/i18n/pull/482) but if we have no key there's no point in proceeding to the check stage.