### PR TITLE
Add caption support

### DIFF
--- a/guide/content/building-blocks/localisation.slim
+++ b/guide/content/building-blocks/localisation.slim
@@ -31,7 +31,7 @@ p.govuk-body
 section
 
   == render('/partials/example-fig.*',
-    caption: "Populating label and hint text from the localisation data",
+    caption: "Populating label, caption and hint text from the localisation data",
     localisation: favourite_kind_of_hat_locale,
     code: favourite_kind_of_hat) do
 
@@ -79,18 +79,24 @@ p.govuk-body
     h4.govuk-heading-s Contexts
 
     p.govuk-body
-      | There are three contexts supported by the form builder: <em>label</em>,
-        <em>legend</em> and <em>hint</em>. Custom locale schemas are
-        configured using an array of symbols that match your locale structure.
+      | There are four contexts supported by the form builder: <em>label</em>,
+        <em>legend</em>, <em>caption</em> and <em>hint</em>. Custom locale
+        schemas are configured using an array of symbols that match your locale
+        structure.
 
     p.govuk-body
       | The special value <code>__context__</code> is used to represent the
         current translation context. It will automatically be replaced with
-        either <em>label</em>, <em>legend</em> or <em>hint</em> when the
-        translation key is generated.
+        either <em>label</em>, <em>legend</em>, <em>caption</em> or <em>hint</em>
+        when the translation key is generated.
 
     p.govuk-body
       | When retrieving a localised string the builder first checks whether
         a contextual schema has been set for the context. If there hasn't,
         the <code>localisation_schema_fallback</code> key will be used. <strong>It is
-        the only one set by default</strong>.
+        the only schema set by default</strong>.
+
+    p.govuk-body.important
+      | Captions are rendered inside the corresponding <code>label</code> or
+        <code>legend</code> tag. If the label or legend is hidden or not rendered,
+        the caption won't be either.

--- a/guide/content/building-blocks/localisation.slim
+++ b/guide/content/building-blocks/localisation.slim
@@ -41,7 +41,7 @@ section
         can be supplied and work in the normal manner.
 
 p.govuk-body
-  | Radio and check box labels use a special key in the locale dictionary composed by the
+  | Radio and check box labels use a special key in the locale dictionary composed from the
     attribute name and the suffix <code>_options</code>. This makes it possible to localise
     the fieldset legend and each of the individual choices separately.
 

--- a/guide/content/css/govuk-design-system-formbuilder-guide.sass
+++ b/guide/content/css/govuk-design-system-formbuilder-guide.sass
@@ -171,3 +171,12 @@ p, li, dt, dd, td, th
 
   code
     background-color: govuk-tint(govuk_colour('yellow'), 40%)
+
+.ugly-gradient
+  display: inline-block
+  padding: 0 0.2rem
+  background: linear-gradient(90deg, rgba(184,255,255,1) 0%, rgba(255,152,255,1) 50%, rgba(255,255,108,1) 100%)
+
+.orange-underline
+  text-decoration: underline orange solid 2px
+  text-underline-offset: 4px

--- a/guide/content/introduction/configuration.slim
+++ b/guide/content/introduction/configuration.slim
@@ -30,6 +30,7 @@ p.govuk-body
           conf.localisation_schema_label    = nil
           conf.localisation_schema_hint     = %i(myapp descriptions __context__)
           conf.localisation_schema_legend   = %i(myapp descriptions __context__)
+          conf.localisation_schema_caption  = %i(myapp descriptions __context__)
         end
 
 p.govuk-body

--- a/guide/content/introduction/labels-captions-hints-and-legends.slim
+++ b/guide/content/introduction/labels-captions-hints-and-legends.slim
@@ -1,5 +1,5 @@
 ---
-title: Labels, hints and legends
+title: Labels, captions, hints and legends
 ---
 
 h1.govuk-heading-xl Labels, hints and legends
@@ -81,6 +81,42 @@ section
 
       p.govuk-body.important
         | This example contains raw html but Rails' built-in tag helpers are fully-supported.
+
+section
+
+  h2.govuk-heading-l Captions
+
+  p.govuk-body
+    | Sometimes you may need to make it clear that a heading is part of a
+      larger section or group. To do this, you can use a heading with a caption.
+
+  p.govuk-body
+    | Captions are supported by all helpers that have labels or legends and can
+      be configured with the following options:
+
+  dl.govuk-summary-list
+    .govuk-summary-list__row
+      dt.govuk-summary-list__key
+        code text
+
+      dd.govuk-summary-list__value
+        | The caption text
+
+    .govuk-summary-list__row
+      dt.govuk-summary-list__key
+        code size
+
+      dd.govuk-summary-list__value
+        | The caption size, either <code>xl</code>, <code>l</code> or <code>m</code>
+
+  p.govuk-body.important
+    | If you want to place the caption <em>outside</em> of the label's tag you can
+      do this by #{link_to('setting the label content with a proc', '#setting-label-content-with-a-proc').html_safe}.
+
+  == render('/partials/example-fig.*',
+    caption: "A label with a caption",
+    code: text_field_with_caption,
+    hide_html_output: false)
 
 section
 

--- a/guide/content/introduction/labels-hints-and-legends.slim
+++ b/guide/content/introduction/labels-hints-and-legends.slim
@@ -63,11 +63,24 @@ section
           value defaults to <code>false</code> and can be overridden with
           <code>true</code>
 
-
   == render('/partials/example-fig.*',
     caption: "A fully-configured label",
     code: text_field_with_configured_label,
     hide_html_output: false)
+
+  == render('/partials/example-fig.*',
+    caption: "Setting label content with a proc",
+    code: text_field_with_label_proc,
+    hide_html_output: false) do
+      p.govuk-body
+        | Label content can be customised further using a
+          #{link_to('Ruby proc', ruby_proc_link).html_safe}. Note that the content
+          of the proc is rendered <em>inside the label</em> so the form builder
+          can enforce consistency between the label's <code>for</code> attribute
+          and the associated form element.
+
+      p.govuk-body.important
+        | This example contains raw html but Rails' built-in tag helpers are fully-supported.
 
 section
 
@@ -143,3 +156,15 @@ section
     caption: "Radio buttons with a fully-customised legend",
     code: radios_with_legend,
     hide_html_output: true)
+
+  == render('/partials/example-fig.*',
+    caption: "Fully customising legends with procs",
+    code: radios_with_legend_proc,
+    hide_html_output: true) do
+
+    p.govuk-body
+      | To take even more control of legends the content can be passed in using
+        a #{link_to('Ruby proc', ruby_proc_link).html_safe}.
+
+    p.govuk-body.important
+      | This example contains raw html but Rails' built-in tag helpers are fully-supported.

--- a/guide/layouts/partials/landing-page/links.slim
+++ b/guide/layouts/partials/landing-page/links.slim
@@ -9,7 +9,7 @@ section#links.govuk-width-container
         li== link_to 'Getting started', '/introduction/getting-started'
         li== link_to 'Configuration', '/introduction/configuration'
         li== link_to 'Supported versions', '/introduction/supported-versions'
-        li== link_to 'Labels, hints and legends', '/introduction/labels-hints-and-legends'
+        li== link_to 'Labels, captions, hints and legends', '/introduction/labels-captions-hints-and-legends'
         li== link_to 'Error handling', '/introduction/error-handling'
 
       h2.govuk-heading-m Building blocks

--- a/guide/lib/examples/labels_captions_hints_and_legends.rb
+++ b/guide/lib/examples/labels_captions_hints_and_legends.rb
@@ -1,5 +1,5 @@
 module Examples
-  module LabelsHintsAndLegends
+  module LabelsCaptionsHintsAndLegends
     def text_field_with_no_label
       "= f.govuk_text_field :favourite_colour"
     end
