### PR TITLE
Allow to set a default caption size via configuration

### DIFF
--- a/guide/content/introduction/configuration.slim
+++ b/guide/content/introduction/configuration.slim
@@ -23,6 +23,7 @@ p.govuk-body
           conf.default_error_summary_title  = 'Uh-oh, spaghettios'          # There is a problem
           conf.default_legend_tag           = 'h3'                          # h1
           conf.default_legend_size          = 'l'                           # m
+          conf.default_caption_size         = 'xl'                          # m
           conf.default_radio_divider_text   = 'how about'                   # or
 
           # localisation settings

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -14,6 +14,9 @@ module GOVUKDesignSystemFormBuilder
   # * +:brand+ sets the value used to prefix all classes, used to allow the
   #   builder to be branded for alternative (similar) design systems.
   #
+  # * +:default_caption_size+ controls the default size of caption text.
+  #   Can be either +xl+, +l+ or +m+.
+  #
   # * +:default_legend_size+ controls the default size of legend text.
   #   Can be either +xl+, +l+, +m+ or +s+.
   #
@@ -45,6 +48,7 @@ module GOVUKDesignSystemFormBuilder
 
     default_legend_size: 'm',
     default_legend_tag: 'h1',
+    default_caption_size: 'm',
     default_submit_button_text: 'Continue',
     default_radio_divider_text: 'or',
     default_error_summary_title: 'There is a problem',

--- a/lib/govuk_design_system_formbuilder/elements/caption.rb
+++ b/lib/govuk_design_system_formbuilder/elements/caption.rb
@@ -3,7 +3,7 @@ module GOVUKDesignSystemFormBuilder
     class Caption < Base
       include Traits::Localisation
 
-      def initialize(builder, object_name, attribute_name, text:, size: 'm')
+      def initialize(builder, object_name, attribute_name, text:, size: nil)
         super(builder, object_name, attribute_name)
 
         @text       = caption_text(text)
@@ -21,7 +21,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def caption_size_class(size)
-        case size
+        case size || config.default_caption_size
         when 'xl' then %(#{brand}-caption-xl)
         when 'l'  then %(#{brand}-caption-l)
         when 'm'  then %(#{brand}-caption-m)

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -22,7 +22,9 @@ RSpec::Matchers.define(:have_no_leading_or_trailing_spaces) do
     [string.start_with?(' '), string.end_with?(' ')].none?
   end
 
+  #:nocov:
   failure_message do |failing_attribute|
     %('#{failing_attribute}' has leading or trailing spaces)
   end
+  #:nocov:
 end

--- a/spec/support/shared/shared_caption_examples.rb
+++ b/spec/support/shared/shared_caption_examples.rb
@@ -25,6 +25,14 @@ shared_examples 'a field that supports captions' do
         end
       end
 
+      context 'when the caption size is not provided' do
+        let(:caption_args) { { text: caption_text } }
+
+        specify 'should use the default size' do
+          expect(subject).to have_tag('span', text: caption_text, with: { class: 'govuk-caption-m' })
+        end
+      end
+
       context 'when the caption size is invalid' do
         let(:caption_size) { 'super-xxxl' }
 


### PR DESCRIPTION
This follows the same pattern used for legends.

It is possible to set a default, project-wise, caption size by using the configuration block.

I've maintained the default as `m` (as that was the chosen size before, and also the default for legends) in order to not break any services that might be already using this size.

In our service the default for captions, as these are used in all cases with h1 page headers, will be `xl` and this PR will save us from having to manually specify the size in each page we use captions.

Note: I will be sending a separate PR in a few minutes for a separate issue we encounter with localisation of captions. But wanted to split the work for easier review.