### PR TITLE
Fix block handling bug on #govuk_fieldset

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -660,7 +660,7 @@ module GOVUKDesignSystemFormBuilder
     # @see https://design-system.service.gov.uk/components/fieldset/ GOV.UK fieldset
     # @return [ActiveSupport::SafeBuffer] HTML output
     def govuk_fieldset(legend: { text: 'Fieldset heading' }, described_by: nil, &block)
-      Containers::Fieldset.new(self, legend: legend, described_by: described_by).html(&block)
+      Containers::Fieldset.new(self, legend: legend, described_by: described_by, &block).html
     end
 
     # Generates an input of type +file+

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -5,8 +5,8 @@ module GOVUKDesignSystemFormBuilder
 
       LEGEND_SIZES = %w(xl l m s).freeze
 
-      def initialize(builder, object_name = nil, attribute_name = nil, legend: {}, described_by: nil)
-        super(builder, object_name, attribute_name)
+      def initialize(builder, object_name = nil, attribute_name = nil, legend: {}, described_by: nil, &block)
+        super(builder, object_name, attribute_name, &block)
 
         @legend         = legend_defaults.merge(legend)
         @described_by   = described_by(described_by)
@@ -15,7 +15,7 @@ module GOVUKDesignSystemFormBuilder
 
       def html
         content_tag('fieldset', class: fieldset_classes, aria: { describedby: @described_by }) do
-          safe_join([build_legend, yield])
+          safe_join([build_legend, (@block_content || yield)])
         end
       end
 


### PR DESCRIPTION
The legend wasn't being displayed by `Containers::Fieldset` when called directly (rather than via another helper), this was due to some weirdness calling `yield` inside `safe_join` in the context of Rails templates.

It's only apparent in `#govuk_fieldset` because it's the only Container class to have its own helper method. `Container` classes work differently to `Element` ones in that they take their block via the HTML method rather than initialize.

There is already more-robust block handling built into the base class for elements, now the `Fieldset` can be called with either a block passed into the initializer or with one passed into `#html`.