### PR TITLE
Add custom classes to the submit element

### DIFF
--- a/guide/content/form-elements/submit.slim
+++ b/guide/content/form-elements/submit.slim
@@ -28,6 +28,10 @@ section
     code: warning_button)
 
   == render('/partials/example-fig.*',
+    caption: "Generating a submit button with custom class",
+    code: custom_classes_button)
+
+  == render('/partials/example-fig.*',
     caption: "Generating a submit button without double click prevention",
     code: submit_button_without_double_click_prevention)
 

--- a/guide/lib/examples/submit.rb
+++ b/guide/lib/examples/submit.rb
@@ -12,6 +12,10 @@ module Examples
       "= f.govuk_submit 'Delete all records', warning: true"
     end
 
+    def custom_classes_button
+      "= f.govuk_submit 'Special button', classes: 'special-button-class'"
+    end
+
     def submit_button_without_double_click_prevention
       "= f.govuk_submit prevent_double_click: false"
     end

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -567,6 +567,7 @@ module GOVUKDesignSystemFormBuilder
     # @param secondary [Boolean] makes the button grey ({https://design-system.service.gov.uk/components/button/#secondary-buttons secondary}) when true
     # @todo The GOV.UK design system also supports {https://design-system.service.gov.uk/components/button/#disabled-buttons disabled buttons}, they
     #   should probably be supported too
+    # @param classes [String] Classes to add to the submit button
     # @param prevent_double_click [Boolean] adds JavaScript to safeguard the
     #   form from being submitted more than once
     # @param validate [Boolean] adds the formnovalidate to the submit button when true, this disables all
@@ -586,8 +587,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_submit "Proceed", prevent_double_click: true do
     #     = link_to 'Cancel', some_other_path, class: 'govuk-button__secondary'
     #
-    def govuk_submit(text = config.default_submit_button_text, warning: false, secondary: false, prevent_double_click: true, validate: false, &block)
-      Elements::Submit.new(self, text, warning: warning, secondary: secondary, prevent_double_click: prevent_double_click, validate: validate, &block).html
+    def govuk_submit(text = config.default_submit_button_text, warning: false, secondary: false, classes: nil, prevent_double_click: true, validate: false, &block)
+      Elements::Submit.new(self, text, warning: warning, secondary: secondary, classes: classes, prevent_double_click: prevent_double_click, validate: validate, &block).html
     end
 
     # Generates three inputs for the +day+, +month+ and +year+ components of a date

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -1,7 +1,7 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     class Submit < Base
-      def initialize(builder, text, warning:, secondary:, prevent_double_click:, validate:, &block)
+      def initialize(builder, text, warning:, secondary:, classes:, prevent_double_click:, validate:, &block)
         fail ArgumentError, 'buttons can be warning or secondary' if warning && secondary
 
         @builder              = builder
@@ -9,6 +9,7 @@ module GOVUKDesignSystemFormBuilder
         @prevent_double_click = prevent_double_click
         @warning              = warning
         @secondary            = secondary
+        @classes              = classes
         @validate             = validate
         @block_content        = capture { block.call } if block_given?
       end
@@ -21,6 +22,7 @@ module GOVUKDesignSystemFormBuilder
               class: %w(govuk-button).push(
                 warning_class,
                 secondary_class,
+                @classes,
                 padding_class(@block_content.present?)
               ).compact,
               **extra_args

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -55,6 +55,14 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           expect { subject }.to raise_error(ArgumentError, /buttons can be warning or secondary/)
         end
       end
+
+      context 'classes' do
+        subject { builder.send(*args.push('Create'), classes: 'custom-class--one custom-class--two') }
+
+        specify 'button should have the custom class' do
+          expect(subject).to have_tag('input', with: { class: %w(govuk-button custom-class--one custom-class--two) })
+        end
+      end
     end
 
     describe 'preventing double clicks' do


### PR DESCRIPTION
## In this PR
- Allow a custom class to be passed as a string to the submit element (e.g `= f.govuk_submit 'Create', custom_class: 'custom-govuk-class'`
- Append the custom class to the built element
- Add a basic spec to check the custom class is added
- Add a section to the guide
