### PR TITLE
Pin SimpleCov to 0.17.1 to fix CC integration

### DIFF
--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("pry-byebug", "~> 3.9", ">= 3.9.0")
   s.add_development_dependency("rspec-html-matchers", "~> 0")
   s.add_development_dependency("rspec-rails", "~> 4.0")
-  s.add_development_dependency("simplecov", "~> 0")
+  s.add_development_dependency("simplecov", "~> 0.17.1")
 
   # Required for the guide
   s.add_development_dependency("adsf", "~> 1.4.2")


### PR DESCRIPTION
SimpleCov's output changed with v0.18.0[0] and became incompatible with
CodeClimate. For the time being, pin it to 0.17.1

[0] https://github.com/codeclimate/test-reporter/issues/413