### PR TITLE
Upgrade to design system 3.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/fde73b5dc9476197281b/test_coverage)](https://codeclimate.com/github/DFE-Digital/govuk_design_system_formbuilder/test_coverage)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=DFE-Digital/govuk_design_system_formbuilder)](https://dependabot.com)
 [![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk_design_system_formbuilder)](https://github.com/DFE-Digital/govuk_design_system_formbuilder/blob/master/LICENSE)
-[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.6.0-brightgreen)](https://design-system.service.gov.uk)
+[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.7.0-brightgreen)](https://design-system.service.gov.uk)
 
 This gem provides a easy-to-use form builder that generates forms that are
-fully-compliant with version 3.6.0 of the [GOV.UK Design System](https://design-system.service.gov.uk/),
+fully-compliant with version 3.7.0 of the [GOV.UK Design System](https://design-system.service.gov.uk/),
 minimising the amount of markup you need to write.
 
 In addition to the basic markup, the more-advanced functionality of the Design

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -16,7 +16,7 @@ dl.govuk-summary-list
       ul.govuk-list
         li
           span.govuk-tag.govuk-tag-govuk
-            | Version 3.6.0
+            | Version 3.7.0
 
   .govuk-summary-list__row
     dt.govuk-summary-list__key

--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "govuk-frontend": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.6.0.tgz",
-      "integrity": "sha512-wTxufdY8vFvKJ2EmmQKmarrQ7n30kzg+vvqgGib2dawl7c5Wst8dffkEJQpy9Zs99TE/yEEFgj0VUO4GRUO22A=="
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.7.0.tgz",
+      "integrity": "sha512-G3bqoKGGF8YQ18UJH9tTARrwB8i7iPwN1xc8RXwWyx91q0p/Xl10uNywZLkzGWcJDzEz1vwmBTTL3SLDU/KxNg=="
     }
   }
 }

--- a/guide/package.json
+++ b/guide/package.json
@@ -12,6 +12,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "govuk-frontend": "^3.6.0"
+    "govuk-frontend": "^3.7.0"
   }
 }


### PR DESCRIPTION
There weren't any changes to form elements so this appears to be straightforward

https://github.com/alphagov/govuk-frontend/releases/tag/v3.7.0