@@ -15,6 +15,14 @@ module Examples
       <<~SNIPPET
         = f.govuk_text_field :favourite_shade_of_orange,
           label: -> { %(<h2 class="govuk-header-m orange-underline">What's your favourite shade of orange?</h2>) }
+      SNIPPET
+    end
+
+    def text_field_with_caption
+      <<~SNIPPET
+        = f.govuk_text_field :favourite_shade_of_grey,
+          label: { text: 'Favourite shade of grey', tag: 'h2', size: 'l' },
+          caption: { text: 'Aesthetic preferences', size: 'm' }
       SNIPPET
     end
 

--- a/guide/lib/examples/labels_hints_and_legends.rb
+++ b/guide/lib/examples/labels_hints_and_legends.rb
@@ -11,6 +11,13 @@ module Examples
       SNIPPET
     end
 
+    def text_field_with_label_proc
+      <<~SNIPPET
+        = f.govuk_text_field :favourite_shade_of_orange,
+          label: -> { %(<h2 class="govuk-header-m orange-underline">What's your favourite shade of orange?</h2>) }
+      SNIPPET
+    end
+
     def text_field_with_hint
       <<~SNIPPET
         = f.govuk_text_field :favourite_shade_of_blue,
@@ -21,11 +28,21 @@ module Examples
 
     def radios_with_legend
       <<~SNIPPET
-        = f.govuk_collection_radio_buttons :new_department_id,
+        = f.govuk_collection_radio_buttons :favourite_colour,
           primary_colours,
           :id,
           :name,
           legend: { text: "What's your favourite primary colour?", size: 'l', tag: 'h4' }
+      SNIPPET
+    end
+
+    def radios_with_legend_proc
+      <<~SNIPPET
+        = f.govuk_collection_radio_buttons :least_favourite_colour,
+          primary_colours,
+          :id,
+          :name,
+          legend: -> { %(<h3 class="govuk-heading-l">Which <span class="ugly-gradient">colour</span> do you hate most?</h3>) }
       SNIPPET
     end
   end

--- a/guide/lib/examples/localisation.rb
+++ b/guide/lib/examples/localisation.rb
@@ -6,6 +6,9 @@ module Examples
           label:
             person:
               favourite_kind_of_hat: Which style of hat do you prefer?
+          caption:
+            person:
+              favourite_kind_of_hat: Fashion choices
           hint:
             person:
               favourite_kind_of_hat: |-
@@ -16,7 +19,7 @@ module Examples
 
     def favourite_kind_of_hat
       <<~SNIPPET
-        = f.govuk_text_field :favourite_kind_of_hat, label: { size: 'm' }
+        = f.govuk_text_field :favourite_kind_of_hat, label: { size: 'l' }
       SNIPPET
     end
 

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -23,7 +23,7 @@ use_helper Examples::Radios
 use_helper Examples::Checkboxes
 use_helper Examples::SubmitButton
 use_helper Examples::Date
-use_helper Examples::LabelsHintsAndLegends
+use_helper Examples::LabelsCaptionsHintsAndLegends
 use_helper Examples::File
 use_helper Examples::ErrorHandling
 use_helper Examples::InjectingContent

--- a/guide/lib/helpers/person.rb
+++ b/guide/lib/helpers/person.rb
@@ -67,8 +67,10 @@ class Person
   attr_accessor(
     :favourite_colour,
     :favourite_shade_of_red,
+    :favourite_shade_of_orange,
     :favourite_shade_of_blue,
-    :favourite_primary_colour
+    :favourite_primary_colour,
+    :least_favourite_colour
   )
 
   # errors

--- a/guide/lib/helpers/person.rb
+++ b/guide/lib/helpers/person.rb
@@ -63,12 +63,13 @@ class Person
     :graduation_month
   )
 
-  # labels, hints and legends
+  # labels, captions, hints and legends
   attr_accessor(
     :favourite_colour,
     :favourite_shade_of_red,
     :favourite_shade_of_orange,
     :favourite_shade_of_blue,
+    :favourite_shade_of_grey,
     :favourite_primary_colour,
     :least_favourite_colour
   )

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -52,7 +52,8 @@ module GOVUKDesignSystemFormBuilder
     localisation_schema_fallback: %i(helpers __context__),
     localisation_schema_label: nil,
     localisation_schema_hint: nil,
-    localisation_schema_legend: nil
+    localisation_schema_legend: nil,
+    localisation_schema_caption: nil
   }.freeze
 
   DEFAULTS.each_key { |k| config_accessor(k) { DEFAULTS[k] } }

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -634,12 +634,6 @@ module GOVUKDesignSystemFormBuilder
     #
     # @param title [String] the error summary heading
     #
-    # @todo Currently the summary anchors link to the inline error messages themselves rather to
-    #   the accompanying input. More work is required to improve this and it needs to be
-    #   handled in a less-generic manner. For example, we can't link to a specific radio button
-    #   if one hasn't been chosen but we should link to a {#govuk_text_field} if one has been left
-    #   blank
-    #
     # @example An error summary with a custom title
     #   = f.govuk_error_summary 'Uh-oh, spaghettios'
     #

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -8,7 +8,7 @@ module GOVUKDesignSystemFormBuilder
     # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
-    # @param [Hash] label configures the associated label
+    # @param label [Hash,Proc] configures or sets the associated label content
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
@@ -32,6 +32,10 @@ module GOVUKDesignSystemFormBuilder
     #     p.govuk-inset-text
     #       | Ensure your stage name is unique
     #
+    # @example A text field with the label supplied as a proc
+    #   = f.govuk_text_field :callsign,
+    #     label: -> { tag.h3('Call-sign') }
+    #
     def govuk_text_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
       Elements::Inputs::Text.new(self, object_name, attribute_name, hint_text: hint_text, label: label, width: width, **args, &block).html
     end
@@ -42,7 +46,7 @@ module GOVUKDesignSystemFormBuilder
     # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
-    # @param [Hash] label configures the associated label
+    # @param label [Hash,Proc] configures or sets the associated label content
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
@@ -67,6 +71,10 @@ module GOVUKDesignSystemFormBuilder
     #     p.govuk-inset-text
     #       | Yes, fax machines are still a thing
     #
+    # @example A phone field with the label supplied as a proc
+    #   = f.govuk_phone_field :work_number,
+    #     label: -> { tag.h3('Work number') }
+    #
     def govuk_phone_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
       Elements::Inputs::Phone.new(self, object_name, attribute_name, hint_text: hint_text, label: label, width: width, **args, &block).html
     end
@@ -77,7 +85,7 @@ module GOVUKDesignSystemFormBuilder
     # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
-    # @param [Hash] label configures the associated label
+    # @param label [Hash,Proc] configures or sets the associated label content
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
@@ -93,12 +101,16 @@ module GOVUKDesignSystemFormBuilder
     #     label: { text: 'Enter your email address' },
     #     placeholder: 'ralph.wiggum@springfield.edu'
     #
-    # @example A email field with injected content
-    #   = f.govuk_phone_field :email_address,
-    #     label: { text: 'Email address' } do
+    # @example An email field with injected content
+    #   = f.govuk_phone_field :work_email,
+    #     label: { text: 'Work email address' } do
     #
     #     p.govuk-inset-text
     #       | Use your work address
+    #
+    # @example A email field with the label supplied as a proc
+    #   = f.govuk_email_field :personal_email,
+    #     label: -> { tag.h3('Personal email address') }
     #
     def govuk_email_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
       Elements::Inputs::Email.new(self, object_name, attribute_name, hint_text: hint_text, label: label, width: width, **args, &block).html
@@ -110,7 +122,7 @@ module GOVUKDesignSystemFormBuilder
     # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
-    # @param [Hash] label configures the associated label
+    # @param label [Hash,Proc] configures or sets the associated label content
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
@@ -132,6 +144,10 @@ module GOVUKDesignSystemFormBuilder
     #     p.govuk-inset-text
     #       | Ensure your password is at least 16 characters long
     #
+    # @example A password field with the label supplied as a proc
+    #   = f.govuk_password_field :passcode,
+    #     label: -> { tag.h3('What is your secret pass code?') }
+    #
     def govuk_password_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
       Elements::Inputs::Password.new(self, object_name, attribute_name, hint_text: hint_text, label: label, width: width, **args, &block).html
     end
@@ -142,7 +158,7 @@ module GOVUKDesignSystemFormBuilder
     # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
-    # @param [Hash] label configures the associated label
+    # @param label [Hash,Proc] configures or sets the associated label content
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
@@ -165,6 +181,10 @@ module GOVUKDesignSystemFormBuilder
     #       p.govuk-inset-text
     #         | This will be visible on your profile
     #
+    # @example A url field with the label supplied as a proc
+    #   = f.govuk_url_field :work_website,
+    #     label: -> { tag.h3("Enter your company's website") }
+    #
     def govuk_url_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
       Elements::Inputs::URL.new(self, object_name, attribute_name, hint_text: hint_text, label: label, width: width, **args, &block).html
     end
@@ -175,7 +195,7 @@ module GOVUKDesignSystemFormBuilder
     # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
-    # @param [Hash] label configures the associated label
+    # @param label [Hash,Proc] configures or sets the associated label content
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
@@ -201,6 +221,10 @@ module GOVUKDesignSystemFormBuilder
     #         | If you haven't measured your height in the last 6 months
     #           do it now
     #
+    # @example A number field with the label supplied as a proc
+    #   = f.govuk_url_field :personal_best_over_100m,
+    #     label: -> { tag.h3("How many seconds does it take you to run 100m?") }
+    #
     def govuk_number_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
       Elements::Inputs::Number.new(self, object_name, attribute_name, hint_text: hint_text, label: label, width: width, **args, &block).html
     end
@@ -211,7 +235,7 @@ module GOVUKDesignSystemFormBuilder
     #
     # @param attribute_name [Symbol] The name of the attribute
     # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
-    # @param [Hash] label configures the associated label
+    # @param label [Hash,Proc] configures or sets the associated label content
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
@@ -228,17 +252,21 @@ module GOVUKDesignSystemFormBuilder
     #   or characters
     #
     # @example A text area with a custom number of rows and a word limit
-    #   = f.govuk_number_field :cv,
+    #   = f.govuk_text_area :cv,
     #     label: { text: 'Tell us about your work history' },
     #     rows: 8,
     #     max_words: 300
     #
     # @example A text area with injected content
-    #   = f.govuk_number_field :description,
+    #   = f.govuk_text_area :description,
     #     label: { text: 'Where did the incident take place?' } do
     #
     #     p.govuk-inset-text
     #       | If you don't know exactly leave this section blank
+    #
+    # @example A text area with the label supplied as a proc
+    #   = f.govuk_text_area :instructions,
+    #     label: -> { tag.h3("How do you set it up?") }
     #
     def govuk_text_area(attribute_name, hint_text: nil, label: {}, max_words: nil, max_chars: nil, rows: 5, threshold: nil, **args, &block)
       Elements::TextArea.new(self, object_name, attribute_name, hint_text: hint_text, label: label, max_words: max_words, max_chars: max_chars, rows: rows, threshold: threshold, **args, &block).html
@@ -259,20 +287,22 @@ module GOVUKDesignSystemFormBuilder
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
     # @example A select box with hint
-    #   = f.govuk_number_field :grade,
+    #   = f.govuk_collection_select :grade,
     #     @grades,
     #     :id,
     #     :name,
     #     hint_text: "If you took the test more than once enter your highest grade"
     #
     # @example A select box with injected content
-    #   = f.govuk_number_field :favourite_colour,
-    #     @colours,
-    #     :id,
-    #     :name do
+    #   = f.govuk_collection_select(:favourite_colour, @colours, :id, :name) do
     #
     #       p.govuk-inset-text
     #         | Select the closest match
+    #
+    # @example A select box with the label supplied as a proc
+    #   = f.govuk_collection_select(:team, @teams, :id, :name) do
+    #     label: -> { tag.h3("Which team did you represent?") }
+    #
     def govuk_collection_select(attribute_name, collection, value_method, text_method, options: {}, html_options: {}, hint_text: nil, label: {}, &block)
       Elements::Select.new(
         self,
@@ -309,7 +339,7 @@ module GOVUKDesignSystemFormBuilder
     #   When a +Proc+ is provided it must take a single argument that is a single member of the collection.
     #   When a +nil+ value is provided the hint text will be retrieved from the locale. This is the default and param can be omitted.
     # @param hint_text [String] The content of the fieldset hint. No hint will be injected if left +nil+
-    # @param legend [Hash] options for configuring the legend
+    # @param legend [Hash,Proc] options for configuring the legend
     # @param inline [Boolean] controls whether the radio buttons are displayed inline or not
     # @param small [Boolean] controls whether small radio buttons are used instead of regular-sized ones
     # @param bold_labels [Boolean] controls whether the radio button labels are bold
@@ -337,13 +367,21 @@ module GOVUKDesignSystemFormBuilder
     #    inline: false
     #
     # @example A collection of radio buttons for grades with injected content
-    #  = f.govuk_collection_radio_buttons :favourite_colour,
+    #  = f.govuk_collection_radio_buttons :grade,
     #    @grades,
     #    :id,
     #    :name do
     #
     #      p.govuk-inset-text
     #        | If you took the test more than once enter your highest grade
+    #
+    # @example A collection of radio buttons with the legend supplied as a proc
+    #  = f.govuk_collection_radio_buttons :category,
+    #    @categories,
+    #    :id,
+    #    :name,
+    #    legend: -> { tag.h3('Which category do you belong to?') }
+    #
     def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, inline: false, small: false, bold_labels: false, classes: nil, &block)
       Elements::Radios::Collection.new(
         self,
@@ -372,7 +410,7 @@ module GOVUKDesignSystemFormBuilder
     #
     # @param attribute_name [Symbol] The name of the attribute
     # @param hint_text [String] The content of the fieldset hint. No hint will be injected if left +nil+
-    # @param legend [Hash] options for configuring the legend
+    # @param legend [Hash,Proc] options for configuring the legend
     # @param inline [Boolean] controls whether the radio buttons are displayed inline or not
     # @param small [Boolean] controls whether small radio buttons are used instead of regular-sized ones
     # @option legend text [String] the fieldset legend's text content
@@ -384,13 +422,22 @@ module GOVUKDesignSystemFormBuilder
     # @see https://design-system.service.gov.uk/components/radios/ GOV.UK Radios
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
-    # @example A collection of radio buttons for favourite colours with a divider
+    # @example A radio button fieldset for favourite colours with a divider
     #
-    #  = f.govuk_collection_radio_buttons :favourite_colour, inline: false do
+    #  = f.govuk_radio_buttons_fieldset :favourite_colour, inline: false do
     #    = f.govuk_radio_button :favourite_colour, :red, label: { text: 'Red' }, link_errors: true
     #    = f.govuk_radio_button :favourite_colour, :green, label: { text: 'Green' }
     #    = f.govuk_radio_divider
     #    = f.govuk_radio_button :favourite_colour, :yellow, label: { text: 'Yellow' }
+    #
+    # @example A radio button fieldset with the legend supplied as a proc
+    #  = f.govuk_radio_buttons_fieldset :burger_id do
+    #    @burgers,
+    #    :id,
+    #    :name,
+    #    legend: -> { tag.h3('Which hamburger do you want with your meal?') } do
+    #      = f.govuk_radio_button :burger_id, :regular, label: { text: 'Hamburger' }, link_errors: true
+    #      = f.govuk_radio_button :burger_id, :cheese, label: { text: 'Cheeseburger' }
     #
     def govuk_radio_buttons_fieldset(attribute_name, hint_text: nil, legend: {}, inline: false, small: false, classes: nil, &block)
       Containers::RadioButtonsFieldset.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, inline: inline, small: small, classes: classes, &block).html
@@ -412,9 +459,9 @@ module GOVUKDesignSystemFormBuilder
     #   from the error summary. <b>Should only be set to +true+ for the first radio button in a fieldset</b>
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
-    # @example A collection of radio buttons for favourite colours with a divider
+    # @example A single radio button for our new favourite colour
     #
-    #  = f.govuk_collection_radio_buttons :favourite_colour, inline: false do
+    #  = f.govuk_radio_buttons_fieldset :favourite_colour do
     #    = f.govuk_radio_button :favourite_colour, :red, label: { text: 'Red' }
     #
     def govuk_radio_button(attribute_name, value, hint_text: nil, label: {}, link_errors: false, &block)
@@ -444,7 +491,7 @@ module GOVUKDesignSystemFormBuilder
     # @param hint_text [String] The content of the fieldset hint. No hint will be injected if left +nil+
     # @param small [Boolean] controls whether small check boxes are used instead of regular-sized ones
     # @param classes [String] Classes to add to the checkbox container.
-    # @param legend [Hash] options for configuring the legend
+    # @param legend [Hash,Proc] options for configuring the legend
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
@@ -470,13 +517,21 @@ module GOVUKDesignSystemFormBuilder
     #    classes: 'app-overflow-scroll',
     #
     # @example A collection of check boxes for types of bread
-    #  = f.govuk_collection_radio_buttons :bread,
+    #  = f.govuk_collection_check_boxes :bread,
     #    @variety,
     #    :id,
     #    :name do
     #
     #      p.govuk-inset-text
     #        | Only Hearty Italian is available with the meal deal menu
+    #
+    # @example A collection of check boxes with the legend supplied as a proc
+    #  = f.govuk_collection_check_boxes :sandwich_type,
+    #    @breads,
+    #    :id,
+    #    :name,
+    #    legend: -> { tag.h3('What kind of sandwich do you want?') }
+    #
     def govuk_collection_check_boxes(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, small: false, classes: nil, &block)
       Elements::CheckBoxes::Collection.new(
         self,
@@ -502,7 +557,7 @@ module GOVUKDesignSystemFormBuilder
     # @param attribute_name [Symbol] The name of the attribute
     # @param hint_text [String] The content of the fieldset hint. No hint will be injected if left +nil+
     # @param small [Boolean] controls whether small check boxes are used instead of regular-sized ones
-    # @param legend [Hash] options for configuring the legend
+    # @param legend [Hash,Proc] options for configuring the legend
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
@@ -512,10 +567,14 @@ module GOVUKDesignSystemFormBuilder
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
     # @example A collection of check boxes for sandwich fillings
-    #
-    #  = f.govuk_check_boxes_fieldset :desired_filling,
+    #  = f.govuk_check_boxes_fieldset :desired_filling, legend: { text: 'Which filling do you want?' },
     #    = f.govuk_check_box :desired_filling, :cheese, label: { text: 'Cheese' }, link_errors: true
     #    = f.govuk_check_box :desired_filling, :tomato, label: { text: 'Tomato' }
+    #
+    # @example A collection of check boxes for drinks choices with legend as a proc
+    #  = f.govuk_check_boxes_fieldset :drink_id, legend: -> { tag.h3('Choose drinks to accompany your meal') },
+    #    = f.govuk_check_box :desired_filling, :lemonade, label: { text: 'Lemonade' }, link_errors: true
+    #    = f.govuk_check_box :desired_filling, :fizzy_orange, label: { text: 'Fizzy orange' }
     #
     def govuk_check_boxes_fieldset(attribute_name, legend: {}, hint_text: {}, small: false, classes: nil, &block)
       Containers::CheckBoxesFieldset.new(
@@ -530,7 +589,7 @@ module GOVUKDesignSystemFormBuilder
       ).html
     end
 
-    # Generates a single fieldset, intended for use within a {#govuk_check_boxes_fieldset}
+    # Generates a single check box, intended for use within a {#govuk_check_boxes_fieldset}
     #
     # @param attribute_name [Symbol] The name of the attribute
     # @param value [Boolean,String,Symbol,Integer] The value of the checkbox when it is checked
@@ -604,7 +663,7 @@ module GOVUKDesignSystemFormBuilder
     #   be 'rounded' up to +2019-10-01+.
     # @param attribute_name [Symbol] The name of the attribute
     # @param hint_text [String] the contents of the hint
-    # @param legend [Hash] options for configuring the legend
+    # @param legend [Hash,Proc] options for configuring the legend
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
@@ -625,6 +684,9 @@ module GOVUKDesignSystemFormBuilder
     #       p.govuk-inset-text
     #         | If you don't fill this in you won't be eligable for a refund
     #
+    # @example A date input with legend supplied as a proc
+    #  = f.govuk_date_field :finishes_on,
+    #    legend: -> { tag.h3('Which category do you belong to?') }
     def govuk_date_field(attribute_name, hint_text: nil, legend: {}, date_of_birth: false, omit_day: false, &block)
       Elements::Date.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, date_of_birth: date_of_birth, omit_day: omit_day, &block).html
     end
@@ -644,7 +706,7 @@ module GOVUKDesignSystemFormBuilder
 
     # Generates a fieldset containing the contents of the block
     #
-    # @param legend [Hash] options for configuring the legend
+    # @param legend [Hash,Proc] options for configuring the legend
     # @param described_by [Array<String>] the ids of the elements that describe this fieldset, usually hints and errors
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
@@ -656,6 +718,11 @@ module GOVUKDesignSystemFormBuilder
     #     = f.govuk_text_field :street
     #     = f.govuk_text_field :town
     #     = f.govuk_text_field :city
+    #
+    # @example A fieldset with the legend as a proc
+    #   = f.govuk_fieldset legend: -> { tag.h3('Skills') }
+    #     = f.govuk_text_area :physical
+    #     = f.govuk_text_area :mental
     #
     # @see https://design-system.service.gov.uk/components/fieldset/ GOV.UK fieldset
     # @return [ActiveSupport::SafeBuffer] HTML output
@@ -679,6 +746,9 @@ module GOVUKDesignSystemFormBuilder
     #
     #     p.govuk-inset-text
     #       | Explicit images will result in account termination
+    #
+    # @example A CV upload field with label as a proc
+    #   = f.govuk_file_field :cv, label: -> { tag.h3('Upload your CV') }
     #
     # @see https://design-system.service.gov.uk/components/file-upload/ GOV.UK file upload
     # @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file MDN documentation for file upload

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -13,10 +13,14 @@ module GOVUKDesignSystemFormBuilder
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
+    # @param caption [Hash] configures or sets the caption content which is inserted above the label
+    # @option caption text [String] the caption text
+    # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
+    # @see https://design-system.service.gov.uk/styles/typography/#headings-with-captions Headings with captions
     #
     # @example A required full name field with a placeholder
     #   = f.govuk_text_field :name,
@@ -51,11 +55,15 @@ module GOVUKDesignSystemFormBuilder
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
+    # @param caption [Hash] configures or sets the caption content which is inserted above the label
+    # @option caption text [String] the caption text
+    # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
     # @see https://design-system.service.gov.uk/patterns/telephone-numbers/ GOV.UK Telephone number patterns
+    # @see https://design-system.service.gov.uk/styles/typography/#headings-with-captions Headings with captions
     #
     # @example A required phone number field with a placeholder
     #   = f.govuk_phone_field :phone_number,
@@ -90,11 +98,15 @@ module GOVUKDesignSystemFormBuilder
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
+    # @param caption [Hash] configures or sets the caption content which is inserted above the label
+    # @option caption text [String] the caption text
+    # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
     # @see https://design-system.service.gov.uk/patterns/email-addresses/ GOV.UK Email address patterns
+    # @see https://design-system.service.gov.uk/styles/typography/#headings-with-captions Headings with captions
     #
     # @example An email address field with a placeholder
     #   = f.govuk_email_field :email_address,
@@ -127,11 +139,15 @@ module GOVUKDesignSystemFormBuilder
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
+    # @param caption [Hash] configures or sets the caption content which is inserted above the label
+    # @option caption text [String] the caption text
+    # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
     # @see https://design-system.service.gov.uk/patterns/passwords/ GOV.UK Password patterns
+    # @see https://design-system.service.gov.uk/styles/typography/#headings-with-captions Headings with captions
     #
     # @example A password field
     #   = f.govuk_password_field :password,
@@ -163,10 +179,14 @@ module GOVUKDesignSystemFormBuilder
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
+    # @param caption [Hash] configures or sets the caption content which is inserted above the label
+    # @option caption text [String] the caption text
+    # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
+    # @see https://design-system.service.gov.uk/styles/typography/#headings-with-captions Headings with captions
     #
     # @example A url field with autocomplete
     #   = f.govuk_url_field :favourite_website,
@@ -200,10 +220,14 @@ module GOVUKDesignSystemFormBuilder
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
+    # @param caption [Hash] configures or sets the caption content which is inserted above the label
+    # @option caption text [String] the caption text
+    # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
+    # @see https://design-system.service.gov.uk/styles/typography/#headings-with-captions Headings with captions
     #
     # @example A number field with placeholder, min, max and step
     #   = f.govuk_number_field :iq,
@@ -240,6 +264,9 @@ module GOVUKDesignSystemFormBuilder
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
+    # @param caption [Hash] configures or sets the caption content which is inserted above the label
+    # @option caption text [String] the caption text
+    # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @param max_words [Integer] adds the GOV.UK max word count
     # @param max_chars [Integer] adds the GOV.UK max characters count
     # @param threshold [Integer] only show the +max_words+ and +max_chars+ warnings once a threshold (percentage) is reached
@@ -247,7 +274,9 @@ module GOVUKDesignSystemFormBuilder
     # @option args [Hash] args additional arguments are applied as attributes to the +textarea+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
+    # @see https://design-system.service.gov.uk/components/textarea/ GOV.UK text area component
     # @see https://design-system.service.gov.uk/components/character-count GOV.UK character count component
+    # @see https://design-system.service.gov.uk/styles/typography/#headings-with-captions Headings with captions
     # @note Setting +max_chars+ or +max_words+ will add a caption beneath the +textarea+ with a live count of words
     #   or characters
     #
@@ -349,6 +378,9 @@ module GOVUKDesignSystemFormBuilder
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
     # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
+    # @param caption [Hash] configures or sets the caption content which is inserted above the legend
+    # @option caption text [String] the caption text
+    # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
     # @example A collection of radio buttons for favourite colours, labels capitalised via a proc
@@ -419,9 +451,13 @@ module GOVUKDesignSystemFormBuilder
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
     # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
+    # @param caption [Hash] configures or sets the caption content which is inserted above the legend
+    # @option caption text [String] the caption text
+    # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @param block [Block] a block of HTML that will be used to populate the fieldset
     # @param classes [String] Classes to add to the radio button container.
     # @see https://design-system.service.gov.uk/components/radios/ GOV.UK Radios
+    # @see https://design-system.service.gov.uk/styles/typography/#headings-with-captions Headings with captions
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
     # @example A radio button fieldset for favourite colours with a divider
@@ -455,6 +491,7 @@ module GOVUKDesignSystemFormBuilder
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
     # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
     # @see https://design-system.service.gov.uk/components/radios/ GOV.UK Radios
+    # @see https://design-system.service.gov.uk/styles/typography/#headings-with-captions Headings with captions
     # @param block [Block] Any supplied HTML will be wrapped in a conditional
     #   container and only revealed when the radio button is picked
     # @param link_errors [Boolean] controls whether this radio button should be linked to from {#govuk_error_summary}
@@ -498,6 +535,9 @@ module GOVUKDesignSystemFormBuilder
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
     # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
+    # @param caption [Hash] configures or sets the caption content which is inserted above the legend
+    # @option caption text [String] the caption text
+    # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @param block [Block] any HTML passed in will be injected into the fieldset, after the hint and before the checkboxes
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
@@ -565,6 +605,9 @@ module GOVUKDesignSystemFormBuilder
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
     # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
+    # @param caption [Hash] configures or sets the caption content which is inserted above the legend
+    # @option caption text [String] the caption text
+    # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @param classes [String] Classes to add to the checkbox container.
     # @param block [Block] a block of HTML that will be used to populate the fieldset
     # @return [ActiveSupport::SafeBuffer] HTML output
@@ -672,6 +715,9 @@ module GOVUKDesignSystemFormBuilder
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
     # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
+    # @param caption [Hash] configures or sets the caption content which is inserted above the legend
+    # @option caption text [String] the caption text
+    # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @param omit_day [Boolean] do not render a day input, only capture month and year
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input group
     # @param date_of_birth [Boolean] if +true+ {https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Values birth date auto completion attributes}
@@ -679,6 +725,7 @@ module GOVUKDesignSystemFormBuilder
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
     # @see https://github.com/alphagov/govuk-frontend/issues/1449 GOV.UK date input element attributes, using text instead of number
+    # @see https://design-system.service.gov.uk/styles/typography/#headings-with-captions Headings with captions
     #
     # @example A regular date input with a legend, hint and injected content
     #   = f.govuk_date_field :starts_on,
@@ -716,6 +763,9 @@ module GOVUKDesignSystemFormBuilder
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
     # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
+    # @param caption [Hash] configures or sets the caption content which is inserted above the label
+    # @option caption text [String] the caption text
+    # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     #
     # @example A fieldset containing address fields
     #   = f.govuk_fieldset legend: { text: 'Address' }
@@ -729,6 +779,7 @@ module GOVUKDesignSystemFormBuilder
     #     = f.govuk_text_area :mental
     #
     # @see https://design-system.service.gov.uk/components/fieldset/ GOV.UK fieldset
+    # @see https://design-system.service.gov.uk/styles/typography/#headings-with-captions Headings with captions
     # @return [ActiveSupport::SafeBuffer] HTML output
     def govuk_fieldset(legend: { text: 'Fieldset heading' }, caption: {}, described_by: nil, &block)
       Containers::Fieldset.new(self, legend: legend, caption: caption, described_by: described_by, &block).html
@@ -741,6 +792,9 @@ module GOVUKDesignSystemFormBuilder
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
+    # @param caption [Hash] configures or sets the caption content which is inserted above the label
+    # @option caption text [String] the caption text
+    # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
@@ -755,6 +809,7 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_file_field :cv, label: -> { tag.h3('Upload your CV') }
     #
     # @see https://design-system.service.gov.uk/components/file-upload/ GOV.UK file upload
+    # @see https://design-system.service.gov.uk/styles/typography/#headings-with-captions Headings with captions
     # @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file MDN documentation for file upload
     #
     # @note Remember to set +multipart: true+ when creating a form with file

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -13,7 +13,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
-    # @option args [Hash] args additional arguments are applied as attributes to +input+ element
+    # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -51,7 +51,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
-    # @option args [Hash] args additional arguments are applied as attributes to +input+ element
+    # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -90,7 +90,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
-    # @option args [Hash] args additional arguments are applied as attributes to +input+ element
+    # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -127,7 +127,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
-    # @option args [Hash] args additional arguments are applied as attributes to +input+ element
+    # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -163,7 +163,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
-    # @option args [Hash] args additional arguments are applied as attributes to +input+ element
+    # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -742,7 +742,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
-    # @option args [Hash] args additional arguments are applied as attributes to +input+ element
+    # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     #
     # @example A photo upload field with file type specifier and injected content

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -36,8 +36,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_text_field :callsign,
     #     label: -> { tag.h3('Call-sign') }
     #
-    def govuk_text_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
-      Elements::Inputs::Text.new(self, object_name, attribute_name, hint_text: hint_text, label: label, width: width, **args, &block).html
+    def govuk_text_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, **args, &block)
+      Elements::Inputs::Text.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, **args, &block).html
     end
 
     # Generates a input of type +tel+
