### PR TITLE
Remove unnecessary check for nil widths

### DIFF
--- a/lib/govuk_design_system_formbuilder/traits/input.rb
+++ b/lib/govuk_design_system_formbuilder/traits/input.rb
@@ -51,7 +51,6 @@ module GOVUKDesignSystemFormBuilder
         return if @width.blank?
 
         case @width
-        when nil then nil
 
           # fixed (character) widths
         when 20 then 'govuk-input--width-20'


### PR DESCRIPTION
This occurs immediately after ensuring the width isn't blank, it's harmless but totally unneeded.