### PR TITLE
Ensure no HTML attributes contain double spaces

### DIFF
--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -28,3 +28,13 @@ RSpec::Matchers.define(:have_no_leading_or_trailing_spaces) do
   end
   #:nocov:
 end
+
+RSpec::Matchers.define(:have_no_double_spaces) do
+  match { |string| string !~ %r(\s{2}) }
+
+  #:nocov:
+  failure_message do |failing_attribute|
+    %('#{failing_attribute}' has double spaces)
+  end
+  #:nocov:
+end

--- a/spec/support/shared/shared_html_formatting_examples.rb
+++ b/spec/support/shared/shared_html_formatting_examples.rb
@@ -2,4 +2,8 @@ shared_examples 'HTML formatting checks' do
   specify 'no attributes have leading or trailing spaces' do
     expect(subject.scan(%r(="(.*?)")).flatten).to all(have_no_leading_or_trailing_spaces)
   end
+
+  specify 'no attributes have double spaces' do
+    expect(subject.scan(%r(="(.*?)")).flatten).to all(have_no_double_spaces)
+  end
 end


### PR DESCRIPTION
Following on from the new formatting checks added in #147 this spec ensures that attributes are correctly-spaced with a single ' '. This should highlight any failings to call #compact on arrays of `class` or `aria-describedby` values.