@@ -75,8 +75,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_phone_field :work_number,
     #     label: -> { tag.h3('Work number') }
     #
-    def govuk_phone_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
-      Elements::Inputs::Phone.new(self, object_name, attribute_name, hint_text: hint_text, label: label, width: width, **args, &block).html
+    def govuk_phone_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, **args, &block)
+      Elements::Inputs::Phone.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, **args, &block).html
     end
 
     # Generates a input of type +email+
@@ -112,8 +112,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_email_field :personal_email,
     #     label: -> { tag.h3('Personal email address') }
     #
-    def govuk_email_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
-      Elements::Inputs::Email.new(self, object_name, attribute_name, hint_text: hint_text, label: label, width: width, **args, &block).html
+    def govuk_email_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, **args, &block)
+      Elements::Inputs::Email.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, **args, &block).html
     end
 
     # Generates a input of type +password+
@@ -148,8 +148,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_password_field :passcode,
     #     label: -> { tag.h3('What is your secret pass code?') }
     #
-    def govuk_password_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
-      Elements::Inputs::Password.new(self, object_name, attribute_name, hint_text: hint_text, label: label, width: width, **args, &block).html
+    def govuk_password_field(attribute_name, hint_text: nil, label: {}, width: nil, caption: {}, **args, &block)
+      Elements::Inputs::Password.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, **args, &block).html
     end
 
     # Generates a input of type +url+
