### PR TITLE
Add support for nanoc live to ease guide writing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ source "https://rubygems.org"
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gemspec
+
+group 'nanoc' do
+  gem 'nanoc-live'
+end

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,7 @@ build:
 build-guide: npm-install
 	${guide_dir} ${prefix} nanoc
 watch-guide: npm-install
-	${guide_dir} ${prefix} nanoc view --live-reload --port 3006 --color
-keep-building-guide:
-	${guide_dir} fd -e rb -eslim -esass -ejs -p guide | entr nanoc
+	${guide_dir} ${prefix} nanoc live
 docs-server:
 	yard server --reload
 code-climate:

--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -38,8 +38,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency("simplecov", "~> 0.17.1")
 
   # Required for the guide
-  s.add_development_dependency("adsf", "~> 1.4.2")
-  s.add_development_dependency("adsf-live", "~> 1.4.2")
   s.add_development_dependency("htmlbeautifier", "~> 1.3.1")
   s.add_development_dependency("nanoc", "~> 4.11")
   s.add_development_dependency("rouge", "~> 3.18.0")

--- a/guide/lib/suppress_listen_symlink_errors.rb
+++ b/guide/lib/suppress_listen_symlink_errors.rb
@@ -1,0 +1,20 @@
+require 'listen/record/symlink_detector'
+
+# Taken from https://github.com/guard/listen/wiki/Duplicate-directory-errors
+#
+# Because we need to use a symlink to allow our Ruby Sass-c compilation to
+# use sources from node_modules, Listen throws warnings and errors that
+# the node_modules directory's already being watched.
+#
+# As this is a prototype and the warnings add noise to the logs, let's
+# just ignore them altogether
+
+module Listen
+  class Record
+    class SymlinkDetector
+      def _fail(_, _)
+        fail Error, "Don't watch locally-symlinked directory twice"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Nanoc has supported 'live editing' for a while but it hadn't been added
to the guide because I couldn't work out how to specify groups in the
gemspec (it needs to be in the `nanoc` group).

It turns out that adding it to the Gemfile works fine. The guide can now
be run using the make command `make watch-guide` or changing to the
`guide` directory and running `bundle exec nanoc live`.

This is a cleaner solution than the previous one of running two make
commands; one to serve the app and the other to rebuild on file changes.