### PR TITLE
Improve link errors documentation for fieldsets

### DIFF
--- a/guide/content/css/govuk-design-system-formbuilder-guide.sass
+++ b/guide/content/css/govuk-design-system-formbuilder-guide.sass
@@ -151,3 +151,10 @@ p, li, dt, dd, td, th
 .govuk-tag
   &.govuk-tag-red
     background-color: $red
+
+.important
+  background-color: govuk-tint(govuk_colour('yellow'), 80%)
+  padding: 1.5em 1em
+
+  code
+    background-color: govuk-tint(govuk_colour('yellow'), 40%)

--- a/guide/content/form-elements/checkboxes.slim
+++ b/guide/content/form-elements/checkboxes.slim
@@ -30,6 +30,8 @@ section
     caption: "Generating checkboxes with a conditionally-revealed text field",
     code: checkbox_field_with_custom_options) do
 
+    == render('/partials/fieldset-warning.*', input_type: 'check box')
+
     p.govuk-body
       | When more advanced functionality like conditional fields is required,
         the <code>govuk_check_boxes_fieldset</code> helper is recommended. Any

--- a/guide/content/form-elements/radios.slim
+++ b/guide/content/form-elements/radios.slim
@@ -75,8 +75,10 @@ section
         them inline.
 
   == render('/partials/example-fig.*',
-    caption: "Radio buttons collection with conditional content and a divider",
+    caption: "Radio buttons fieldset with conditional content and a divider",
     code: radio_field_with_conditional_content) do
+
+    == render('/partials/fieldset-warning.*', input_type: 'radio button')
 
     h4.govuk-heading-s Adding conditional content
 

--- a/guide/content/form-elements/radios.slim
+++ b/guide/content/form-elements/radios.slim
@@ -84,7 +84,7 @@ section
       |
         If your list of options is hard-coded or you want to add extra
         customisation, like inserting a text divider, the
-        <code>#govuk_radio_button_fieldset</code> helper offers additional
+        <code>#govuk_radio_buttons_fieldset</code> helper offers additional
         flexibility.
 
     p.govuk-body

--- a/guide/layouts/partials/fieldset-warning.slim
+++ b/guide/layouts/partials/fieldset-warning.slim
@@ -1,0 +1,4 @@
+p.govuk-body.important
+  | The form builder does not keep track of its contents so to ensure
+    the error summary correctly links to the first #{input_type}
+    <code>link_errors</code> must be set to <code>true</code>

--- a/guide/lib/examples/checkboxes.rb
+++ b/guide/lib/examples/checkboxes.rb
@@ -40,6 +40,7 @@ module Examples
           = f.govuk_check_box :languages,
             :english,
             label: { text: "English" },
+            link_errors: true,
             hint_text: "Only select English if you have a GCSE at grade C or above"
 
           = f.govuk_check_box :languages,

--- a/guide/lib/examples/radios.rb
+++ b/guide/lib/examples/radios.rb
@@ -48,7 +48,7 @@ module Examples
     def radio_field_with_conditional_content
       <<~SNIPPET
         = f.govuk_radio_buttons_fieldset(:old_department_id, legend: { size: 'm', text: 'Which department do you work in?' }) do
-          = f.govuk_radio_button :old_department_id, 'it', label: { text: 'Information Technology' }
+          = f.govuk_radio_button :old_department_id, 'it', label: { text: 'Information Technology' }, link_errors: true
           = f.govuk_radio_button :old_department_id, 'marketing', label: { text: 'Marketing' }
           = f.govuk_radio_divider
           = f.govuk_radio_button :old_department_id, 'other', label: { text: 'Other' } do

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -367,6 +367,9 @@ module GOVUKDesignSystemFormBuilder
     #
     # @note The intention is to use {#govuk_radio_button} and {#govuk_radio_divider} within the passed-in block
     #
+    # @note To ensure the {#govuk_error_summary} link functions correctly ensure the first {#govuk_radio_button}
+    #   is set to +link_errors: true+
+    #
     # @param attribute_name [Symbol] The name of the attribute
     # @param hint_text [String] The content of the fieldset hint. No hint will be injected if left +nil+
     # @param legend [Hash] options for configuring the legend
@@ -384,7 +387,7 @@ module GOVUKDesignSystemFormBuilder
     # @example A collection of radio buttons for favourite colours with a divider
     #
     #  = f.govuk_collection_radio_buttons :favourite_colour, inline: false do
-    #    = f.govuk_radio_button :favourite_colour, :red, label: { text: 'Red' }
+    #    = f.govuk_radio_button :favourite_colour, :red, label: { text: 'Red' }, link_errors: true
     #    = f.govuk_radio_button :favourite_colour, :green, label: { text: 'Green' }
     #    = f.govuk_radio_divider
     #    = f.govuk_radio_button :favourite_colour, :yellow, label: { text: 'Yellow' }
@@ -405,7 +408,7 @@ module GOVUKDesignSystemFormBuilder
     # @see https://design-system.service.gov.uk/components/radios/ GOV.UK Radios
     # @param block [Block] Any supplied HTML will be wrapped in a conditional
     #   container and only revealed when the radio button is picked
-    # @param link_errors [Boolean] controls whether this radio button should be linked to
+    # @param link_errors [Boolean] controls whether this radio button should be linked to from {#govuk_error_summary}
     #   from the error summary. <b>Should only be set to +true+ for the first radio button in a fieldset</b>
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
@@ -493,6 +496,9 @@ module GOVUKDesignSystemFormBuilder
 
     # Generate a fieldset intended to conatain one or more {#govuk_check_box}
     #
+    # @note To ensure the {#govuk_error_summary} link functions correctly ensure the first {#govuk_check_box}
+    #   is set to +link_errors: true+
+    #
     # @param attribute_name [Symbol] The name of the attribute
     # @param hint_text [String] The content of the fieldset hint. No hint will be injected if left +nil+
     # @param small [Boolean] controls whether small check boxes are used instead of regular-sized ones
@@ -529,7 +535,7 @@ module GOVUKDesignSystemFormBuilder
     # @param attribute_name [Symbol] The name of the attribute
     # @param value [Boolean,String,Symbol,Integer] The value of the checkbox when it is checked
     # @param hint_text [String] the contents of the hint
-    # @param link_errors [Boolean] controls whether this radio button should be linked to
+    # @param link_errors [Boolean] controls whether this radio button should be linked to from {#govuk_error_summary}
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings


### PR DESCRIPTION
The docs and guide really didn't make it obvious that `link_errors` is required on the first radio button or check box in a fieldset in order to make the link in the error summary function correctly.

This PR adds a `@note` to the `#govuk_radio_buttons_fieldset` and `#govuk_check_boxes_fieldset` methods and adds a yellow warning box to the relevant sections of the guide. The guide examples now contain the correct markup too.

![Screenshot from 2020-05-22 21-03-17](https://user-images.githubusercontent.com/128088/82705612-da89fa80-9c6f-11ea-8f13-6639f8240b49.png)

This has been a problem for a while (see #84) and I'm not sure there's a technical fix; it's beyond the builder's remit to keep track of what's been added and to try to guess where to add the link target.
