### PR TITLE
Update rubocop-govuk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,5 @@ Style/SignalException:
   Enabled: false
 Style/AsciiComments:
   Enabled: false
+Style/FormatString:
+  EnforcedStyle: format

--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
     s.add_dependency(*VersionFormatter.new(lib, rails_version, exact_rails_version).to_a)
   end
 
-  s.add_development_dependency("rubocop-govuk", "= 3.9.0")
+  s.add_development_dependency("rubocop-govuk", "= 3.14.0")
   s.add_development_dependency("pry", "~> 0.13.0")
   s.add_development_dependency("pry-byebug", "~> 3.9", ">= 3.9.0")
   s.add_development_dependency("rspec-html-matchers", "~> 0")


### PR DESCRIPTION
This also includes the overriding of [one of the choices](https://github.com/alphagov/rubocop-govuk/pull/70) made by `rubocop-govuk` where `sprintf` is favoured over `format` :man_facepalming: 

