### PR TITLE
Fix attributes with leading or trailing spaces

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -28,7 +28,10 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def submit_classes
-        %w(button).prefix(brand).push(warning_class, secondary_class, disabled_class, @classes, padding_class(@block_content.present?))
+        %w(button)
+          .prefix(brand)
+          .push(warning_class, secondary_class, disabled_class, @classes, padding_class(@block_content.present?))
+          .compact
       end
 
       def submit_options

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
@@ -20,6 +20,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
+    include_examples 'HTML formatting checks'
+
     it_behaves_like 'a field that supports custom branding'
 
     it_behaves_like 'a field that supports labels' do

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
@@ -17,6 +17,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
+    include_examples 'HTML formatting checks'
+
     it_behaves_like 'a field that supports a fieldset with legend' do
       let(:legend_text) { 'Which projects is this person assigned to?' }
     end

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
@@ -21,6 +21,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     subject { builder.send(*args, &example_block) }
 
+    include_examples 'HTML formatting checks'
+
     it_behaves_like 'a field that supports errors' do
       let(:error_message) { /Select at least one project/ }
       let(:error_class) { nil }

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -24,6 +24,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     let(:field_type) { 'input' }
     let(:aria_described_by_target) { 'fieldset' }
 
+    include_examples 'HTML formatting checks'
+
     it_behaves_like 'a field that supports hints'
 
     it_behaves_like 'a field that supports errors' do

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -10,6 +10,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     context 'when the object has errors' do
       before { object.valid? }
 
+      include_examples 'HTML formatting checks'
+
       specify 'the error summary should be present' do
         expect(subject).to have_tag('div', with: { class: 'govuk-error-summary' })
       end

--- a/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
@@ -14,6 +14,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       builder.send(method, legend: legend_options, &example_block)
     end
 
+    include_examples 'HTML formatting checks'
+
     specify 'output should be a fieldset containing the block contents' do
       expect(subject).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
         expect(fs).to have_tag('legend', text: legend_text)

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -18,6 +18,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
+    include_examples 'HTML formatting checks'
+
     it_behaves_like 'a field that supports labels'
     it_behaves_like 'a field that supports labels as procs'
     it_behaves_like 'a field that supports captions on the label'

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -23,6 +23,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
+    include_examples 'HTML formatting checks'
+
     it_behaves_like 'a field that supports custom branding'
 
     it_behaves_like 'a field that supports a fieldset with legend' do

--- a/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
@@ -24,6 +24,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       specify { expect { subject }.to raise_error(NoMethodError, /undefined method.*call/) }
     end
 
+    include_examples 'HTML formatting checks'
+
     it_behaves_like 'a field that supports errors' do
       let(:error_message) { /Choose a favourite colour/ }
       let(:error_class) { nil }

--- a/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
@@ -18,6 +18,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
+    include_examples 'HTML formatting checks'
+
     it_behaves_like 'a field that supports labels' do
       let(:label_text) { 'Red' }
       let(:field_type) { 'input' }

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -13,6 +13,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     let(:field_type) { 'select' }
     let(:aria_described_by_target) { 'select' }
 
+    include_examples 'HTML formatting checks'
+
     it_behaves_like 'a field that supports labels'
     it_behaves_like 'a field that supports captions on the label'
     it_behaves_like 'a field that supports labels as procs'

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -7,6 +7,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     let(:args) { [method] }
     subject { builder.send(method, text) }
 
+    include_examples 'HTML formatting checks'
+
     it_behaves_like 'a field that supports custom branding'
 
     specify 'output should be a submit input' do

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -36,6 +36,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
   end
 
+  include_examples 'HTML formatting checks'
+
   it_behaves_like 'a field that accepts arbitrary blocks of HTML' do
     let(:described_element) { 'textarea' }
   end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,6 +1,6 @@
 require 'rspec/expectations'
 
-RSpec::Matchers.define :have_root_element_with_class do |class_name|
+RSpec::Matchers.define(:have_root_element_with_class) do |class_name|
   # We're using xpath here because there's no sane way (ie without wrapping
   # everything in a useless element just for testing) of checking that elements
   # appear at the root of the fragment
@@ -15,4 +15,14 @@ RSpec::Matchers.define :have_root_element_with_class do |class_name|
     "expected that #{class_name} would be a class of a root element in fragment: #{nokogiri_fragment}"
   end
   #:nocov:
+end
+
+RSpec::Matchers.define(:have_no_leading_or_trailing_spaces) do
+  match do |string|
+    [string.start_with?(' '), string.end_with?(' ')].none?
+  end
+
+  failure_message do |failing_attribute|
+    %('#{failing_attribute}' has leading or trailing spaces)
+  end
 end

--- a/spec/support/shared/shared_html_formatting_examples.rb
+++ b/spec/support/shared/shared_html_formatting_examples.rb
@@ -1,0 +1,5 @@
+shared_examples 'HTML formatting checks' do
+  specify 'no attributes have leading or trailing spaces' do
+    expect(subject.scan(%r(="(.*?)")).flatten).to all(have_no_leading_or_trailing_spaces)
+  end
+end

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -21,6 +21,8 @@ shared_examples 'a regular input' do |method_identifier, field_type|
   let(:field_type) { 'input' }
   let(:aria_described_by_target) { 'input' }
 
+  include_examples 'HTML formatting checks'
+
   it_behaves_like 'a field that supports labels'
   it_behaves_like 'a field that supports labels as procs'
   it_behaves_like 'a field that supports captions on the label'


### PR DESCRIPTION
A _minor_ formatting bug was introduced in 5772f91 where a `#compact` was removed from an array which resulted in spaces being appended to the end of a class attribute on the submit button, as detailed in #146 

This PR adds shared examples that ensure no attribute has any leading or trailing spaces. Attributes are found using a regular expression that matches anything between two double quotes preceded by an `=`. This approach was chosen over the XPath method because XPath's matching for the root _and_ any child elements seems clunky. I'm no XPath expert but I can't see a way of matching the root, the child or any descendent without using a `or` like this, which is ugly AF:

```ruby
parsed_subject.xpath('*[@class]|/*[@class]|//*[@class]')
```
this approach would also mean we'd need to explicitly list attributes we want to check.

Happy to modify this if there's a nicer approach!


### Example RSpec output when leading or trailing spaces are detected

```
Failure/Error: expect(subject.scan(%r(="(.*?)")).flatten).to all(have_no_leading_or_trailing_spaces)

  expected ["govuk-error-summary", "-1", "alert", "govuk-error-summary ", "error-summary-title", "error-summary-...ite-colour-field-error", "false", "#person-projects-field-error", "false", "#person-cv-field-error"] to all have no leading or trailing spaces

    object at index 3 failed to match:
        'govuk-error-summary ' has leading or trailing spaces

```