### PR TITLE
Some tidying up, refactoring and minor readability improvements

### DIFF
--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -18,6 +18,11 @@ module GOVUKDesignSystemFormBuilder
       @block_content  = capture { block.call } if block_given?
     end
 
+    # objects that implement #to_s can be passed directly into #safe_join
+    def to_s
+      html || ''
+    end
+
   private
 
     def brand(override = nil)

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -18,16 +18,16 @@ module GOVUKDesignSystemFormBuilder
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
           Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, caption: @caption, described_by: [error_element.error_id, hint_element.hint_id]).html do
-            safe_join(
-              [
-                hint_element.html,
-                error_element.html,
-                Containers::CheckBoxes.new(@builder, small: @small, classes: @classes).html do
-                  @block_content
-                end
-              ]
-            )
+            safe_join([hint_element, error_element, checkboxes])
           end
+        end
+      end
+
+    private
+
+      def checkboxes
+        Containers::CheckBoxes.new(@builder, small: @small, classes: @classes).html do
+          @block_content
         end
       end
     end

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -34,10 +34,10 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def legend_content
-        @legend_raw || build_legend
+        @legend_raw || legend
       end
 
-      def build_legend
+      def legend
         if legend_text.present?
           content_tag('legend', class: legend_classes) do
             content_tag(@legend_options.dig(:tag), class: legend_heading_classes) do

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -41,7 +41,7 @@ module GOVUKDesignSystemFormBuilder
         if legend_text.present?
           content_tag('legend', class: legend_classes) do
             content_tag(@legend_options.dig(:tag), class: legend_heading_classes) do
-              safe_join([caption_element.html, legend_text])
+              safe_join([caption_element, legend_text])
             end
           end
         end

--- a/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
@@ -19,16 +19,16 @@ module GOVUKDesignSystemFormBuilder
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
           Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, caption: @caption, described_by: [error_element.error_id, hint_element.hint_id]).html do
-            safe_join(
-              [
-                hint_element.html,
-                error_element.html,
-                Containers::Radios.new(@builder, inline: @inline, small: @small, classes: @classes).html do
-                  @block_content
-                end
-              ]
-            )
+            safe_join([hint_element, error_element, radios])
           end
+        end
+      end
+
+    private
+
+      def radios
+        Containers::Radios.new(@builder, inline: @inline, small: @small, classes: @classes).html do
+          @block_content
         end
       end
     end

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -23,7 +23,7 @@ module GOVUKDesignSystemFormBuilder
         def html
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
             Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, caption: @caption, described_by: [error_id, hint_id, supplemental_id]).html do
-              safe_join([supplemental_content.html, hint_element.html, error_element.html, check_boxes])
+              safe_join([supplemental_content, hint_element, error_element, check_boxes])
             end
           end
         end

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -23,21 +23,18 @@ module GOVUKDesignSystemFormBuilder
         def html
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
             Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, caption: @caption, described_by: [error_id, hint_id, supplemental_id]).html do
-              safe_join(
-                [
-                  supplemental_content.html,
-                  hint_element.html,
-                  error_element.html,
-                  Containers::CheckBoxes.new(@builder, small: @small, classes: @classes).html do
-                    build_collection
-                  end
-                ]
-              )
+              safe_join([supplemental_content.html, hint_element.html, error_element.html, check_boxes])
             end
           end
         end
 
       private
+
+        def check_boxes
+          Containers::CheckBoxes.new(@builder, small: @small, classes: @classes).html do
+            collection
+          end
+        end
 
         # Builds a collection of check {Elements::CheckBoxes::CheckBox}
         # @return [ActiveSupport::SafeBuffer] HTML output
@@ -47,7 +44,7 @@ module GOVUKDesignSystemFormBuilder
         #   be rendered when it happens we need to work on the chance that it might, so
         #   the +link_errors+ variable is set to +true+ if this attribute has errors and
         #   always set back to +false+ after the first checkbox has been rendered
-        def build_collection
+        def collection
           link_errors = has_errors?
 
           @builder.collection_check_boxes(@attribute_name, @collection, @value_method, @text_method) do |check_box|

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
@@ -10,30 +10,32 @@ module GOVUKDesignSystemFormBuilder
         def initialize(builder, object_name, attribute_name, checkbox, hint_method = nil, link_errors: false)
           super(builder, object_name, attribute_name)
 
