### PR TITLE
Disabled submit buttons

### DIFF
--- a/guide/content/form-elements/submit.slim
+++ b/guide/content/form-elements/submit.slim
@@ -36,6 +36,10 @@ section
     code: submit_button_without_double_click_prevention)
 
   == render('/partials/example-fig.*',
+    caption: "Generating a disabled submit button",
+    code: submit_button_disabled)
+
+  == render('/partials/example-fig.*',
     caption: "A submit button with an accompanying call to action",
     code: multiple_buttons) do
 

--- a/guide/lib/examples/submit.rb
+++ b/guide/lib/examples/submit.rb
@@ -20,6 +20,10 @@ module Examples
       "= f.govuk_submit prevent_double_click: false"
     end
 
+    def submit_button_disabled
+      "= f.govuk_submit 'Disabled button', disabled: true"
+    end
+
     def multiple_buttons
       <<~SNIPPET
         = f.govuk_submit 'Save and continue' do

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -677,8 +677,6 @@ module GOVUKDesignSystemFormBuilder
     # @param text [String] the button text
     # @param warning [Boolean] makes the button red ({https://design-system.service.gov.uk/components/button/#warning-buttons warning}) when true
     # @param secondary [Boolean] makes the button grey ({https://design-system.service.gov.uk/components/button/#secondary-buttons secondary}) when true
-    # @todo The GOV.UK design system also supports {https://design-system.service.gov.uk/components/button/#disabled-buttons disabled buttons}, they
-    #   should probably be supported too
     # @param classes [String] Classes to add to the submit button
     # @param prevent_double_click [Boolean] adds JavaScript to safeguard the
     #   form from being submitted more than once

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -685,6 +685,7 @@ module GOVUKDesignSystemFormBuilder
     # @param validate [Boolean] adds the formnovalidate to the submit button when true, this disables all
     #   client-side validation provided by the browser. This is to provide a more consistent and accessible user
     #   experience
+    # @param disabled [Boolean] makes the button disabled when true
     # @param block [Block] Any supplied HTML will be inserted immediately after
     #   the submit button. It is intended for other buttons directly related to
     #   the form's operation, such as 'Cancel' or 'Safe draft'
@@ -699,8 +700,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_submit "Proceed", prevent_double_click: true do
     #     = link_to 'Cancel', some_other_path, class: 'govuk-button__secondary'
     #
-    def govuk_submit(text = config.default_submit_button_text, warning: false, secondary: false, classes: nil, prevent_double_click: true, validate: false, &block)
-      Elements::Submit.new(self, text, warning: warning, secondary: secondary, classes: classes, prevent_double_click: prevent_double_click, validate: validate, &block).html
+    def govuk_submit(text = config.default_submit_button_text, warning: false, secondary: false, classes: nil, prevent_double_click: true, validate: false, disabled: false, &block)
+      Elements::Submit.new(self, text, warning: warning, secondary: secondary, classes: classes, prevent_double_click: prevent_double_click, validate: validate, disabled: disabled, &block).html
     end
 
     # Generates three inputs for the +day+, +month+ and +year+ components of a date

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -3,7 +3,7 @@ module GOVUKDesignSystemFormBuilder
     class Submit < Base
       using PrefixableArray
 
-      def initialize(builder, text, warning:, secondary:, classes:, prevent_double_click:, validate:, &block)
+      def initialize(builder, text, warning:, secondary:, classes:, prevent_double_click:, validate:, disabled:, &block)
         fail ArgumentError, 'buttons can be warning or secondary' if warning && secondary
 
         @builder              = builder
@@ -13,6 +13,7 @@ module GOVUKDesignSystemFormBuilder
         @secondary            = secondary
         @classes              = classes
         @validate             = validate
+        @disabled             = disabled
         @block_content        = capture { block.call } if block_given?
       end
 
@@ -49,12 +50,13 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def extra_args
+        disabled_hash = @disabled ? { disabled: 'disabled' } : {}
         {
           formnovalidate: !@validate,
           data: {
             module: %(#{brand}-button), 'prevent-double-click' => @prevent_double_click
           }.select { |_k, v| v.present? }
-        }
+        }.merge!(disabled_hash)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -55,13 +55,13 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def extra_args
-        disabled_hash = @disabled ? { disabled: 'disabled' } : {}
         {
           formnovalidate: !@validate,
+          disabled: @disabled,
           data: {
             module: %(#{brand}-button), 'prevent-double-click' => @prevent_double_click
           }.select { |_k, v| v.present? }
-        }.merge!(disabled_hash)
+        }
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -25,6 +25,7 @@ module GOVUKDesignSystemFormBuilder
               class: %w(button).prefix(brand).push(
                 warning_class,
                 secondary_class,
+                disabled_class,
                 @classes,
                 padding_class(@block_content.present?)
               ).compact,
@@ -47,6 +48,10 @@ module GOVUKDesignSystemFormBuilder
 
       def padding_class(content_present)
         %(#{brand}-!-margin-right-1) if content_present
+      end
+
+      def disabled_class
+        %(#{brand}-button--disabled) if @disabled
       end
 
       def extra_args

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -126,5 +126,23 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
     end
+
+    describe 'disabling button' do
+      context 'when disabled is false' do
+        subject { builder.send(*args.push('Create')) }
+
+        specify 'input should not have the disabled attribute' do
+          expect(parsed_subject.at_css('input').attributes.keys).not_to include('disabled')
+        end
+      end
+
+      context 'when disabled is true' do
+        subject { builder.send(*args.push('Create'), disabled: true) }
+
+        specify 'input should have the disabled attribute' do
+          expect(parsed_subject.at_css('input').attributes.keys).to include('disabled')
+        end
+      end
+    end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -141,6 +141,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
         specify 'input should have the disabled attribute' do
           expect(parsed_subject.at_css('input').attributes.keys).to include('disabled')
+          expect(subject).to have_tag('input', with: { class: %w(govuk-button govuk-button--disabled) })
         end
       end
     end


### PR DESCRIPTION
Strictly speaking, HTML requires just the `disabled` attribute to be present on the input element, but if it is present with a value it will have the same effect.

## In this PR
- Allow disabled attribute to be passed to the submit element
- Add disabled class to disabled elements
- Update guide