@@ -185,8 +185,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_url_field :work_website,
     #     label: -> { tag.h3("Enter your company's website") }
     #
-    def govuk_url_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
-      Elements::Inputs::URL.new(self, object_name, attribute_name, hint_text: hint_text, label: label, width: width, **args, &block).html
+    def govuk_url_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, **args, &block)
+      Elements::Inputs::URL.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, **args, &block).html
     end
 
     # Generates a input of type +number+
@@ -225,8 +225,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_url_field :personal_best_over_100m,
     #     label: -> { tag.h3("How many seconds does it take you to run 100m?") }
     #
-    def govuk_number_field(attribute_name, hint_text: nil, label: {}, width: nil, **args, &block)
-      Elements::Inputs::Number.new(self, object_name, attribute_name, hint_text: hint_text, label: label, width: width, **args, &block).html
+    def govuk_number_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, **args, &block)
+      Elements::Inputs::Number.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, **args, &block).html
     end
 
     # Generates a +textarea+ element with a label, optional hint. Also offers
@@ -268,8 +268,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_text_area :instructions,
     #     label: -> { tag.h3("How do you set it up?") }
     #
-    def govuk_text_area(attribute_name, hint_text: nil, label: {}, max_words: nil, max_chars: nil, rows: 5, threshold: nil, **args, &block)
-      Elements::TextArea.new(self, object_name, attribute_name, hint_text: hint_text, label: label, max_words: max_words, max_chars: max_chars, rows: rows, threshold: threshold, **args, &block).html
+    def govuk_text_area(attribute_name, hint_text: nil, label: {}, caption: {}, max_words: nil, max_chars: nil, rows: 5, threshold: nil, **args, &block)
+      Elements::TextArea.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, max_words: max_words, max_chars: max_chars, rows: rows, threshold: threshold, **args, &block).html
     end
 
     # Generates a +select+ element containing +option+ for each member in the provided collection
@@ -303,7 +303,7 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_collection_select(:team, @teams, :id, :name) do
     #     label: -> { tag.h3("Which team did you represent?") }
     #
-    def govuk_collection_select(attribute_name, collection, value_method, text_method, options: {}, html_options: {}, hint_text: nil, label: {}, &block)
+    def govuk_collection_select(attribute_name, collection, value_method, text_method, options: {}, html_options: {}, hint_text: nil, label: {}, caption: {}, &block)
       Elements::Select.new(
         self,
         object_name,
@@ -313,6 +313,7 @@ module GOVUKDesignSystemFormBuilder
         text_method: text_method,
         hint_text: hint_text,
         label: label,
+        caption: caption,
         options: options,
         html_options: html_options,
         &block
@@ -382,7 +383,7 @@ module GOVUKDesignSystemFormBuilder
     #    :name,
     #    legend: -> { tag.h3('Which category do you belong to?') }
     #
-    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, inline: false, small: false, bold_labels: false, classes: nil, &block)
+    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, caption: {}, inline: false, small: false, bold_labels: false, classes: nil, &block)
       Elements::Radios::Collection.new(
         self,
         object_name,
@@ -393,6 +394,7 @@ module GOVUKDesignSystemFormBuilder
         hint_method: hint_method,
         hint_text: hint_text,
         legend: legend,
+        caption: caption,
         inline: inline,
         small: small,
         bold_labels: bold_labels,
@@ -439,8 +441,8 @@ module GOVUKDesignSystemFormBuilder
     #      = f.govuk_radio_button :burger_id, :regular, label: { text: 'Hamburger' }, link_errors: true
     #      = f.govuk_radio_button :burger_id, :cheese, label: { text: 'Cheeseburger' }
     #
-    def govuk_radio_buttons_fieldset(attribute_name, hint_text: nil, legend: {}, inline: false, small: false, classes: nil, &block)
-      Containers::RadioButtonsFieldset.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, inline: inline, small: small, classes: classes, &block).html
+    def govuk_radio_buttons_fieldset(attribute_name, hint_text: nil, legend: {}, caption: {}, inline: false, small: false, classes: nil, &block)
+      Containers::RadioButtonsFieldset.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, caption: caption, inline: inline, small: small, classes: classes, &block).html
     end
 
     # Generates a radio button
@@ -532,7 +534,7 @@ module GOVUKDesignSystemFormBuilder
     #    :name,
     #    legend: -> { tag.h3('What kind of sandwich do you want?') }
     #
-    def govuk_collection_check_boxes(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, small: false, classes: nil, &block)
+    def govuk_collection_check_boxes(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, caption: {}, small: false, classes: nil, &block)
       Elements::CheckBoxes::Collection.new(
         self,
         object_name,
@@ -543,6 +545,7 @@ module GOVUKDesignSystemFormBuilder
         hint_method: hint_method,
         hint_text: hint_text,
         legend: legend,
+        caption: caption,
         small: small,
         classes: classes,
         &block
@@ -576,13 +579,14 @@ module GOVUKDesignSystemFormBuilder
     #    = f.govuk_check_box :desired_filling, :lemonade, label: { text: 'Lemonade' }, link_errors: true
     #    = f.govuk_check_box :desired_filling, :fizzy_orange, label: { text: 'Fizzy orange' }
     #
-    def govuk_check_boxes_fieldset(attribute_name, legend: {}, hint_text: {}, small: false, classes: nil, &block)
+    def govuk_check_boxes_fieldset(attribute_name, legend: {}, caption: {}, hint_text: {}, small: false, classes: nil, &block)
       Containers::CheckBoxesFieldset.new(
         self,
         object_name,
         attribute_name,
         hint_text: hint_text,
         legend: legend,
+        caption: caption,
         small: small,
         classes: classes,
         &block
@@ -687,8 +691,8 @@ module GOVUKDesignSystemFormBuilder
     # @example A date input with legend supplied as a proc
     #  = f.govuk_date_field :finishes_on,
     #    legend: -> { tag.h3('Which category do you belong to?') }
-    def govuk_date_field(attribute_name, hint_text: nil, legend: {}, date_of_birth: false, omit_day: false, &block)
-      Elements::Date.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, date_of_birth: date_of_birth, omit_day: omit_day, &block).html
+    def govuk_date_field(attribute_name, hint_text: nil, legend: {}, caption: {}, date_of_birth: false, omit_day: false, &block)
+      Elements::Date.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, caption: caption, date_of_birth: date_of_birth, omit_day: omit_day, &block).html
     end
 
     # Generates a summary of errors in the form, each linking to the corresponding
@@ -726,8 +730,8 @@ module GOVUKDesignSystemFormBuilder
     #
     # @see https://design-system.service.gov.uk/components/fieldset/ GOV.UK fieldset
     # @return [ActiveSupport::SafeBuffer] HTML output
-    def govuk_fieldset(legend: { text: 'Fieldset heading' }, described_by: nil, &block)
-      Containers::Fieldset.new(self, legend: legend, described_by: described_by, &block).html
+    def govuk_fieldset(legend: { text: 'Fieldset heading' }, caption: {}, described_by: nil, &block)
+      Containers::Fieldset.new(self, legend: legend, caption: caption, described_by: described_by, &block).html
     end
 
     # Generates an input of type +file+
@@ -756,8 +760,8 @@ module GOVUKDesignSystemFormBuilder
     # @note Remember to set +multipart: true+ when creating a form with file
     #   uploads, {https://guides.rubyonrails.org/form_helpers.html#uploading-files see
     #   the Rails documentation} for more information
-    def govuk_file_field(attribute_name, label: {}, hint_text: nil, **args, &block)
-      Elements::File.new(self, object_name, attribute_name, label: label, hint_text: hint_text, **args, &block).html
+    def govuk_file_field(attribute_name, label: {}, caption: {}, hint_text: nil, **args, &block)
+      Elements::File.new(self, object_name, attribute_name, label: label, caption: caption, hint_text: hint_text, **args, &block).html
     end
   end
 end

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -4,10 +4,11 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Error
       include Traits::Hint
 
-      def initialize(builder, object_name, attribute_name, hint_text:, legend:, small:, classes:, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, legend:, caption:, small:, classes:, &block)
         super(builder, object_name, attribute_name, &block)
 
         @legend        = legend
+        @caption       = caption
         @hint_text     = hint_text
         @small         = small
         @classes       = classes
