### PR TITLE
Fix caption leaking its localisation to radio options

### DIFF
--- a/guide/lib/examples/localisation.rb
+++ b/guide/lib/examples/localisation.rb
@@ -33,6 +33,9 @@ module Examples
     def contact_type_locale
       <<~LOCALE
         helpers:
+          caption:
+            person:
+              contact_type: Contacting you
           legend:
             person:
               contact_type: What is your preferred method of contact?
@@ -61,6 +64,9 @@ module Examples
     def department_check_boxes_locale
       <<~LOCALE
         helpers:
+          caption:
+            person:
+              department_ids: Departments
           legend:
             person:
               department_ids: Which department do you work in?

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -39,7 +39,7 @@ module GOVUKDesignSystemFormBuilder
 
       def label
         @builder.label(@attribute_name, label_options) do
-          @content || safe_join([caption_html, @text])
+          @content || safe_join([caption, @text])
         end
       end
 
@@ -61,8 +61,8 @@ module GOVUKDesignSystemFormBuilder
         }
       end
 
-      def caption_html
-        caption_element.html if [@radio_class, @checkbox_class].all?(nil)
+      def caption
+        caption_element.html unless [@radio_class, @checkbox_class].any?
       end
 
       def radio_class(radio)

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -39,7 +39,7 @@ module GOVUKDesignSystemFormBuilder
 
       def label
         @builder.label(@attribute_name, label_options) do
-          @content || safe_join([caption_element.html, @text])
+          @content || safe_join([caption_html, @text])
         end
       end
 
@@ -59,6 +59,10 @@ module GOVUKDesignSystemFormBuilder
           for: field_id(link_errors: @link_errors),
           class: %w(label).prefix(brand).push(@size_class, @weight_class, @radio_class, @checkbox_class).compact
         }
+      end
+
+      def caption_html
+        caption_element.html if [@radio_class, @checkbox_class].all?(nil)
       end
 
       def radio_class(radio)


### PR DESCRIPTION
We run into a problem when using the new [captions capability](https://github.com/DFE-Digital/govuk_design_system_formbuilder/pull/135) of the gem where the localised caption of `govuk_collection_radio_buttons` or `govuk_radio_buttons_fieldset` will leak also to each of their corresponding radio option labels.

I think there is not a use-case to use captions in the labels of individual radio or check box options and couldn't find anything in the design system documentation about this, so I opted for the simplest possible solution, but if in the future there is a use-case for having captions also in these option labels, then I suppose a bit of work is neccessary in the localisation to not inherit that of the fieldset.

I didn't see this happening to check boxes, at least in the scenarios I have, but just in case I'm also excluding these check boxes from being "captionable".

Before:
<img width="664" alt="Screen Shot 2020-06-26 at 12 48 57" src="https://user-images.githubusercontent.com/687910/85856218-86fb5700-b7af-11ea-9d91-6cb306221a73.png">

After:
<img width="609" alt="Screen Shot 2020-06-26 at 12 53 18" src="https://user-images.githubusercontent.com/687910/85856232-8c58a180-b7af-11ea-9ddf-c52807a223b6.png">