-          @checkbox  = checkbox
-          @item      = checkbox.object
-          @value     = checkbox.value
-          @hint_text = retrieve(@item, hint_method)
+          @checkbox    = checkbox
+          @item        = checkbox.object
+          @value       = checkbox.value
+          @hint_text   = retrieve(@item, hint_method)
           @link_errors = link_errors
         end
 
         def html
           content_tag('div', class: %(#{brand}-checkboxes__item)) do
-            safe_join(
-              [
-                @checkbox.check_box(
-                  id: field_id(link_errors: @link_errors),
-                  class: %(#{brand}-checkboxes__input),
-                  aria: { describedby: hint_id }
-                ),
-                label_element.html,
-                hint_element.html
-              ]
-            )
+            safe_join([check_box, label_element.html, hint_element.html])
           end
         end
 
       private
+
+        def check_box
+          @checkbox.check_box(**check_box_options)
+        end
+
+        def check_box_options
+          {
+            id: field_id(link_errors: @link_errors),
+            class: %(#{brand}-checkboxes__input),
+            aria: { describedby: hint_id }
+          }
+        end
 
         def label_element
           @label_element ||= Label.new(@builder, @object_name, @attribute_name, @checkbox, value: @value, link_errors: @link_errors)

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
@@ -19,7 +19,7 @@ module GOVUKDesignSystemFormBuilder
 
         def html
           content_tag('div', class: %(#{brand}-checkboxes__item)) do
-            safe_join([check_box, label_element.html, hint_element.html])
+            safe_join([check_box, label_element, hint_element])
           end
         end
 

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -24,41 +24,33 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def html
-          safe_join(
-            [
-              content_tag('div', class: %(#{brand}-checkboxes__item)) do
-                safe_join(
-                  [
-                    input,
-                    label_element.html,
-                    hint_element.html,
-                  ]
-                )
-              end,
-              @conditional_content
-            ]
-          )
+          safe_join([check_box, @conditional_content])
         end
 
       private
 
+        def check_box
+          content_tag('div', class: %(#{brand}-checkboxes__item)) do
+            safe_join([input, label_element.html, hint_element.html])
+          end
+        end
+
         def input
-          @builder.check_box(
-            @attribute_name,
-            {
-              id: field_id(link_errors: @link_errors),
-              class: check_box_classes,
-              multiple: @multiple,
-              aria: { describedby: hint_id },
-              data: { 'aria-controls' => @conditional_id }
-            },
-            @value,
-            false
-          )
+          @builder.check_box(@attribute_name, input_options, @value, false)
+        end
+
+        def input_options
+          {
+            id: field_id(link_errors: @link_errors),
+            class: check_box_classes,
+            multiple: @multiple,
+            aria: { describedby: hint_id },
+            data: { 'aria-controls' => @conditional_id }
+          }
         end
 
         def label_element
-          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, checkbox: true, value: @value, link_errors: @link_errors, **label_args)
+          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, checkbox: true, value: @value, link_errors: @link_errors, **label_options)
         end
 
         def hint_element

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -31,7 +31,7 @@ module GOVUKDesignSystemFormBuilder
 
         def check_box
           content_tag('div', class: %(#{brand}-checkboxes__item)) do
-            safe_join([input, label_element.html, hint_element.html])
+            safe_join([input, label_element, hint_element])
           end
         end
 

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -22,7 +22,7 @@ module GOVUKDesignSystemFormBuilder
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
           Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, caption: @caption, described_by: [error_id, hint_id, supplemental_id]).html do
-            safe_join([supplemental_content.html, hint_element.html, error_element.html, date])
+            safe_join([supplemental_content, hint_element, error_element, date])
           end
         end
       end

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -22,21 +22,18 @@ module GOVUKDesignSystemFormBuilder
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
           Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, caption: @caption, described_by: [error_id, hint_id, supplemental_id]).html do
-            safe_join(
-              [
-                supplemental_content.html,
-                hint_element.html,
-                error_element.html,
-                content_tag('div', class: %(#{brand}-date-input)) do
-                  safe_join([day, month, year])
-                end
-              ]
-            )
+            safe_join([supplemental_content.html, hint_element.html, error_element.html, date])
           end
         end
       end
 
     private
+
+      def date
+        content_tag('div', class: %(#{brand}-date-input)) do
+          safe_join([day, month, year])
+        end
+      end
 
       def omit_day?
         @omit_day
@@ -45,18 +42,18 @@ module GOVUKDesignSystemFormBuilder
       def day
         return nil if omit_day?
 
-        date_input_item(:day, link_errors: true)
+        date_part_input(:day, link_errors: true)
       end
 
       def month
-        date_input_item(:month, link_errors: omit_day?)
+        date_part_input(:month, link_errors: omit_day?)
       end
 
       def year
-        date_input_item(:year, width: 4)
+        date_part_input(:year, width: 4)
       end
 
-      def date_input_item(segment, width: 2, link_errors: false)
+      def date_part_input(segment, width: 2, link_errors: false)
         value = @builder.object.try(@attribute_name).try(segment)
 
         content_tag('div', class: %w(date-input__item).prefix(brand)) do
@@ -65,14 +62,14 @@ module GOVUKDesignSystemFormBuilder
               [
                 tag.label(
                   segment.capitalize,
-                  class: date_input_label_classes,
-                  for: date_attribute_id(segment, link_errors)
+                  class: date_part_label_classes,
+                  for: date_part_attribute_id(segment, link_errors)
                 ),
 
                 tag.input(
-                  id: date_attribute_id(segment, link_errors),
-                  class: date_input_classes(width),
-                  name: date_attribute_name(segment),
+                  id: date_part_attribute_id(segment, link_errors),
+                  class: date_part_input_classes(width),
+                  name: date_part_attribute_name(segment),
                   type: 'text',
                   pattern: '[0-9]*',
                   inputmode: 'numeric',
@@ -85,21 +82,21 @@ module GOVUKDesignSystemFormBuilder
         end
       end
 
-      def date_input_classes(width)
+      def date_part_input_classes(width)
         %w(input date-input__input).prefix(brand).tap do |classes|
           classes.push(%(#{brand}-input--width-#{width}))
           classes.push(%(#{brand}-input--error)) if has_errors?
         end
       end
 
-      def date_input_label_classes
+      def date_part_label_classes
         %w(label date-input__label).prefix(brand)
       end
 
       # if the field has errors we want the govuk_error_summary to
       # be able to link to the day field. Otherwise, generate IDs
       # in the normal fashion
-      def date_attribute_id(segment, link_errors)
+      def date_part_attribute_id(segment, link_errors)
         if has_errors? && link_errors
           field_id(link_errors: link_errors)
         else
@@ -107,7 +104,7 @@ module GOVUKDesignSystemFormBuilder
         end
       end
 
-      def date_attribute_name(segment)
+      def date_part_attribute_name(segment)
         format(
           "%<object_name>s[%<attribute_name>s(%<segment>s)]",
           object_name: @object_name,

--- a/lib/govuk_design_system_formbuilder/elements/error_message.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_message.rb
@@ -13,16 +13,17 @@ module GOVUKDesignSystemFormBuilder
         return nil unless has_errors?
 
         content_tag('span', class: %(#{brand}-error-message), id: error_id) do
-          safe_join(
-            [
-              tag.span('Error: ', class: %(#{brand}-visually-hidden)),
-              message
-            ]
-          )
+          safe_join([error_prefix, error_message])
         end
       end
 
-      def message
+    private
+
+      def error_prefix
+        tag.span('Error: ', class: %(#{brand}-visually-hidden))
+      end
+
+      def error_message
         @builder.object.errors.messages[@attribute_name]&.first
       end
     end

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -12,43 +12,40 @@ module GOVUKDesignSystemFormBuilder
       def html
         return nil unless object_has_errors?
 
-        content_tag('div', class: summary_class, **error_summary_attributes) do
-          safe_join(
-            [
-              tag.h2(@title, id: error_summary_title_id, class: summary_class('title')),
-              content_tag('div', class: summary_class('body')) do
-                content_tag('ul', class: [%(#{brand}-list), summary_class('list')]) do
-                  safe_join(
-                    @builder.object.errors.messages.map do |attribute, messages|
-                      error_list_item(attribute, messages.first)
-                    end
-                  )
-                end
-              end
-            ]
-          )
+        content_tag('div', class: error_summary_class, **error_summary_options) do
+          safe_join([error_title, error_summary])
         end
       end
 
     private
 
-      def error_list_item(attribute, message)
-        content_tag('li') do
-          link_to(
-            message,
-            same_page_link(field_id(attribute)),
-            data: {
-              turbolinks: false
-            }
-          )
+      def error_title
+        tag.h2(@title, id: error_summary_title_id, class: error_summary_class('title'))
+      end
+
+      def error_summary
+        content_tag('div', class: error_summary_class('body')) do
+          content_tag('ul', class: [%(#{brand}-list), error_summary_class('list')]) do
+            safe_join(error_list)
+          end
         end
+      end
+
+      def error_list
+        @builder.object.errors.messages.map do |attribute, messages|
+          error_list_item(attribute, messages.first)
+        end
+      end
+
+      def error_list_item(attribute, message)
+        tag.li(link_to(message, same_page_link(field_id(attribute)), data: { turbolinks: false }))
       end
 
       def same_page_link(target)
         '#'.concat(target)
       end
 
-      def summary_class(part = nil)
+      def error_summary_class(part = nil)
         if part
           %(#{brand}-error-summary).concat('__', part)
         else
@@ -68,7 +65,7 @@ module GOVUKDesignSystemFormBuilder
         @builder.object.errors.any?
       end
 
-      def error_summary_attributes
+      def error_summary_options
         {
           tabindex: -1,
           role: 'alert',

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -19,7 +19,7 @@ module GOVUKDesignSystemFormBuilder
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-          safe_join([label_element.html, supplemental_content.html, hint_element.html, error_element.html, file])
+          safe_join([label_element, supplemental_content, hint_element, error_element, file])
         end
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -8,36 +8,34 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Label
       include Traits::Supplemental
 
-      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, **extra_args, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @label      = label
-        @caption    = caption
-        @hint_text  = hint_text
-        @extra_args = extra_args
+        @label         = label
+        @caption       = caption
+        @hint_text     = hint_text
+        @extra_options = kwargs
       end
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-          safe_join(
-            [
-              label_element.html,
-              supplemental_content.html,
-              hint_element.html,
-              error_element.html,
-              @builder.file_field(
-                @attribute_name,
-                id: field_id(link_errors: true),
-                class: file_classes,
-                aria: { describedby: described_by(hint_id, error_id, supplemental_id) },
-                **@extra_args
-              )
-            ]
-          )
+          safe_join([label_element.html, supplemental_content.html, hint_element.html, error_element.html, file])
         end
       end
 
     private
+
+      def file
+        @builder.file_field(@attribute_name, **file_options, **@extra_options)
+      end
+
+      def file_options
+        {
+          id: field_id(link_errors: true),
+          class: file_classes,
+          aria: { describedby: described_by(hint_id, error_id, supplemental_id) }
+        }
+      end
 
       def file_classes
         %w(file-upload).prefix(brand).tap do |c|

--- a/lib/govuk_design_system_formbuilder/elements/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/hint.rb
@@ -24,10 +24,7 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def hint_text(supplied)
-        [
-          supplied.presence,
-          localised_text(:hint)
-        ].compact.first
+        [supplied.presence, localised_text(:hint)].compact.first
       end
 
       def hint_classes

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -29,21 +29,16 @@ module GOVUKDesignSystemFormBuilder
         return nil if [@content, @text].all?(&:blank?)
 
         if @tag.present?
-          content_tag(@tag, class: %(#{brand}-label-wrapper)) { build_label }
+          content_tag(@tag, class: %(#{brand}-label-wrapper)) { label }
         else
-          build_label
+          label
         end
       end
 
     private
 
-      def build_label
-        @builder.label(
-          @attribute_name,
-          value: @value,
-          for: field_id(link_errors: @link_errors),
-          class: %w(label).prefix(brand).push(@size_class, @weight_class, @radio_class, @checkbox_class).compact
-        ) do
+      def label
+        @builder.label(@attribute_name, label_options) do
           @content || safe_join([caption_element.html, @text])
         end
       end
@@ -56,6 +51,14 @@ module GOVUKDesignSystemFormBuilder
         else
           text
         end
+      end
+
+      def label_options
+        {
+          value: @value,
+          for: field_id(link_errors: @link_errors),
+          class: %w(label).prefix(brand).push(@size_class, @weight_class, @radio_class, @checkbox_class).compact
+        }
       end
 
       def radio_class(radio)

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -25,36 +25,37 @@ module GOVUKDesignSystemFormBuilder
         def html
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
             Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, caption: @caption, described_by: [error_id, hint_id, supplemental_id]).html do
-              safe_join(
-                [
-                  supplemental_content.html,
-                  hint_element.html,
-                  error_element.html,
-                  Containers::Radios.new(@builder, inline: @inline, small: @small, classes: @classes).html do
-                    safe_join(build_collection)
-                  end
-                ]
-              )
+              safe_join([supplemental_content.html, hint_element.html, error_element.html, radios])
             end
           end
         end
 
       private
 
-        def build_collection
-          @collection.map.with_index do |item, i|
-            Elements::Radios::CollectionRadioButton.new(
-              @builder,
-              @object_name,
-              @attribute_name,
-              item,
-              value_method: @value_method,
-              text_method: @text_method,
-              hint_method: @hint_method,
-              link_errors: has_errors? && i.zero?,
-              bold_labels: @bold_labels
-            ).html
+        def radios
+          Containers::Radios.new(@builder, inline: @inline, small: @small, classes: @classes).html do
+            safe_join(collection)
           end
+        end
+
+        def collection
+          @collection.map.with_index do |item, i|
+            Elements::Radios::CollectionRadioButton.new(@builder, @object_name, @attribute_name, item, **collection_options(i)).html
+          end
+        end
+
+        def collection_options(index)
+          {
+            value_method: @value_method,
+            text_method: @text_method,
+            hint_method: @hint_method,
+            link_errors: link_errors?(index),
+            bold_labels: @bold_labels
+          }
+        end
+
+        def link_errors?(index)
+          has_errors? && index.zero?
         end
       end
     end

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -25,7 +25,7 @@ module GOVUKDesignSystemFormBuilder
         def html
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
             Containers::Fieldset.new(@builder, @object_name, @attribute_name, legend: @legend, caption: @caption, described_by: [error_id, hint_id, supplemental_id]).html do
-              safe_join([supplemental_content.html, hint_element.html, error_element.html, radios])
+              safe_join([supplemental_content, hint_element, error_element, radios])
             end
           end
         end

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
@@ -24,7 +24,7 @@ module GOVUKDesignSystemFormBuilder
 
         def html
           content_tag('div', class: %(#{brand}-radios__item)) do
-            safe_join([radio, label_element.html, hint_element.html])
+            safe_join([radio, label_element, hint_element])
           end
         end
 

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
@@ -24,23 +24,23 @@ module GOVUKDesignSystemFormBuilder
 
         def html
           content_tag('div', class: %(#{brand}-radios__item)) do
-            safe_join(
-              [
-                @builder.radio_button(
-                  @attribute_name,
-                  @value,
-                  id: field_id(link_errors: @link_errors),
-                  aria: { describedby: hint_id },
-                  class: %w(radios__input).prefix(brand)
-                ),
-                label_element.html,
-                hint_element.html
-              ]
-            )
+            safe_join([radio, label_element.html, hint_element.html])
           end
         end
 
       private
+
+        def radio
+          @builder.radio_button(@attribute_name, @value, **radio_options)
+        end
+
+        def radio_options
+          {
+            id: field_id(link_errors: @link_errors),
+            aria: { describedby: hint_id },
+            class: %w(radios__input).prefix(brand)
+          }
+        end
 
         def hint_element
           @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text, @value, radio: true)

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -23,26 +23,19 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def html
-          safe_join(
-            [
-              content_tag('div', class: %(#{brand}-radios__item)) do
-                safe_join(
-                  [
-                    input,
-                    label_element.html,
-                    hint_element.html,
-                  ]
-                )
-              end,
-              @conditional_content
-            ]
-          )
+          safe_join([radio, @conditional_content])
         end
 
       private
 
+        def radio
+          content_tag('div', class: %(#{brand}-radios__item)) do
+            safe_join([input, label_element.html, hint_element.html])
+          end
+        end
+
         def label_element
-          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, radio: true, value: @value, link_errors: @link_errors, **label_args)
+          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, radio: true, value: @value, link_errors: @link_errors, **label_options)
         end
 
         def hint_element
@@ -50,14 +43,16 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def input
-          @builder.radio_button(
-            @attribute_name,
-            @value,
+          @builder.radio_button(@attribute_name, @value, input_options)
+        end
+
+        def input_options
+          {
             id: field_id(link_errors: @link_errors),
             aria: { describedby: hint_id },
             data: { 'aria-controls' => @conditional_id },
             class: %w(radios__input).prefix(brand)
-          )
+          }
         end
 
         def conditional_classes

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -30,7 +30,7 @@ module GOVUKDesignSystemFormBuilder
 
         def radio
           content_tag('div', class: %(#{brand}-radios__item)) do
-            safe_join([input, label_element.html, hint_element.html])
+            safe_join([input, label_element, hint_element])
           end
         end
 

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -23,28 +23,17 @@ module GOVUKDesignSystemFormBuilder
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-          safe_join(
-            [
-              label_element.html,
-              supplemental_content.html,
-              hint_element.html,
-              error_element.html,
-              @builder.collection_select(
-                @attribute_name,
-                @collection,
-                @value_method,
-                @text_method,
-                @options,
-                build_html_options
-              )
-            ]
-          )
+          safe_join([label_element.html, supplemental_content.html, hint_element.html, error_element.html, select])
         end
       end
 
     private
 
-      def build_html_options
+      def select
+        @builder.collection_select(@attribute_name, @collection, @value_method, @text_method, @options, select_options)
+      end
+
+      def select_options
         @html_options.deep_merge(
           id: field_id(link_errors: true),
           class: select_classes,

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -23,7 +23,7 @@ module GOVUKDesignSystemFormBuilder
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-          safe_join([label_element.html, supplemental_content.html, hint_element.html, error_element.html, select])
+          safe_join([label_element, supplemental_content, hint_element, error_element, select])
         end
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -18,25 +18,29 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        safe_join(
-          [
-            @builder.submit(
-              @text,
-              class: %w(button).prefix(brand).push(
-                warning_class,
-                secondary_class,
-                disabled_class,
-                @classes,
-                padding_class(@block_content.present?)
-              ).compact,
-              **extra_args
-            ),
-            @block_content
-          ]
-        )
+        safe_join([submit, @block_content])
       end
 
     private
+
+      def submit
+        @builder.submit(@text, class: submit_classes, **submit_options)
+      end
+
+      def submit_classes
+        %w(button).prefix(brand).push(warning_class, secondary_class, disabled_class, @classes, padding_class(@block_content.present?))
+      end
+
+      def submit_options
+        {
+          formnovalidate: !@validate,
+          disabled: @disabled,
+          data: {
+            module: %(#{brand}-button),
+            'prevent-double-click': @prevent_double_click
+          }.select { |_k, v| v.present? }
+        }
+      end
 
       def warning_class
         %(#{brand}-button--warning) if @warning
@@ -52,16 +56,6 @@ module GOVUKDesignSystemFormBuilder
 
       def disabled_class
         %(#{brand}-button--disabled) if @disabled
-      end
-
-      def extra_args
-        {
-          formnovalidate: !@validate,
-          disabled: @disabled,
-          data: {
-            module: %(#{brand}-button), 'prevent-double-click' => @prevent_double_click
-          }.select { |_k, v| v.present? }
-        }
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -24,13 +24,7 @@ module GOVUKDesignSystemFormBuilder
       def html
         Containers::CharacterCount.new(@builder, max_words: @max_words, max_chars: @max_chars, threshold: @threshold).html do
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-            safe_join(
-              [
-                [label_element, supplemental_content, hint_element, error_element].map(&:html),
-                text_area,
-                limit_description
-              ]
-            )
+            safe_join([label_element, supplemental_content, hint_element, error_element, text_area, limit_description])
           end
         end
       end

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -8,13 +8,13 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Label
       include Traits::Supplemental
 
-      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, rows:, max_words:, max_chars:, threshold:, **extra_args, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, rows:, max_words:, max_chars:, threshold:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
         @label      = label
         @caption    = caption
         @hint_text  = hint_text
-        @extra_args = extra_args
+        @attributes = kwargs
         @max_words  = max_words
         @max_chars  = max_chars
         @threshold  = threshold
@@ -26,23 +26,10 @@ module GOVUKDesignSystemFormBuilder
           Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
             safe_join(
               [
-                [
-                  label_element,
-                  supplemental_content,
-                  hint_element,
-                  error_element
-                ].map(&:html),
-                @builder.text_area(
-                  @attribute_name,
-                  id: field_id(link_errors: true),
-                  class: govuk_textarea_classes,
-                  aria: {
-                    describedby: described_by(hint_id, error_id, supplemental_id, limit_description_id)
-                  },
-                  **@extra_args.merge(rows: @rows)
-                ),
+                [label_element, supplemental_content, hint_element, error_element].map(&:html),
+                text_area,
                 limit_description
-              ].flatten.compact
+              ]
             )
           end
         end
@@ -50,11 +37,23 @@ module GOVUKDesignSystemFormBuilder
 
     private
 
-      def govuk_textarea_classes
+      def text_area
+        @builder.text_area(@attribute_name, **text_area_options, **@attributes.merge(rows: @rows))
+      end
+
+      def text_area_classes
         %w(textarea).prefix(brand).tap do |classes|
           classes.push(%(#{brand}-textarea--error)) if has_errors?
           classes.push(%(#{brand}-js-character-count)) if limit?
         end
+      end
+
+      def text_area_options
+        {
+          id: field_id(link_errors: true),
+          class: text_area_classes,
+          aria: { describedby: described_by(hint_id, error_id, supplemental_id, limit_description_id) },
+        }
       end
 
       # Provides an id for use by the textual description of character and word limits.

--- a/lib/govuk_design_system_formbuilder/traits/caption.rb
+++ b/lib/govuk_design_system_formbuilder/traits/caption.rb
@@ -4,12 +4,11 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def caption_element
-        @caption_element ||= Elements::Caption.new(
-          @builder,
-          @object_name,
-          @attribute_name,
-          **{ text: nil }.merge({ text: caption_text, size: caption_size }.compact)
-        )
+        @caption_element ||= Elements::Caption.new(@builder, @object_name, @attribute_name, **caption_options)
+      end
+
+      def caption_options
+        { text: nil }.merge({ text: caption_text, size: caption_size }.compact)
       end
 
       def caption_text

--- a/lib/govuk_design_system_formbuilder/traits/input.rb
+++ b/lib/govuk_design_system_formbuilder/traits/input.rb
@@ -1,44 +1,35 @@
 module GOVUKDesignSystemFormBuilder
   module Traits
     module Input
-      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, width:, **extra_args, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, width:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @width          = width
-        @extra_args     = extra_args
-        @label          = label
-        @caption        = caption
-        @hint_text      = hint_text
+        @width      = width
+        @attributes = kwargs
+        @label      = label
+        @caption    = caption
+        @hint_text  = hint_text
       end
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-          safe_join(
-            [
-              label_element.html,
-              supplemental_content.html,
-              hint_element.html,
-              error_element.html,
-              @builder.send(
-                builder_method,
-                @attribute_name,
-                id: field_id(link_errors: true),
-                class: input_classes,
-                aria: {
-                  describedby: described_by(
-                    hint_id,
-                    error_id,
-                    supplemental_id
-                  )
-                },
-                **@extra_args
-              )
-            ]
-          )
+          safe_join([label_element.html, supplemental_content.html, hint_element.html, error_element.html, input])
         end
       end
 
     private
+
+      def input
+        @builder.send(builder_method, @attribute_name, **input_options.merge(@attributes))
+      end
+
+      def input_options
+        {
+          id: field_id(link_errors: true),
+          class: input_classes,
+          aria: { describedby: described_by(hint_id, error_id, supplemental_id) }
+        }
+      end
 
       def input_classes
         [%(#{brand}-input)].push(width_classes, error_classes).compact

--- a/lib/govuk_design_system_formbuilder/traits/input.rb
+++ b/lib/govuk_design_system_formbuilder/traits/input.rb
@@ -13,7 +13,7 @@ module GOVUKDesignSystemFormBuilder
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
-          safe_join([label_element.html, supplemental_content.html, hint_element.html, error_element.html, input])
+          safe_join([label_element, supplemental_content, hint_element, error_element, input])
         end
       end
 

--- a/lib/govuk_design_system_formbuilder/traits/label.rb
+++ b/lib/govuk_design_system_formbuilder/traits/label.rb
@@ -4,10 +4,10 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def label_element
-        @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, caption: @caption, **label_args)
+        @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, caption: @caption, **label_options)
       end
 
-      def label_args
+      def label_options
         case @label
         when Hash
           @label


### PR DESCRIPTION
This PR is a collection of refactorings and tidyings up.

* Simplify HTML construction by separating the bigger sets of nested blocks with indented hashes/arrays into smaller (saner) methods
* Add `GOVUKDesignSystemFormBuilder::Base#to_s` so we needn't call `#html` on every element we're passing into `#safe_join`
* Improve naming conventions:
  * `_args` methods are now `_options` as they return the _options_ used to configure Rails helpers
  * `extra_args` methods are now `kwargs` to make it more obvious that surplus keyword args are _converted_ to HTML attributes on the input we're generating
