### PR TITLE
Switch nanoc port to 3006 to avoid clashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 prefix=bundle exec
 guide_dir=cd guide;
+nanoc_default_port=3006
 nanoc_internal_checks=internal_links stale mixed_content
 nanoc_external_checks=external_links
 
@@ -23,7 +24,7 @@ build:
 build-guide: npm-install
 	${guide_dir} ${prefix} nanoc
 watch-guide: npm-install
-	${guide_dir} ${prefix} nanoc live
+	${guide_dir} ${prefix} nanoc live --port ${nanoc_default_port}
 docs-server:
 	yard server --reload
 code-climate:


### PR DESCRIPTION
`3006` was the default until #129 removed it and it reverted to `3000`.