### PR TITLE
Yet more refactoring

### DIFF
--- a/lib/govuk_design_system_formbuilder/containers/character_count.rb
+++ b/lib/govuk_design_system_formbuilder/containers/character_count.rb
@@ -14,12 +14,12 @@ module GOVUKDesignSystemFormBuilder
       def html
         return yield unless limit?
 
-        content_tag('div', **character_count_options) { yield }
+        content_tag('div', **options) { yield }
       end
 
     private
 
-      def character_count_options
+      def options
         {
           class: %(#{brand}-character-count),
           data: { module: %(#{brand}-character-count) }.merge(**limit, **threshold).compact

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
@@ -8,9 +8,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        content_tag('div', **options) do
-          yield
-        end
+        content_tag('div', **options) { yield }
       end
 
     private

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
@@ -1,8 +1,6 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
     class CheckBoxes < Base
-      using PrefixableArray
-
       def initialize(builder, small:, classes: nil)
         @builder = builder
         @small   = small
@@ -10,25 +8,26 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        content_tag('div', **check_boxes_options) do
+        content_tag('div', **options) do
           yield
         end
       end
 
     private
 
-      def check_boxes_options
+      def options
         {
-          class: check_boxes_classes,
+          class: classes,
           data: { module: %(#{brand}-checkboxes) }
         }
       end
 
-      def check_boxes_classes
-        %w(checkboxes).prefix(brand).tap do |c|
-          c.push(%(#{brand}-checkboxes--small)) if @small
-          c.push(@classes) if @classes
-        end
+      def classes
+        [%(#{brand}-checkboxes), small_class, @classes].compact
+      end
+
+      def small_class
+        %(#{brand}-checkboxes--small) if @small
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -1,33 +1,18 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
     class Fieldset < Base
-      using PrefixableArray
-
-      include Traits::Caption
-      include Traits::Localisation
-
-      LEGEND_SIZES = %w(xl l m s).freeze
-
       def initialize(builder, object_name = nil, attribute_name = nil, legend: {}, caption: {}, described_by: nil, &block)
         super(builder, object_name, attribute_name, &block)
 
+        @legend         = legend
+        @caption        = caption
         @described_by   = described_by(described_by)
         @attribute_name = attribute_name
-
-        case legend
-        when Proc
-          @legend_raw = legend.call
-        when Hash
-          @legend_options = legend_defaults.merge(legend)
-          @caption        = caption
-        else
-          fail(ArgumentError, %(legend must be a Proc or Hash))
-        end
       end
 
       def html
         content_tag('fieldset', **fieldset_options) do
-          safe_join([legend, (@block_content || yield)])
+          safe_join([legend_element, (@block_content || yield)])
         end
       end
 
@@ -41,50 +26,15 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def fieldset_classes
-        %w(fieldset).prefix(brand)
+        %(#{brand}-fieldset)
       end
 
-      def legend
-        @legend_raw || legend_content
+      def legend_element
+        @legend_element ||= Elements::Legend.new(@builder, @object_name, @attribute_name, **legend_options)
       end
 
-      def legend_content
-        if legend_text.present?
-          content_tag('legend', class: legend_classes) do
-            content_tag(@legend_options.dig(:tag), class: legend_heading_classes) do
-              safe_join([caption_element, legend_text])
-            end
-          end
-        end
-      end
-
-      def legend_text
-        @legend_options.dig(:text) || localised_text(:legend)
-      end
-
-      def legend_size
-        @legend_options.dig(:size).tap do |size|
-          fail "invalid size '#{size}', must be #{LEGEND_SIZES.join(', ')}" unless size.in?(LEGEND_SIZES)
-        end
-      end
-
-      def legend_classes
-        [%(fieldset__legend), %(fieldset__legend--#{legend_size})].prefix(brand).tap do |classes|
-          classes.push(%(#{brand}-visually-hidden)) if @legend_options.dig(:hidden)
-        end
-      end
-
-      def legend_heading_classes
-        %w(fieldset__heading).prefix(brand)
-      end
-
-      def legend_defaults
-        {
-          hidden: false,
-          text: nil,
-          tag:  config.default_legend_tag,
-          size: config.default_legend_size
-        }
+      def legend_options
+        { legend: @legend, caption: @caption }
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -11,21 +11,21 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        content_tag('fieldset', **fieldset_options) do
+        content_tag('fieldset', **options) do
           safe_join([legend_element, (@block_content || yield)])
         end
       end
 
     private
 
-      def fieldset_options
+      def options
         {
-          class: fieldset_classes,
+          class: classes,
           aria: { describedby: @described_by }
         }
       end
 
-      def fieldset_classes
+      def classes
         %(#{brand}-fieldset)
       end
 

--- a/lib/govuk_design_system_formbuilder/containers/form_group.rb
+++ b/lib/govuk_design_system_formbuilder/containers/form_group.rb
@@ -6,9 +6,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        content_tag('div', class: classes) do
-          yield
-        end
+        content_tag('div', class: classes) { yield }
       end
 
     private

--- a/lib/govuk_design_system_formbuilder/containers/form_group.rb
+++ b/lib/govuk_design_system_formbuilder/containers/form_group.rb
@@ -1,24 +1,28 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
     class FormGroup < Base
-      using PrefixableArray
-
       def initialize(builder, object_name, attribute_name)
         super(builder, object_name, attribute_name)
       end
 
       def html
-        content_tag('div', class: form_group_classes) do
+        content_tag('div', class: classes) do
           yield
         end
       end
 
     private
 
-      def form_group_classes
-        %w(form-group).prefix(brand).tap do |classes|
-          classes.push(%(#{brand}-form-group--error)) if has_errors?
-        end
+      def classes
+        [form_group_class, error_class].compact
+      end
+
+      def form_group_class
+        %(#{brand}-form-group)
+      end
+
+      def error_class
+        %(#{brand}-form-group--error) if has_errors?
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/containers/radios.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radios.rb
@@ -11,9 +11,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        content_tag('div', **options) do
-          yield
-        end
+        content_tag('div', **options) { yield }
       end
 
     private

--- a/lib/govuk_design_system_formbuilder/containers/radios.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radios.rb
@@ -1,8 +1,6 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
     class Radios < Base
-      using PrefixableArray
-
       include Traits::Hint
 
       def initialize(builder, inline:, small:, classes:)
@@ -13,26 +11,30 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        content_tag('div', **radios_options) do
+        content_tag('div', **options) do
           yield
         end
       end
 
     private
 
-      def radios_options
+      def options
         {
-          class: radios_classes,
+          class: classes,
           data: { module: %(#{brand}-radios) }
         }
       end
 
-      def radios_classes
-        %w(radios).prefix(brand).tap do |c|
-          c.push(%(#{brand}-radios--inline)) if @inline
-          c.push(%(#{brand}-radios--small))  if @small
-          c.push(@classes)                   if @classes
-        end
+      def classes
+        [%(#{brand}-radios), inline_class, small_class, @classes].compact
+      end
+
+      def inline_class
+        %(#{brand}-radios--inline) if @inline
+      end
+
+      def small_class
+        %(#{brand}-radios--small)  if @small
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/containers/supplemental.rb
+++ b/lib/govuk_design_system_formbuilder/containers/supplemental.rb
@@ -13,6 +13,8 @@ module GOVUKDesignSystemFormBuilder
         content_tag('div', id: supplemental_id) { @content }
       end
 
+    private
+
       def supplemental_id
         build_id('supplemental')
       end

--- a/lib/govuk_design_system_formbuilder/elements/caption.rb
+++ b/lib/govuk_design_system_formbuilder/elements/caption.rb
@@ -6,8 +6,8 @@ module GOVUKDesignSystemFormBuilder
       def initialize(builder, object_name, attribute_name, text:, size: nil)
         super(builder, object_name, attribute_name)
 
-        @text       = caption_text(text)
-        @size_class = caption_size_class(size)
+        @text       = text(text)
+        @size_class = size_class(size)
       end
 
       def html
@@ -18,11 +18,11 @@ module GOVUKDesignSystemFormBuilder
 
     private
 
-      def caption_text(override)
+      def text(override)
         override || localised_text(:caption)
       end
 
-      def caption_size_class(size)
+      def size_class(size)
         case size || config.default_caption_size
         when 'xl' then %(#{brand}-caption-xl)
         when 'l'  then %(#{brand}-caption-l)

--- a/lib/govuk_design_system_formbuilder/elements/caption.rb
+++ b/lib/govuk_design_system_formbuilder/elements/caption.rb
@@ -16,6 +16,8 @@ module GOVUKDesignSystemFormBuilder
         tag.span(@text, class: @size_class)
       end
 
+    private
+
       def caption_text(override)
         override || localised_text(:caption)
       end

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
@@ -26,10 +26,10 @@ module GOVUKDesignSystemFormBuilder
       private
 
         def check_box
-          @checkbox.check_box(**check_box_options)
+          @checkbox.check_box(**options)
         end
 
-        def check_box_options
+        def options
           {
             id: field_id(link_errors: @link_errors),
             class: %(#{brand}-checkboxes__input),

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -24,29 +24,33 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def html
-          safe_join([check_box, @conditional_content])
+          safe_join([item, @conditional_content])
         end
 
       private
 
-        def check_box
+        def item
           content_tag('div', class: %(#{brand}-checkboxes__item)) do
-            safe_join([input, label_element, hint_element])
+            safe_join([check_box, label_element, hint_element])
           end
         end
 
-        def input
-          @builder.check_box(@attribute_name, input_options, @value, false)
+        def check_box
+          @builder.check_box(@attribute_name, options, @value, false)
         end
 
-        def input_options
+        def options
           {
             id: field_id(link_errors: @link_errors),
-            class: check_box_classes,
+            class: classes,
             multiple: @multiple,
             aria: { describedby: hint_id },
             data: { 'aria-controls' => @conditional_id }
           }
+        end
+
+        def classes
+          %w(checkboxes__input).prefix(brand)
         end
 
         def label_element
@@ -63,10 +67,6 @@ module GOVUKDesignSystemFormBuilder
 
         def conditional_classes
           %w(checkboxes__conditional checkboxes__conditional--hidden).prefix(brand)
-        end
-
-        def check_box_classes
-          %w(checkboxes__input).prefix(brand)
         end
       end
     end

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -71,15 +71,15 @@ module GOVUKDesignSystemFormBuilder
         tag.label(
           segment.capitalize,
           class: label_classes,
-          for: input_id(segment, link_errors)
+          for: id(segment, link_errors)
         )
       end
 
       def input(segment, link_errors, width, value)
         tag.input(
-          id: input_id(segment, link_errors),
-          class: input_classes(width),
-          name: input_name(segment),
+          id: id(segment, link_errors),
+          class: classes(width),
+          name: name(segment),
           type: 'text',
           pattern: '[0-9]*',
           inputmode: 'numeric',
@@ -88,21 +88,17 @@ module GOVUKDesignSystemFormBuilder
         )
       end
 
-      def input_classes(width)
+      def classes(width)
         %w(input date-input__input).prefix(brand).tap do |classes|
           classes.push(%(#{brand}-input--width-#{width}))
           classes.push(%(#{brand}-input--error)) if has_errors?
         end
       end
 
-      def label_classes
-        %w(label date-input__label).prefix(brand)
-      end
-
       # if the field has errors we want the govuk_error_summary to
       # be able to link to the day field. Otherwise, generate IDs
       # in the normal fashion
-      def input_id(segment, link_errors)
+      def id(segment, link_errors)
         if has_errors? && link_errors
           field_id(link_errors: link_errors)
         else
@@ -110,7 +106,7 @@ module GOVUKDesignSystemFormBuilder
         end
       end
 
-      def input_name(segment)
+      def name(segment)
         format(
           "%<object_name>s[%<input_name>s(%<segment>s)]",
           object_name: @object_name,
@@ -123,6 +119,10 @@ module GOVUKDesignSystemFormBuilder
         return nil unless @date_of_birth
 
         { day: 'bday-day', month: 'bday-month', year: 'bday-year' }.fetch(segment)
+      end
+
+      def label_classes
+        %w(label date-input__label).prefix(brand)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/error_message.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_message.rb
@@ -13,17 +13,17 @@ module GOVUKDesignSystemFormBuilder
         return nil unless has_errors?
 
         content_tag('span', class: %(#{brand}-error-message), id: error_id) do
-          safe_join([error_prefix, error_message])
+          safe_join([prefix, message])
         end
       end
 
     private
 
-      def error_prefix
+      def prefix
         tag.span('Error: ', class: %(#{brand}-visually-hidden))
       end
 
-      def error_message
+      def message
         @builder.object.errors.messages[@attribute_name]&.first
       end
     end

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -12,32 +12,32 @@ module GOVUKDesignSystemFormBuilder
       def html
         return nil unless object_has_errors?
 
-        content_tag('div', class: error_summary_class, **error_summary_options) do
-          safe_join([error_title, error_summary])
+        content_tag('div', class: summary_class, **summary_options) do
+          safe_join([title, summary])
         end
       end
 
     private
 
-      def error_title
-        tag.h2(@title, id: error_summary_title_id, class: error_summary_class('title'))
+      def title
+        tag.h2(@title, id: summary_title_id, class: summary_class('title'))
       end
 
-      def error_summary
-        content_tag('div', class: error_summary_class('body')) do
-          content_tag('ul', class: [%(#{brand}-list), error_summary_class('list')]) do
-            safe_join(error_list)
+      def summary
+        content_tag('div', class: summary_class('body')) do
+          content_tag('ul', class: [%(#{brand}-list), summary_class('list')]) do
+            safe_join(list)
           end
         end
       end
 
-      def error_list
+      def list
         @builder.object.errors.messages.map do |attribute, messages|
-          error_list_item(attribute, messages.first)
+          list_item(attribute, messages.first)
         end
       end
 
-      def error_list_item(attribute, message)
+      def list_item(attribute, message)
         tag.li(link_to(message, same_page_link(field_id(attribute)), data: { turbolinks: false }))
       end
 
@@ -45,7 +45,7 @@ module GOVUKDesignSystemFormBuilder
         '#'.concat(target)
       end
 
-      def error_summary_class(part = nil)
+      def summary_class(part = nil)
         if part
           %(#{brand}-error-summary).concat('__', part)
         else
@@ -57,7 +57,7 @@ module GOVUKDesignSystemFormBuilder
         build_id('field-error', attribute_name: attribute)
       end
 
-      def error_summary_title_id
+      def summary_title_id
         'error-summary-title'
       end
 
@@ -65,7 +65,7 @@ module GOVUKDesignSystemFormBuilder
         @builder.object.errors.any?
       end
 
-      def error_summary_options
+      def summary_options
         {
           tabindex: -1,
           role: 'alert',
@@ -73,7 +73,7 @@ module GOVUKDesignSystemFormBuilder
             module: %(#{brand}-error-summary)
           },
           aria: {
-            labelledby: error_summary_title_id
+            labelledby: summary_title_id
           }
         }
       end

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -26,18 +26,18 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def file
-        @builder.file_field(@attribute_name, **file_options, **@extra_options)
+        @builder.file_field(@attribute_name, **options, **@extra_options)
       end
 
-      def file_options
+      def options
         {
           id: field_id(link_errors: true),
-          class: file_classes,
+          class: classes,
           aria: { describedby: described_by(hint_id, error_id, supplemental_id) }
         }
       end
 
-      def file_classes
+      def classes
         %w(file-upload).prefix(brand).tap do |c|
           c.push(%(#{brand}-file-upload--error)) if has_errors?
         end

--- a/lib/govuk_design_system_formbuilder/elements/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/hint.rb
@@ -10,7 +10,7 @@ module GOVUKDesignSystemFormBuilder
         super(builder, object_name, attribute_name)
 
         @value     = value
-        @hint_text = hint_text(text)
+        @hint_text = retrieve_text(text)
         @radio     = radio
         @checkbox  = checkbox
       end
@@ -18,16 +18,16 @@ module GOVUKDesignSystemFormBuilder
       def html
         return nil if @hint_text.blank?
 
-        tag.span(@hint_text, class: hint_classes, id: hint_id)
+        tag.span(@hint_text, class: classes, id: hint_id)
       end
 
     private
 
-      def hint_text(supplied)
+      def retrieve_text(supplied)
         supplied.presence || localised_text(:hint)
       end
 
-      def hint_classes
+      def classes
         %w(hint).prefix(brand).push(radio_class, checkbox_class).compact
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/inputs/email.rb
+++ b/lib/govuk_design_system_formbuilder/elements/inputs/email.rb
@@ -10,6 +10,8 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Label
         include Traits::Supplemental
 
+      private
+
         def builder_method
           :email_field
         end

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -79,11 +79,11 @@ module GOVUKDesignSystemFormBuilder
 
       def label_size_class(size)
         case size
-        when 'xl'      then %(#{brand}-label--xl)
-        when 'l'       then %(#{brand}-label--l)
-        when 'm'       then %(#{brand}-label--m)
-        when 's'       then %(#{brand}-label--s)
-        when nil       then nil
+        when 'xl' then %(#{brand}-label--xl)
+        when 'l'  then %(#{brand}-label--l)
+        when 'm'  then %(#{brand}-label--m)
+        when 's'  then %(#{brand}-label--s)
+        when nil  then nil
         else
           fail "invalid size '#{size}', must be xl, l, m, s or nil"
         end

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -15,8 +15,8 @@ module GOVUKDesignSystemFormBuilder
           @content = content.call
         else
           @value       = value # used by field_id
-          @text        = label_text(text, hidden)
-          @size_class  = label_size_class(size)
+          @text        = retrieve_text(text, hidden)
+          @size_class  = size_class(size)
           @radio       = radio
           @checkbox    = checkbox
           @tag         = tag
@@ -38,12 +38,12 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def label
-        @builder.label(@attribute_name, **label_options) do
+        @builder.label(@attribute_name, **options) do
           @content || safe_join([caption, @text])
         end
       end
 
-      def label_text(option_text, hidden)
+      def retrieve_text(option_text, hidden)
         text = [option_text, localised_text(:label), @attribute_name.capitalize].compact.first.to_s
 
         if hidden
@@ -53,7 +53,7 @@ module GOVUKDesignSystemFormBuilder
         end
       end
 
-      def label_options
+      def options
         {
           value: @value,
           for: field_id(link_errors: @link_errors),
@@ -77,7 +77,7 @@ module GOVUKDesignSystemFormBuilder
         %(#{brand}-checkboxes__label)
       end
 
-      def label_size_class(size)
+      def size_class(size)
         case size
         when 'xl' then %(#{brand}-label--xl)
         when 'l'  then %(#{brand}-label--l)

--- a/lib/govuk_design_system_formbuilder/elements/legend.rb
+++ b/lib/govuk_design_system_formbuilder/elements/legend.rb
@@ -1,0 +1,83 @@
+module GOVUKDesignSystemFormBuilder
+  module Elements
+    class Legend < Base
+      include Traits::Caption
+      include Traits::Localisation
+
+      def initialize(builder, object_name, attribute_name, legend:, caption:)
+        super(builder, object_name, attribute_name)
+
+        case legend
+        when Proc
+          @legend_raw = legend.call
+        when Hash
+          legend_defaults.merge(legend).tap do |l|
+            @text           = legend_text(l.dig(:text))
+            @hidden         = l.dig(:hidden)
+            @tag            = l.dig(:tag)
+            @size           = l.dig(:size)
+            @caption        = caption
+          end
+        else
+          fail(ArgumentError, %(legend must be a Proc or Hash))
+        end
+      end
+
+      def html
+        @legend_raw || legend_content
+      end
+
+    private
+
+      def legend_content
+        if @text.present?
+          content_tag('legend', class: legend_classes) do
+            content_tag(@tag, class: legend_heading_classes) do
+              safe_join([caption_element, @text])
+            end
+          end
+        end
+      end
+
+      def legend_text(supplied_text)
+        supplied_text || localised_text(:legend)
+      end
+
+      def legend_classes
+        [legend_class, legend_size_class, legend_visually_hidden_class].compact
+      end
+
+      def legend_class
+        %(#{brand}-fieldset__legend)
+      end
+
+      def legend_size_class
+        case @size
+        when 'xl'      then %(#{brand}-fieldset__legend--xl)
+        when 'l'       then %(#{brand}-fieldset__legend--l)
+        when 'm'       then %(#{brand}-fieldset__legend--m)
+        when 's'       then %(#{brand}-fieldset__legend--s)
+        else
+          fail "invalid size '#{@size}', must be xl, l, m or s"
+        end
+      end
+
+      def legend_visually_hidden_class
+        %(#{brand}-visually-hidden) if @hidden
+      end
+
+      def legend_heading_classes
+        %(#{brand}-fieldset__heading)
+      end
+
+      def legend_defaults
+        {
+          hidden: false,
+          text: nil,
+          tag:  config.default_legend_tag,
+          size: config.default_legend_size
+        }
+      end
+    end
+  end
+end

--- a/lib/govuk_design_system_formbuilder/elements/legend.rb
+++ b/lib/govuk_design_system_formbuilder/elements/legend.rb
@@ -9,14 +9,14 @@ module GOVUKDesignSystemFormBuilder
 
         case legend
         when Proc
-          @legend_raw = legend.call
+          @raw = legend.call
         when Hash
-          legend_defaults.merge(legend).tap do |l|
-            @text           = legend_text(l.dig(:text))
-            @hidden         = l.dig(:hidden)
-            @tag            = l.dig(:tag)
-            @size           = l.dig(:size)
-            @caption        = caption
+          defaults.merge(legend).tap do |l|
+            @text    = text(l.dig(:text))
+            @hidden  = l.dig(:hidden)
+            @tag     = l.dig(:tag)
+            @size    = l.dig(:size)
+            @caption = caption
           end
         else
           fail(ArgumentError, %(legend must be a Proc or Hash))
@@ -24,53 +24,49 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        @legend_raw || legend_content
+        @raw || content
       end
 
     private
 
-      def legend_content
+      def content
         if @text.present?
-          content_tag('legend', class: legend_classes) do
-            content_tag(@tag, class: legend_heading_classes) do
+          content_tag('legend', class: classes) do
+            content_tag(@tag, class: heading_classes) do
               safe_join([caption_element, @text])
             end
           end
         end
       end
 
-      def legend_text(supplied_text)
+      def text(supplied_text)
         supplied_text || localised_text(:legend)
       end
 
-      def legend_classes
-        [legend_class, legend_size_class, legend_visually_hidden_class].compact
+      def classes
+        [%(#{brand}-fieldset__legend), size_class, visually_hidden_class].compact
       end
 
-      def legend_class
-        %(#{brand}-fieldset__legend)
-      end
-
-      def legend_size_class
+      def size_class
         case @size
-        when 'xl'      then %(#{brand}-fieldset__legend--xl)
-        when 'l'       then %(#{brand}-fieldset__legend--l)
-        when 'm'       then %(#{brand}-fieldset__legend--m)
-        when 's'       then %(#{brand}-fieldset__legend--s)
+        when 'xl' then %(#{brand}-fieldset__legend--xl)
+        when 'l'  then %(#{brand}-fieldset__legend--l)
+        when 'm'  then %(#{brand}-fieldset__legend--m)
+        when 's'  then %(#{brand}-fieldset__legend--s)
         else
           fail "invalid size '#{@size}', must be xl, l, m or s"
         end
       end
 
-      def legend_visually_hidden_class
+      def visually_hidden_class
         %(#{brand}-visually-hidden) if @hidden
       end
 
-      def legend_heading_classes
+      def heading_classes
         %(#{brand}-fieldset__heading)
       end
 
-      def legend_defaults
+      def defaults
         {
           hidden: false,
           text: nil,

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
@@ -31,10 +31,10 @@ module GOVUKDesignSystemFormBuilder
       private
 
         def radio
-          @builder.radio_button(@attribute_name, @value, **radio_options)
+          @builder.radio_button(@attribute_name, @value, **options)
         end
 
-        def radio_options
+        def options
           {
             id: field_id(link_errors: @link_errors),
             aria: { describedby: hint_id },

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -47,10 +47,10 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def input
-          @builder.radio_button(@attribute_name, @value, **input_options)
+          @builder.radio_button(@attribute_name, @value, **options)
         end
 
-        def input_options
+        def options
           {
             id: field_id(link_errors: @link_errors),
             aria: { describedby: hint_id },

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -28,26 +28,26 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def select
-        @builder.collection_select(@attribute_name, @collection, @value_method, @text_method, @options, **select_options)
+        @builder.collection_select(@attribute_name, @collection, @value_method, @text_method, @options, **options)
       end
 
-      def select_options
+      def options
         @html_options.deep_merge(
           id: field_id(link_errors: true),
-          class: select_classes,
+          class: classes,
           aria: { describedby: described_by(hint_id, error_id, supplemental_id) }
         )
       end
 
-      def select_classes
-        [%(#{brand}-select), select_error_class, select_custom_classes].flatten.compact
+      def classes
+        [%(#{brand}-select), error_class, custom_classes].flatten.compact
       end
 
-      def select_error_class
+      def error_class
         %(#{brand}-select--error) if has_errors?
       end
 
-      def select_custom_classes
+      def custom_classes
         @html_options.dig(:class)
       end
     end

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -24,17 +24,17 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def submit
-        @builder.submit(@text, class: submit_classes, **submit_options)
+        @builder.submit(@text, class: classes, **options)
       end
 
-      def submit_classes
+      def classes
         %w(button)
           .prefix(brand)
           .push(warning_class, secondary_class, disabled_class, padding_class, @classes)
           .compact
       end
 
-      def submit_options
+      def options
         {
           formnovalidate: !@validate,
           disabled: @disabled,

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -36,20 +36,20 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def text_area
-        @builder.text_area(@attribute_name, **text_area_options, **@html_attributes)
+        @builder.text_area(@attribute_name, **options, **@html_attributes)
       end
 
-      def text_area_classes
+      def classes
         %w(textarea).prefix(brand).tap do |classes|
           classes.push(%(#{brand}-textarea--error)) if has_errors?
           classes.push(%(#{brand}-js-character-count)) if limit?
         end
       end
 
-      def text_area_options
+      def options
         {
           id: field_id(link_errors: true),
-          class: text_area_classes,
+          class: classes,
           rows: @rows,
           aria: { describedby: described_by(hint_id, error_id, supplemental_id, limit_description_id) },
         }

--- a/spec/support/shared/shared_legend_examples.rb
+++ b/spec/support/shared/shared_legend_examples.rb
@@ -58,7 +58,7 @@ shared_examples 'a field that supports a fieldset with legend' do
         subject { builder.send(*args, legend: { text: legend_text, size: size }) }
 
         specify 'should raise an error' do
-          expect { subject }.to raise_error("invalid size '#{size}', must be xl, l, m, s")
+          expect { subject }.to raise_error("invalid size '#{size}', must be xl, l, m or s")
         end
       end
     end


### PR DESCRIPTION
### Splitting out legends

The `Containers::Fieldset` class was over-complicated due to it handling the generation of both the fieldset (simple) _and_ the legend (complex). This change introduces a new `Elements::Legend` class that removes the complexity and provides two clean classes instead of one dirty one.

### Make more methods private

For the most part, the only methods that should be public are `#html`, `#to_s` and those that originate in `Traits`. This was a small tidying up exercise

### Remove unnecessary prefixes

Prefixes are only really necessary for methods that are either:

* traits - as they're shared among various elements
* ancillary items - where there might be clashes within a single class
  (eg classes vs label_classes)

This change generally improves readability without sacrificing the understanding; `Label.options` is clear than `Label.label_options`

### Other

* make short (one word in this case) blocks inline rather than `do`/`end`.