@@ -16,7 +17,7 @@ module GOVUKDesignSystemFormBuilder
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-          Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, described_by: [error_element.error_id, hint_element.hint_id]).html do
+          Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, caption: @caption, described_by: [error_element.error_id, hint_element.hint_id]).html do
             safe_join(
               [
                 hint_element.html,

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -8,7 +8,7 @@ module GOVUKDesignSystemFormBuilder
 
       LEGEND_SIZES = %w(xl l m s).freeze
 
-      def initialize(builder, object_name = nil, attribute_name = nil, legend: {}, described_by: nil, &block)
+      def initialize(builder, object_name = nil, attribute_name = nil, legend: {}, caption: {}, described_by: nil, &block)
         super(builder, object_name, attribute_name, &block)
 
         @described_by   = described_by(described_by)
@@ -16,10 +16,10 @@ module GOVUKDesignSystemFormBuilder
 
         case legend
         when Proc
-          @legend = legend.call
+          @legend_raw = legend.call
         when Hash
           @legend_options = legend_defaults.merge(legend)
-          @caption        = @legend_options.dig(:caption)
+          @caption        = caption
         else
           fail(ArgumentError, %(legend must be a Proc or Hash))
         end
@@ -34,7 +34,7 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def legend_content
-        @legend || build_legend
+        @legend_raw || build_legend
       end
 
       def build_legend

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -3,6 +3,7 @@ module GOVUKDesignSystemFormBuilder
     class Fieldset < Base
       using PrefixableArray
 
+      include Traits::Caption
       include Traits::Localisation
 
       LEGEND_SIZES = %w(xl l m s).freeze
@@ -18,6 +19,7 @@ module GOVUKDesignSystemFormBuilder
           @legend = legend.call
         when Hash
           @legend_options = legend_defaults.merge(legend)
+          @caption        = @legend_options.dig(:caption)
         else
           fail(ArgumentError, %(legend must be a Proc or Hash))
         end
@@ -38,7 +40,9 @@ module GOVUKDesignSystemFormBuilder
       def build_legend
         if legend_text.present?
           content_tag('legend', class: legend_classes) do
-            tag.send(@legend_options.dig(:tag), legend_text, class: legend_heading_classes)
+            content_tag(@legend_options.dig(:tag), class: legend_heading_classes) do
+              safe_join([caption_element.html, legend_text])
+            end
           end
         end
       end

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -10,18 +10,59 @@ module GOVUKDesignSystemFormBuilder
       def initialize(builder, object_name = nil, attribute_name = nil, legend: {}, described_by: nil, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @legend         = legend_defaults.merge(legend)
         @described_by   = described_by(described_by)
         @attribute_name = attribute_name
+
+        case legend
+        when Proc
+          @legend = legend.call
+        when Hash
+          @legend_options = legend_defaults.merge(legend)
+        else
+          fail(ArgumentError, %(legend must be a Proc or Hash))
+        end
       end
 
       def html
         content_tag('fieldset', class: fieldset_classes, aria: { describedby: @described_by }) do
-          safe_join([build_legend, (@block_content || yield)])
+          safe_join([legend_content, (@block_content || yield)])
         end
       end
 
     private
+
+      def legend_content
+        @legend || build_legend
+      end
+
+      def build_legend
+        if legend_text.present?
+          content_tag('legend', class: legend_classes) do
+            tag.send(@legend_options.dig(:tag), legend_text, class: legend_heading_classes)
+          end
+        end
+      end
+
+      def legend_text
+        [@legend_options.dig(:text), localised_text(:legend)].compact.first
+      end
+
+      def fieldset_classes
+        %w(fieldset).prefix(brand)
+      end
+
+      def legend_classes
+        size = @legend_options.dig(:size)
+        fail "invalid size '#{size}', must be #{LEGEND_SIZES.join(', ')}" unless size.in?(LEGEND_SIZES)
+
+        [%(fieldset__legend), %(fieldset__legend--#{size})].prefix(brand).tap do |classes|
+          classes.push(%(#{brand}-visually-hidden)) if @legend_options.dig(:hidden)
+        end
+      end
+
+      def legend_heading_classes
+        %w(fieldset__heading).prefix(brand)
+      end
 
       def legend_defaults
         {
@@ -30,35 +71,6 @@ module GOVUKDesignSystemFormBuilder
           tag:  config.default_legend_tag,
           size: config.default_legend_size
         }
-      end
-
-      def build_legend
-        if legend_text.present?
-          content_tag('legend', class: legend_classes) do
-            tag.send(@legend.dig(:tag), legend_text, class: legend_heading_classes)
-          end
-        end
-      end
-
-      def legend_text
-        [@legend.dig(:text), localised_text(:legend)].compact.first
-      end
-
-      def fieldset_classes
-        %w(fieldset).prefix(brand)
-      end
-
-      def legend_classes
-        size = @legend.dig(:size)
-        fail "invalid size '#{size}', must be #{LEGEND_SIZES.join(', ')}" unless size.in?(LEGEND_SIZES)
-
-        [%(fieldset__legend), %(fieldset__legend--#{size})].prefix(brand).tap do |classes|
-          classes.push(%(#{brand}-visually-hidden)) if @legend.dig(:hidden)
-        end
-      end
-
-      def legend_heading_classes
-        %w(fieldset__heading).prefix(brand)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
@@ -4,12 +4,13 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Hint
       include Traits::Error
 
-      def initialize(builder, object_name, attribute_name, hint_text:, legend:, inline:, small:, classes:, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, legend:, caption:, inline:, small:, classes:, &block)
         super(builder, object_name, attribute_name)
 
         @inline        = inline
         @small         = small
         @legend        = legend
+        @caption       = caption
         @hint_text     = hint_text
         @classes       = classes
         @block_content = capture { block.call }
@@ -17,7 +18,7 @@ module GOVUKDesignSystemFormBuilder
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-          Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, described_by: [error_element.error_id, hint_element.hint_id]).html do
+          Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, caption: @caption, described_by: [error_element.error_id, hint_element.hint_id]).html do
             safe_join(
               [
                 hint_element.html,

--- a/lib/govuk_design_system_formbuilder/elements/caption.rb
+++ b/lib/govuk_design_system_formbuilder/elements/caption.rb
@@ -13,11 +13,19 @@ module GOVUKDesignSystemFormBuilder
         tag.span(@text, class: @size)
       end
 
+      def caption_text(override)
+        override || localised_text(:caption)
+      end
+
+      def caption_size
+        @size
+      end
+
       def caption_size_class(size)
         case size
-        when 'xl'      then %(#{brand}-caption-xl)
-        when 'l'       then %(#{brand}-caption-l)
-        when 'm'       then %(#{brand}-caption-m)
+        when 'xl' then %(#{brand}-caption-xl)
+        when 'l'  then %(#{brand}-caption-l)
+        when 'm'  then %(#{brand}-caption-m)
         else
           fail ArgumentError, "invalid size '#{size}', must be xl, l or m"
         end

--- a/lib/govuk_design_system_formbuilder/elements/caption.rb
+++ b/lib/govuk_design_system_formbuilder/elements/caption.rb
@@ -1,0 +1,27 @@
+module GOVUKDesignSystemFormBuilder
+  module Elements
+    class Caption < Base
+      def initialize(builder:, text:, size: 'm')
+        @builder = builder
+        @text    = text
+        @size    = caption_size_class(size)
+      end
+
+      def html
+        return nil if @text.blank?
+
+        tag.span(@text, class: @size)
+      end
+
+      def caption_size_class(size)
+        case size
+        when 'xl'      then %(#{brand}-caption-xl)
+        when 'l'       then %(#{brand}-caption-l)
+        when 'm'       then %(#{brand}-caption-m)
+        else
+          fail ArgumentError, "invalid size '#{size}', must be xl, l or m"
+        end
+      end
+    end
+  end
+end

--- a/lib/govuk_design_system_formbuilder/elements/caption.rb
+++ b/lib/govuk_design_system_formbuilder/elements/caption.rb
@@ -1,24 +1,23 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     class Caption < Base
-      def initialize(builder:, text:, size: 'm')
-        @builder = builder
-        @text    = text
-        @size    = caption_size_class(size)
+      include Traits::Localisation
+
+      def initialize(builder, object_name, attribute_name, text:, size: 'm')
+        super(builder, object_name, attribute_name)
+
+        @text       = caption_text(text)
+        @size_class = caption_size_class(size)
       end
 
       def html
         return nil if @text.blank?
 
-        tag.span(@text, class: @size)
+        tag.span(@text, class: @size_class)
       end
 
       def caption_text(override)
         override || localised_text(:caption)
-      end
-
-      def caption_size
-        @size
       end
 
       def caption_size_class(size)

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -6,7 +6,7 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Supplemental
 
-        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method: nil, hint_text:, legend:, small:, classes:, &block)
+        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method: nil, hint_text:, legend:, caption:, small:, classes:, &block)
           super(builder, object_name, attribute_name, &block)
 
           @collection    = collection
@@ -15,13 +15,14 @@ module GOVUKDesignSystemFormBuilder
           @hint_method   = hint_method
           @small         = small
           @legend        = legend
+          @caption       = caption
           @hint_text     = hint_text
           @classes       = classes
         end
 
         def html
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-            Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
+            Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, caption: @caption, described_by: [error_id, hint_id, supplemental_id]).html do
               safe_join(
                 [
                   supplemental_content.html,

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -4,6 +4,7 @@ module GOVUKDesignSystemFormBuilder
       class FieldsetCheckBox < Base
         using PrefixableArray
 
+        include Traits::Label
         include Traits::Hint
         include Traits::Conditional
 
@@ -57,7 +58,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def label_element
-          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, checkbox: true, value: @value, **@label, link_errors: @link_errors)
+          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, checkbox: true, value: @value, link_errors: @link_errors, **label_args)
         end
 
         def hint_element

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -9,10 +9,11 @@ module GOVUKDesignSystemFormBuilder
 
       SEGMENTS = { day: '3i', month: '2i', year: '1i' }.freeze
 
-      def initialize(builder, object_name, attribute_name, legend:, hint_text:, date_of_birth: false, omit_day:, &block)
+      def initialize(builder, object_name, attribute_name, legend:, caption:, hint_text:, date_of_birth: false, omit_day:, &block)
         super(builder, object_name, attribute_name, &block)
 
         @legend        = legend
+        @caption       = caption
         @hint_text     = hint_text
         @date_of_birth = date_of_birth
         @omit_day      = omit_day
@@ -20,7 +21,7 @@ module GOVUKDesignSystemFormBuilder
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-          Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
+          Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, caption: @caption, described_by: [error_id, hint_id, supplemental_id]).html do
             safe_join(
               [
                 supplemental_content.html,

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -8,10 +8,11 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Label
       include Traits::Supplemental
 
-      def initialize(builder, object_name, attribute_name, hint_text:, label:, **extra_args, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, **extra_args, &block)
         super(builder, object_name, attribute_name, &block)
 
         @label      = label
+        @caption    = caption
         @hint_text  = hint_text
         @extra_args = extra_args
       end

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -3,11 +3,14 @@ module GOVUKDesignSystemFormBuilder
     class Label < Base
       using PrefixableArray
 
+      include Traits::Caption
       include Traits::Localisation
 
-      def initialize(builder, object_name, attribute_name, text: nil, value: nil, size: nil, hidden: false, radio: false, checkbox: false, tag: nil, link_errors: true, content: nil)
+      def initialize(builder, object_name, attribute_name, text: nil, value: nil, size: nil, hidden: false, radio: false, checkbox: false, tag: nil, link_errors: true, content: nil, caption: nil)
         super(builder, object_name, attribute_name)
 
+        # content is passed in directly via a proc and overrides
+        # the other display options
         if content
           @content = content.call
         else
@@ -18,6 +21,7 @@ module GOVUKDesignSystemFormBuilder
           @checkbox_class = checkbox_class(checkbox)
           @tag            = tag
           @link_errors    = link_errors
+          @caption        = caption
         end
       end
 
@@ -40,7 +44,7 @@ module GOVUKDesignSystemFormBuilder
           for: field_id(link_errors: @link_errors),
           class: %w(label).prefix(brand).push(@size_class, @weight_class, @radio_class, @checkbox_class).compact
         ) do
-          @content || @text
+          @content || safe_join([caption_element.html, @text])
         end
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -5,20 +5,24 @@ module GOVUKDesignSystemFormBuilder
 
       include Traits::Localisation
 
-      def initialize(builder, object_name, attribute_name, text: nil, value: nil, size: nil, hidden: false, radio: false, checkbox: false, tag: nil, link_errors: true)
+      def initialize(builder, object_name, attribute_name, text: nil, value: nil, size: nil, hidden: false, radio: false, checkbox: false, tag: nil, link_errors: true, content: nil)
         super(builder, object_name, attribute_name)
 
-        @value          = value # used by field_id
-        @text           = label_text(text, hidden)
-        @size_class     = label_size_class(size)
-        @radio_class    = radio_class(radio)
-        @checkbox_class = checkbox_class(checkbox)
-        @tag            = tag
-        @link_errors    = link_errors
+        if content
+          @content = content.call
+        else
+          @value          = value # used by field_id
+          @text           = label_text(text, hidden)
+          @size_class     = label_size_class(size)
+          @radio_class    = radio_class(radio)
+          @checkbox_class = checkbox_class(checkbox)
+          @tag            = tag
+          @link_errors    = link_errors
+        end
       end
 
       def html
-        return nil if @text.blank?
+        return nil if [@content, @text].all?(&:blank?)
 
         if @tag.present?
           content_tag(@tag, class: %(#{brand}-label-wrapper)) { build_label }
@@ -36,7 +40,7 @@ module GOVUKDesignSystemFormBuilder
           for: field_id(link_errors: @link_errors),
           class: %w(label).prefix(brand).push(@size_class, @weight_class, @radio_class, @checkbox_class).compact
         ) do
-          @text
+          @content || @text
         end
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -6,7 +6,7 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Supplemental
 
-        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method:, hint_text:, legend:, inline:, small:, bold_labels:, classes:, &block)
+        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method:, hint_text:, legend:, caption:, inline:, small:, bold_labels:, classes:, &block)
           super(builder, object_name, attribute_name, &block)
 
           @collection    = collection
@@ -16,6 +16,7 @@ module GOVUKDesignSystemFormBuilder
           @inline        = inline
           @small         = small
           @legend        = legend
+          @caption       = caption
           @hint_text     = hint_text
           @classes       = classes
           @bold_labels   = hint_method.present? || bold_labels
@@ -23,7 +24,7 @@ module GOVUKDesignSystemFormBuilder
 
         def html
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-            Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, described_by: [error_id, hint_id, supplemental_id]).html do
+            Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, caption: @caption, described_by: [error_id, hint_id, supplemental_id]).html do
               safe_join(
                 [
                   supplemental_content.html,

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -4,6 +4,7 @@ module GOVUKDesignSystemFormBuilder
       class FieldsetRadioButton < Base
         using PrefixableArray
 
+        include Traits::Label
         include Traits::Hint
         include Traits::Conditional
 
@@ -41,7 +42,7 @@ module GOVUKDesignSystemFormBuilder
       private
 
         def label_element
-          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, radio: true, value: @value, **@label, link_errors: @link_errors)
+          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, radio: true, value: @value, link_errors: @link_errors, **label_args)
         end
 
         def hint_element

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -8,7 +8,7 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Hint
       include Traits::Supplemental
 
-      def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, options: {}, html_options: {}, hint_text:, label:, &block)
+      def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, options: {}, html_options: {}, hint_text:, label:, caption:, &block)
         super(builder, object_name, attribute_name, &block)
 
         @collection    = collection
@@ -17,6 +17,7 @@ module GOVUKDesignSystemFormBuilder
         @options       = options
         @html_options  = html_options
         @label         = label
+        @caption       = caption
         @hint_text     = hint_text
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -8,10 +8,11 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Label
       include Traits::Supplemental
 
-      def initialize(builder, object_name, attribute_name, hint_text:, label:, rows:, max_words:, max_chars:, threshold:, **extra_args, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, rows:, max_words:, max_chars:, threshold:, **extra_args, &block)
         super(builder, object_name, attribute_name, &block)
 
         @label      = label
+        @caption    = caption
         @hint_text  = hint_text
         @extra_args = extra_args
         @max_words  = max_words

--- a/lib/govuk_design_system_formbuilder/traits/caption.rb
+++ b/lib/govuk_design_system_formbuilder/traits/caption.rb
@@ -1,0 +1,31 @@
+module GOVUKDesignSystemFormBuilder
+  module Traits
+    module Caption
+    private
+
+      def caption_element
+        @caption_element ||= Elements::Caption.new(
+          **{ text: nil }.merge(
+            {
+              builder: @builder,
+              text: caption_text,
+              size: caption_size
+            }.compact
+          )
+        )
+      end
+
+      def caption_text
+        return nil if @caption.blank?
+
+        @caption.dig(:text)
+      end
+
+      def caption_size
+        return nil if @caption.blank?
+
+        @caption.dig(:size)
+      end
+    end
+  end
+end

--- a/lib/govuk_design_system_formbuilder/traits/caption.rb
+++ b/lib/govuk_design_system_formbuilder/traits/caption.rb
@@ -5,26 +5,19 @@ module GOVUKDesignSystemFormBuilder
 
       def caption_element
         @caption_element ||= Elements::Caption.new(
-          **{ text: nil }.merge(
-            {
-              builder: @builder,
-              text: caption_text,
-              size: caption_size
-            }.compact
-          )
+          @builder,
+          @object_name,
+          @attribute_name,
+          **{ text: nil }.merge({ text: caption_text, size: caption_size }.compact)
         )
       end
 
       def caption_text
-        return nil if @caption.blank?
-
-        @caption.dig(:text)
+        @caption&.dig(:text)
       end
 
       def caption_size
-        return nil if @caption.blank?
-
-        @caption.dig(:size)
+        @caption&.dig(:size)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/traits/input.rb
+++ b/lib/govuk_design_system_formbuilder/traits/input.rb
@@ -1,12 +1,13 @@
 module GOVUKDesignSystemFormBuilder
   module Traits
     module Input
-      def initialize(builder, object_name, attribute_name, hint_text:, label:, width:, **extra_args, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, width:, **extra_args, &block)
         super(builder, object_name, attribute_name, &block)
 
         @width          = width
         @extra_args     = extra_args
         @label          = label
+        @caption        = caption
         @hint_text      = hint_text
       end
 

--- a/lib/govuk_design_system_formbuilder/traits/label.rb
+++ b/lib/govuk_design_system_formbuilder/traits/label.rb
@@ -4,7 +4,18 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def label_element
-        @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, **@label)
+        @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, **label_args)
+      end
+
+      def label_args
+        case @label
+        when Hash
+          @label
+        when Proc
+          { content: @label }
+        else
+          fail(ArgumentError, %(label must be a Proc or Hash))
+        end
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/traits/label.rb
+++ b/lib/govuk_design_system_formbuilder/traits/label.rb
@@ -4,7 +4,7 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def label_element
-        @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, **label_args)
+        @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, caption: @caption, **label_args)
       end
 
       def label_args

--- a/lib/govuk_design_system_formbuilder/traits/localisation.rb
+++ b/lib/govuk_design_system_formbuilder/traits/localisation.rb
@@ -40,6 +40,8 @@ module GOVUKDesignSystemFormBuilder
                               config.localisation_schema_hint
                             when :label
                               config.localisation_schema_label
+                            when :caption
+                              config.localisation_schema_caption
                             end
 
         (contextual_schema || config.localisation_schema_fallback).dup

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
@@ -42,6 +42,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports custom branding'
 
     it_behaves_like 'a field that supports setting the legend via localisation'
+    it_behaves_like 'a field that supports setting the legend caption via localisation'
     it_behaves_like 'a field that supports setting the hint via localisation'
 
     it_behaves_like 'a field that accepts a plain ruby object' do

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
@@ -21,6 +21,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:legend_text) { 'Which projects is this person assigned to?' }
     end
 
+    it_behaves_like 'a field that supports a fieldset with legend' do
+      let(:legend_text) { 'Which projects is this person assigned to?' }
+    end
+
     it_behaves_like 'a field that supports hints' do
       let(:hint_text) { 'The most agile project in the world!' }
     end

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
@@ -41,6 +41,36 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       specify { expect { subject }.to raise_error(NoMethodError, /undefined method.*call/) }
     end
 
+    context 'when a caption is supplied' do
+      let(:caption_text) { 'Personal preferences' }
+      let(:caption_size) { 'l' }
+      let(:caption) { { text: caption_text, size: caption_size } }
+      let(:caption_class) { "govuk-caption-#{caption_size}" }
+
+      subject do
+        builder.send(*args, legend: legend, caption: caption, &example_block)
+      end
+
+      context 'with a legend' do
+        let(:legend_text) { 'Favourite colour?' }
+        let(:legend) { { text: legend_text } }
+
+        specify 'output should contain a correclty-positioned caption with the right content' do
+          expect(subject).to have_tag('fieldset', with: { class: %w(govuk-fieldset) }) do
+            with_tag('span', text: caption_text, with: { class: caption_class })
+          end
+        end
+      end
+
+      context 'without a legend' do
+        let(:legend) { {} }
+
+        specify 'output should contain no caption at all' do
+          expect(subject).not_to have_tag('span', with: { class: caption_class })
+        end
+      end
+    end
+
     context 'when a block containing check boxes is supplied' do
       specify 'output should be a form group containing a form group and fieldset' do
         expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -63,6 +63,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports setting the hint via localisation'
     it_behaves_like 'a field that supports custom branding'
     it_behaves_like 'a field that supports a fieldset with legend'
+    it_behaves_like 'a field that supports captions on the legend'
 
     it_behaves_like 'a field that accepts a plain ruby object' do
       let(:described_element) { ['input', { count: 3 }] }

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -62,6 +62,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports setting the legend via localisation'
     it_behaves_like 'a field that supports setting the hint via localisation'
     it_behaves_like 'a field that supports custom branding'
+    it_behaves_like 'a field that supports a fieldset with legend'
 
     it_behaves_like 'a field that accepts a plain ruby object' do
       let(:described_element) { ['input', { count: 3 }] }

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -60,7 +60,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that supports setting the legend via localisation'
+    it_behaves_like 'a field that supports setting the legend caption via localisation'
     it_behaves_like 'a field that supports setting the hint via localisation'
+
     it_behaves_like 'a field that supports custom branding'
     it_behaves_like 'a field that supports a fieldset with legend'
     it_behaves_like 'a field that supports captions on the legend'

--- a/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
@@ -8,10 +8,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     let(:legend_options) { { text: legend_text } }
 
+    let(:example_block) { proc { builder.tag.span(inner_text) } }
+
     subject do
-      builder.send(method, legend: legend_options) do
-        builder.tag.span(inner_text)
-      end
+      builder.send(method, legend: legend_options, &example_block)
     end
 
     specify 'output should be a fieldset containing the block contents' do
@@ -34,10 +34,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     context 'with inner form elements' do
+      let(:example_block) { proc { builder.govuk_text_field(:name) } }
+
       subject do
-        builder.send(method, legend: { text: legend_text }) do
-          builder.govuk_text_field(:name)
-        end
+        builder.send(method, legend: { text: legend_text }, &example_block)
       end
 
       specify 'inner inputs should be contained in the fieldset' do
@@ -81,6 +81,36 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
         specify 'the aria-describedby attribute should contain the supplied element ids' do
           expect(subject).to have_tag('fieldset', with: { 'aria-describedby' => element_id })
+        end
+      end
+    end
+
+    context 'when a caption is supplied' do
+      let(:caption_text) { 'Personal preferences' }
+      let(:caption_size) { 'l' }
+      let(:caption) { { text: caption_text, size: caption_size } }
+      let(:caption_class) { "govuk-caption-#{caption_size}" }
+
+      subject do
+        builder.send(method, legend: legend, caption: caption, &example_block)
+      end
+
+      context 'with a legend' do
+        let(:legend_text) { 'Favourite colour?' }
+        let(:legend) { { text: legend_text } }
+
+        specify 'output should contain a correclty-positioned caption with the right content' do
+          expect(subject).to have_tag('fieldset', with: { class: %w(govuk-fieldset) }) do
+            with_tag('span', text: caption_text, with: { class: caption_class })
+          end
+        end
+      end
+
+      context 'without a legend' do
+        let(:legend) { {} }
+
+        specify 'output should contain no caption at all' do
+          expect(subject).not_to have_tag('span', with: { class: caption_class })
         end
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -41,6 +41,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that supports setting the label via localisation'
+    it_behaves_like 'a field that supports setting the label caption via localisation'
     it_behaves_like 'a field that supports setting the hint via localisation'
 
     it_behaves_like 'a field that accepts a plain ruby object' do

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -20,6 +20,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     it_behaves_like 'a field that supports labels'
     it_behaves_like 'a field that supports labels as procs'
+    it_behaves_like 'a field that supports captions on the label'
     it_behaves_like 'a field that supports custom branding'
 
     it_behaves_like 'a field that accepts arbitrary blocks of HTML' do

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -19,6 +19,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that supports labels'
+    it_behaves_like 'a field that supports labels as procs'
     it_behaves_like 'a field that supports custom branding'
 
     it_behaves_like 'a field that accepts arbitrary blocks of HTML' do

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -29,6 +29,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:legend_text) { 'Pick your favourite colour' }
     end
 
+    it_behaves_like 'a field that supports captions on the legend' do
+      let(:legend_text) { 'Pick your favourite colour' }
+    end
+
     it_behaves_like 'a field that supports hints' do
       let(:hint_text) { 'The colour of your favourite handkerchief' }
     end

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -48,6 +48,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that supports setting the hint via localisation'
+    it_behaves_like 'a field that supports setting the legend caption via localisation'
     it_behaves_like 'a field that supports setting the legend via localisation'
 
     it_behaves_like 'a field that accepts a plain ruby object' do

--- a/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
@@ -6,9 +6,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   describe '#govuk_radio_buttons_fieldset' do
     let(:method) { :govuk_radio_buttons_fieldset }
     let(:args) { [method, attribute] }
-
-    subject do
-      builder.send(*args) do
+    let(:example_block) do
+      proc do
         builder.safe_join(
           [
             builder.govuk_radio_button(:favourite_colour, :red, label: { text: red_label }),
@@ -17,6 +16,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         )
       end
     end
+
+    subject { builder.send(*args, &example_block) }
 
     context 'when no block is supplied' do
       subject { builder.send(*args) }
@@ -40,11 +41,37 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:described_element) { 'fieldset' }
     end
 
-    context 'when a block containing radio buttons is supplied' do
-      let(:example_block) do
-        proc { builder.govuk_radio_button(:favourite_colour, :red, label: { text: red_label }) }
+    context 'when a caption is supplied' do
+      let(:caption_text) { 'Personal preferences' }
+      let(:caption_size) { 'l' }
+      let(:caption) { { text: caption_text, size: caption_size } }
+      let(:caption_class) { "govuk-caption-#{caption_size}" }
+
+      subject do
+        builder.send(*args, legend: legend, caption: caption, &example_block)
       end
 
+      context 'with a legend' do
+        let(:legend_text) { 'Favourite colour?' }
+        let(:legend) { { text: legend_text } }
+
+        specify 'output should contain a correclty-positioned caption with the right content' do
+          expect(subject).to have_tag('fieldset', with: { class: %w(govuk-fieldset) }) do
+            with_tag('span', text: caption_text, with: { class: caption_class })
+          end
+        end
+      end
+
+      context 'without a legend' do
+        let(:legend) { {} }
+
+        specify 'output should contain no caption at all' do
+          expect(subject).not_to have_tag('span', with: { class: caption_class })
+        end
+      end
+    end
+
+    context 'when a block containing radio buttons is supplied' do
       specify 'output should be a form group containing a form group and fieldset' do
         expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
           expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' })

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -14,6 +14,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     let(:aria_described_by_target) { 'select' }
 
     it_behaves_like 'a field that supports labels'
+    it_behaves_like 'a field that supports labels as procs'
 
     it_behaves_like 'a field that supports hints'
     it_behaves_like 'a field that supports custom branding'

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -14,6 +14,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     let(:aria_described_by_target) { 'select' }
 
     it_behaves_like 'a field that supports labels'
+    it_behaves_like 'a field that supports captions on the label'
     it_behaves_like 'a field that supports labels as procs'
 
     it_behaves_like 'a field that supports hints'

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -31,6 +31,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that supports setting the label via localisation'
+    it_behaves_like 'a field that supports setting the label caption via localisation'
     it_behaves_like 'a field that supports setting the hint via localisation'
 
     it_behaves_like 'a field that accepts a plain ruby object' do

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -60,6 +60,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   end
 
   it_behaves_like 'a field that supports setting the label via localisation'
+  it_behaves_like 'a field that supports setting the label caption via localisation'
   it_behaves_like 'a field that supports setting the hint via localisation'
 
   it_behaves_like 'a field that accepts a plain ruby object' do

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -41,6 +41,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   end
 
   it_behaves_like 'a field that supports labels', 'textarea'
+  it_behaves_like 'a field that supports captions on the label'
   it_behaves_like 'a field that supports labels as procs'
 
   it_behaves_like 'a field that supports hints' do

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -41,6 +41,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   end
 
   it_behaves_like 'a field that supports labels', 'textarea'
+  it_behaves_like 'a field that supports labels as procs'
 
   it_behaves_like 'a field that supports hints' do
     let(:aria_described_by_target) { 'textarea' }

--- a/spec/support/locales/sample.en.yaml
+++ b/spec/support/locales/sample.en.yaml
@@ -9,6 +9,14 @@ helpers:
       projects_options:
         11: Eleven
       photo: Upload a recent passport photo
+  caption:
+    person:
+      name: Personal information
+      favourite_colour: Aesthetic choices
+      photo: Personal appearance
+      cv: Background information
+      born_on: Required data
+      projects: Workplace data
   legend:
     person:
       favourite_colour: To which colours are you most partial?

--- a/spec/support/shared/shared_caption_examples.rb
+++ b/spec/support/shared/shared_caption_examples.rb
@@ -1,0 +1,69 @@
+shared_examples 'a field that supports captions' do
+  let(:caption_text) { 'Stage 3' }
+  let(:caption_class) { %(govuk-caption-#{caption_size}) }
+  let(:caption_size) { 'l' }
+  let(:caption_args) { { text: caption_text, size: caption_size } }
+
+  subject { builder.send(*args, caption: caption_args, **caption_container) }
+
+  describe 'inserting a caption' do
+    specify 'should contain the caption' do
+      expect(subject).to have_tag(caption_container_tag) do
+        with_tag('span', text: caption_text, with: { class: caption_class })
+      end
+    end
+
+    describe 'caption sizes' do
+      %w(xl l m).each do |size|
+        context %(when the caption size is #{size}) do
+          let(:caption_size) { size }
+          subject { builder.send(*args, **caption_container, caption: caption_args.merge(size: caption_size)) }
+
+          specify "the caption should be size #{size}" do
+            expect(subject).to have_tag('span', text: caption_text, with: { class: caption_class })
+          end
+        end
+      end
+
+      context 'when the caption size is invalid' do
+        let(:caption_size) { 'super-xxxl' }
+
+        specify 'should fail with an appropriate error message' do
+          expect { subject }.to raise_error(ArgumentError, %(invalid size '#{caption_size}', must be xl, l or m))
+        end
+      end
+    end
+  end
+end
+
+shared_examples 'a field that supports captions on the legend' do
+  it_behaves_like 'a field that supports captions' do
+    let(:caption_container_tag) { 'legend' }
+    let(:caption_container) { { legend: { text: legend_text, tag: caption_container_tag } } }
+
+    context 'when no legend is present but a caption is' do
+      subject { builder.send(*args, caption: caption_args) }
+
+      specify 'no caption should be rendered' do
+        expect(subject).not_to have_tag('span', with: { class: caption_class })
+      end
+    end
+  end
+end
+
+shared_examples 'a field that supports captions on the label' do
+  it_behaves_like 'a field that supports captions' do
+    let(:caption_container_tag) { 'label' }
+    let(:caption_container) { { label: { text: label_text, size: 'm' } } }
+
+    context 'when no label is present but a caption is' do
+      # Unlike the legend, labels will fall back to their attribute name, so we
+      # can only test against an empty label
+      subject { builder.send(*args, label: { text: '' }, caption: caption_args) }
+
+      specify 'no caption should be rendered' do
+        expect(subject).not_to have_tag('span', with: { class: caption_class })
+      end
+    end
+  end
+end

--- a/spec/support/shared/shared_label_examples.rb
+++ b/spec/support/shared/shared_label_examples.rb
@@ -69,45 +69,6 @@ shared_examples 'a field that supports labels' do
         end
       end
     end
-
-    context 'captions' do
-      let(:label_header_tag) { 'h3' }
-      let(:caption_args) { { text: caption_text, size: caption_size } }
-      subject { builder.send(*args, label: { text: label_text, tag: label_header_tag, caption: caption_args }) }
-
-      context 'when a label and caption are present' do
-        let(:caption_text) { 'Stage 3' }
-
-        describe 'inserting a caption' do
-          let(:caption_size) { 'l' }
-
-          specify 'should contain the caption' do
-            expect(subject).to have_tag(label_header_tag) do
-              with_tag('span', text: caption_text, with: { class: "govuk-caption-#{caption_size}" })
-            end
-          end
-        end
-
-        %w(xl l m).each do |size|
-          context %(when the caption size is #{size}) do
-            let(:caption_size) { size }
-            subject { builder.send(*args, label: { text: label_text, tag: label_header_tag, caption: caption_args.merge(size: caption_size) }) }
-
-            specify "the caption should be size #{size}" do
-              expect(subject).to have_tag('span', text: caption_text, with: { class: "govuk-caption-#{caption_size}" })
-            end
-          end
-        end
-
-        context 'when the caption size is invalid' do
-          let(:caption_size) { 'super-xxxl' }
-
-          specify 'should fail with an appropriate error message' do
-            expect { subject }.to raise_error(ArgumentError, %(invalid size '#{caption_size}', must be xl, l or m))
-          end
-        end
-      end
-    end
   end
 
   context 'when no label is provided' do

--- a/spec/support/shared/shared_label_examples.rb
+++ b/spec/support/shared/shared_label_examples.rb
@@ -79,3 +79,32 @@ shared_examples 'a field that supports labels' do
     end
   end
 end
+
+shared_examples 'a field that supports labels as procs' do
+  let(:caption_classes) { %w(govuk-caption-m) }
+  let(:heading_classes) { %w(govuk-heading-l) }
+  let(:caption) { %(Caption from the proc) }
+  let(:heading) { %(Heading from the proc) }
+
+  let(:label) do
+    proc do
+      builder.safe_join(
+        [
+          builder.tag.span(caption, class: caption_classes),
+          builder.tag.h1(heading, class: heading_classes)
+        ]
+      )
+    end
+  end
+
+  subject { builder.send(*args, label: label) }
+
+  specify 'output fieldset should contain the specified tag' do
+    expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
+      expect(fg).to have_tag('label', with: { class: 'govuk-label' }) do |fs|
+        expect(fs).to have_tag('span', class: caption_classes, text: caption)
+        expect(fs).to have_tag('h1', class: heading_classes, text: heading)
+      end
+    end
+  end
+end

--- a/spec/support/shared/shared_label_examples.rb
+++ b/spec/support/shared/shared_label_examples.rb
@@ -69,6 +69,45 @@ shared_examples 'a field that supports labels' do
         end
       end
     end
+
+    context 'captions' do
+      let(:label_header_tag) { 'h3' }
+      let(:caption_args) { { text: caption_text, size: caption_size } }
+      subject { builder.send(*args, label: { text: label_text, tag: label_header_tag, caption: caption_args }) }
+
+      context 'when a label and caption are present' do
+        let(:caption_text) { 'Stage 3' }
+
+        describe 'inserting a caption' do
+          let(:caption_size) { 'l' }
+
+          specify 'should contain the caption' do
+            expect(subject).to have_tag(label_header_tag) do
+              with_tag('span', text: caption_text, with: { class: "govuk-caption-#{caption_size}" })
+            end
+          end
+        end
+
+        %w(xl l m).each do |size|
+          context %(when the caption size is #{size}) do
+            let(:caption_size) { size }
+            subject { builder.send(*args, label: { text: label_text, tag: label_header_tag, caption: caption_args.merge(size: caption_size) }) }
+
+            specify "the caption should be size #{size}" do
+              expect(subject).to have_tag('span', text: caption_text, with: { class: "govuk-caption-#{caption_size}" })
+            end
+          end
+        end
+
+        context 'when the caption size is invalid' do
+          let(:caption_size) { 'super-xxxl' }
+
+          specify 'should fail with an appropriate error message' do
+            expect { subject }.to raise_error(ArgumentError, %(invalid size '#{caption_size}', must be xl, l or m))
+          end
+        end
+      end
+    end
   end
 
   context 'when no label is provided' do

--- a/spec/support/shared/shared_label_examples.rb
+++ b/spec/support/shared/shared_label_examples.rb
@@ -117,6 +117,12 @@ shared_examples 'a field that supports labels' do
       expect(subject).to have_tag('label', with: { class: 'govuk-label' }, text: attribute.capitalize)
     end
   end
+
+  context 'when something other than a Proc or Hash is supplied' do
+    subject { builder.send(*args, label: "This should fail") }
+
+    specify { expect { subject }.to raise_error(ArgumentError, 'label must be a Proc or Hash') }
+  end
 end
 
 shared_examples 'a field that supports labels as procs' do

--- a/spec/support/shared/shared_legend_examples.rb
+++ b/spec/support/shared/shared_legend_examples.rb
@@ -8,6 +8,12 @@ shared_examples 'a field that supports a fieldset with legend' do
       end
     end
 
+    context 'when something other than a Proc or Hash is supplied' do
+      subject { builder.send(*args, legend: "This should fail") }
+
+      specify { expect { subject }.to raise_error(ArgumentError, 'legend must be a Proc or Hash') }
+    end
+
     context 'when no text is supplied' do
       subject { builder.send(*args, legend: { text: nil }) }
 

--- a/spec/support/shared/shared_legend_examples.rb
+++ b/spec/support/shared/shared_legend_examples.rb
@@ -63,44 +63,6 @@ shared_examples 'a field that supports a fieldset with legend' do
       end
     end
 
-    context 'captions' do
-      let(:legend_header_tag) { 'h3' }
-      let(:caption_args) { { text: caption_text, size: caption_size } }
-      subject { builder.send(*args, legend: { text: legend_text, tag: legend_header_tag, caption: caption_args }) }
-
-      context 'when a legend and caption are present' do
-        let(:caption_text) { 'Stage 3' }
-
-        describe 'inserting a caption' do
-          let(:caption_size) { 'l' }
-          specify 'should contain the caption' do
-            expect(subject).to have_tag(legend_header_tag) do
-              with_tag('span', text: caption_text, with: { class: "govuk-caption-#{caption_size}" })
-            end
-          end
-        end
-
-        %w(xl l m).each do |size|
-          context %(when the caption size is #{size}) do
-            let(:caption_size) { size }
-            subject { builder.send(*args, legend: { text: legend_text, tag: legend_header_tag, caption: caption_args.merge(size: caption_size) }) }
-
-            specify "the caption should be size #{size}" do
-              expect(subject).to have_tag('span', text: caption_text, with: { class: "govuk-caption-#{caption_size}" })
-            end
-          end
-        end
-
-        context 'when the caption size is invalid' do
-          let(:caption_size) { 'super-xxxl' }
-
-          specify 'should fail with an appropriate error message' do
-            expect { subject }.to raise_error(ArgumentError, %(invalid size '#{caption_size}', must be xl, l or m))
-          end
-        end
-      end
-    end
-
     context 'when a proc is supplied' do
       let(:caption_classes) { %w(govuk-caption-m) }
       let(:heading_classes) { %w(govuk-heading-l) }

--- a/spec/support/shared/shared_legend_examples.rb
+++ b/spec/support/shared/shared_legend_examples.rb
@@ -57,6 +57,44 @@ shared_examples 'a field that supports a fieldset with legend' do
       end
     end
 
+    context 'captions' do
+      let(:legend_header_tag) { 'h3' }
+      let(:caption_args) { { text: caption_text, size: caption_size } }
+      subject { builder.send(*args, legend: { text: legend_text, tag: legend_header_tag, caption: caption_args }) }
+
+      context 'when a legend and caption are present' do
+        let(:caption_text) { 'Stage 3' }
+
+        describe 'inserting a caption' do
+          let(:caption_size) { 'l' }
+          specify 'should contain the caption' do
+            expect(subject).to have_tag(legend_header_tag) do
+              with_tag('span', text: caption_text, with: { class: "govuk-caption-#{caption_size}" })
+            end
+          end
+        end
+
+        %w(xl l m).each do |size|
+          context %(when the caption size is #{size}) do
+            let(:caption_size) { size }
+            subject { builder.send(*args, legend: { text: legend_text, tag: legend_header_tag, caption: caption_args.merge(size: caption_size) }) }
+
+            specify "the caption should be size #{size}" do
+              expect(subject).to have_tag('span', text: caption_text, with: { class: "govuk-caption-#{caption_size}" })
+            end
+          end
+        end
+
+        context 'when the caption size is invalid' do
+          let(:caption_size) { 'super-xxxl' }
+
+          specify 'should fail with an appropriate error message' do
+            expect { subject }.to raise_error(ArgumentError, %(invalid size '#{caption_size}', must be xl, l or m))
+          end
+        end
+      end
+    end
+
     context 'when a proc is supplied' do
       let(:caption_classes) { %w(govuk-caption-m) }
       let(:heading_classes) { %w(govuk-heading-l) }

--- a/spec/support/shared/shared_legend_examples.rb
+++ b/spec/support/shared/shared_legend_examples.rb
@@ -56,6 +56,35 @@ shared_examples 'a field that supports a fieldset with legend' do
         end
       end
     end
+
+    context 'when a proc is supplied' do
+      let(:caption_classes) { %w(govuk-caption-m) }
+      let(:heading_classes) { %w(govuk-heading-l) }
+      let(:caption) { %(Caption from the proc) }
+      let(:heading) { %(Heading from the proc) }
+
+      let(:legend) do
+        proc do
+          builder.safe_join(
+            [
+              builder.tag.span(caption, class: caption_classes),
+              builder.tag.h1(heading, class: heading_classes)
+            ]
+          )
+        end
+      end
+
+      subject { builder.send(*args, legend: legend) }
+
+      specify 'output fieldset should contain the specified tag' do
+        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
+          expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
+            expect(fs).to have_tag('span', class: caption_classes, text: caption)
+            expect(fs).to have_tag('h1', class: heading_classes, text: heading)
+          end
+        end
+      end
+    end
   end
 
   context 'when no legend is supplied' do

--- a/spec/support/shared/shared_localisation_examples.rb
+++ b/spec/support/shared/shared_localisation_examples.rb
@@ -9,6 +9,7 @@ shared_examples 'a field that supports setting the label via localisation' do
     let(:localisation_key) do
       defined?(value) ? "#{attribute}_options.#{value}" : attribute
     end
+
     let(:expected_label) do
       I18n.translate(localisation_key, scope: 'helpers.label.person')
     end
@@ -17,7 +18,8 @@ shared_examples 'a field that supports setting the label via localisation' do
 
     specify 'should set the label from the locales' do
       with_localisations(localisations) do
-        expect(subject).to have_tag('label', text: expected_label)
+        # wrap label assertation in a regexp because the caption is placed alongside the text
+        expect(subject).to have_tag('label', text: Regexp.new(expected_label))
       end
     end
   end
@@ -29,7 +31,72 @@ shared_examples 'a field that supports setting the label via localisation' do
 
     specify 'should use the supplied label text' do
       with_localisations(localisations) do
-        expect(subject).to have_tag('label', text: expected_label)
+        # wrap label assertation in a regexp because the caption is placed alongside the text
+        expect(subject).to have_tag('label', text: Regexp.new(expected_label))
+      end
+    end
+  end
+end
+
+shared_examples 'a field that supports setting the label caption via localisation' do
+  let(:localisations) { LOCALISATIONS }
+
+  context 'localising when no text is supplied' do
+    let(:localisation_key) { attribute }
+
+    let(:expected_caption) do
+      I18n.translate(localisation_key, scope: 'helpers.caption.person')
+    end
+
+    subject { builder.send(*args) }
+
+    specify 'should set the caption from the locales' do
+      with_localisations(localisations) do
+        expect(subject).to have_tag('span', text: expected_caption)
+      end
+    end
+  end
+
+  context 'allowing localised text to be overridden' do
+    let(:expected_caption) { "Private data" }
+
+    subject { builder.send(*args, caption: { text: expected_caption }) }
+
+    specify 'should use the supplied caption text' do
+      with_localisations(localisations) do
+        expect(subject).to have_tag('span', text: expected_caption)
+      end
+    end
+  end
+end
+
+shared_examples 'a field that supports setting the legend caption via localisation' do
+  let(:localisations) { LOCALISATIONS }
+
+  context 'localising when no text is supplied' do
+    let(:localisation_key) { attribute }
+
+    let(:expected_caption) do
+      I18n.translate(localisation_key, scope: 'helpers.caption.person')
+    end
+
+    subject { builder.send(*args) }
+
+    specify 'should set the caption from the locales' do
+      with_localisations(localisations) do
+        expect(subject).to have_tag('span', text: expected_caption)
+      end
+    end
+  end
+
+  context 'allowing localised text to be overridden' do
+    let(:expected_caption) { "Private data" }
+
+    subject { builder.send(*args, caption: { text: expected_caption }) }
+
+    specify 'should use the supplied caption text' do
+      with_localisations(localisations) do
+        expect(subject).to have_tag('span', text: expected_caption)
       end
     end
   end
@@ -78,7 +145,7 @@ shared_examples 'a field that supports setting the legend via localisation' do
       with_localisations(localisations) do
         expect(subject).to have_tag('fieldset') do
           with_tag('legend', with: { class: 'govuk-fieldset__legend' }) do
-            with_tag('h1', text: expected_legend, with: { class: 'govuk-fieldset__heading' })
+            with_tag('h1', text: Regexp.new(expected_legend), with: { class: 'govuk-fieldset__heading' })
           end
         end
       end
@@ -93,7 +160,7 @@ shared_examples 'a field that supports setting the legend via localisation' do
       with_localisations(localisations) do
         expect(subject).to have_tag('fieldset') do
           with_tag('legend', with: { class: 'govuk-fieldset__legend' }) do
-            with_tag('h1', text: expected_legend, with: { class: 'govuk-fieldset__heading' })
+            with_tag('h1', text: Regexp.new(expected_legend), with: { class: 'govuk-fieldset__heading' })
           end
         end
       end

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -23,6 +23,7 @@ shared_examples 'a regular input' do |method_identifier, field_type|
 
   it_behaves_like 'a field that supports labels'
   it_behaves_like 'a field that supports labels as procs'
+  it_behaves_like 'a field that supports captions on the label'
   it_behaves_like 'a field that supports hints'
   it_behaves_like 'a field that supports custom branding'
 

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -22,9 +22,8 @@ shared_examples 'a regular input' do |method_identifier, field_type|
   let(:aria_described_by_target) { 'input' }
 
   it_behaves_like 'a field that supports labels'
-
+  it_behaves_like 'a field that supports labels as procs'
   it_behaves_like 'a field that supports hints'
-
   it_behaves_like 'a field that supports custom branding'
 
   it_behaves_like 'a field that accepts arbitrary blocks of HTML' do

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -40,6 +40,7 @@ shared_examples 'a regular input' do |method_identifier, field_type|
   end
 
   it_behaves_like 'a field that supports setting the label via localisation'
+  it_behaves_like 'a field that supports setting the label caption via localisation'
   it_behaves_like 'a field that supports setting the hint via localisation'
 
   it_behaves_like 'a field that accepts a plain ruby object' do


### PR DESCRIPTION
This introduces the ability to set [captions](https://design-system.service.gov.uk/styles/typography/#headings-with-captions) via form builder labels and legends.

Two approaches are available.

### Built in

The simplest and most-common kind of captions, those that are **inside** the label/legend tag can be set by adding a `caption` argument to the `label` or `legend` options. The caption hash can take two values, `text` and `size`. The text will form the body of the caption and the size will set its size; [`xl`, `l` and `m` are the supported sizes](https://github.com/alphagov/govuk-frontend/blob/master/package/govuk/core/_typography.scss#L67).

### Using a proc

The more-flexible approach is to set the label content using a [proc](https://ruby-doc.org/core-2.7.1/Proc.html). Here, _any HTML_ can be placed in the legend or label, so this brings dangers in addition to opportunities. This approach is not recommended _unless there is a compelling reason_.

```ruby
module SomeHelper
  def description_legend
    content_tag(:h1, class: 'govuk-heading-l') do
      concat(tag.span("Description caption", class: 'govuk-caption-m'))
      concat('Description')
    end
  end
end
```

```slim
/ inside a form declaration
= form.govuk_text_area :description, label: -> { description_legend }
```

### Examples

Expanding on the above, here's an entire form rendered with captions. The first two elements use the built-in approach and the last two use procs.

```slim
= form_with(model: widget) do |form|

  = form.govuk_text_field :name,
    label: { tag: %(h3),
             size: %(l),
             caption: { text: %(Name caption),
                        size: %(m) } }

  = form.govuk_date_field :created_at,
    legend: { text: %(Created on),
              size: %(l),
              caption: { text: %(Created on caption), size: %(m) } }

  = form.govuk_text_area :description,
    label: -> { description_legend }

  = form.govuk_collection_radio_buttons :category_id,
    @categories,
    :id,
    :name,
    legend: -> { category_legend }

```

The above code renders a form that looks like this:

![Screenshot from 2020-05-29 15-51-22](https://user-images.githubusercontent.com/128088/83275030-82e71400-a1c6-11ea-94cc-2c1afde0c1e0.png)


### Tasks

* [x] Add the ability to specify captions for labels and legends
* [x] Allow labels and legends to be set via procs
* [x] Document label and legend proc behaviour
* [x] Add guide examples for label and legend procs
* [x] Ensure captions can be set via localisation
* [x] Add documentation for setting the caption to all relevant helper docs
* [x] Update the guide and add examples
* [x] Bring test coverage back up to 100%, there are two missing `else fail(ArgumentError, %(label must be a Proc or Hash))` case condition clauses - one in `Traits::Label` and the other in `Containers::Fieldset`

Fixes #133 