### PR TITLE
Add documentation for collection select options and fix html_options class bug

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -312,7 +312,10 @@ module GOVUKDesignSystemFormBuilder
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
+    # @param options [Hash] Options hash passed through to Rails' +collection_select+ helper
+    # @param html_options [Hash] HTML Options hash passed through to Rails' +collection_select+ helper
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
+    # @see https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-collection_select Rails collection_select (called by govuk_collection_select)
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
     # @example A select box with hint

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -1,8 +1,6 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     class Select < Base
-      using PrefixableArray
-
       include Traits::Error
       include Traits::Label
       include Traits::Hint
@@ -42,9 +40,15 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def select_classes
-        %w(select).prefix(brand).tap do |classes|
-          classes.push(%(#{brand}-select--error)) if has_errors?
-        end
+        [%(#{brand}-select), select_error_class, select_custom_classes].flatten.compact
+      end
+
+      def select_error_class
+        %(#{brand}-select--error) if has_errors?
+      end
+
+      def select_custom_classes
+        @html_options.dig(:class)
       end
     end
   end

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -42,7 +42,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     specify 'output should be a form group containing a label and select box' do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-        expect(fg).to have_tag('select')
+        expect(fg).to have_tag('select', with: { class: 'govuk-select' })
       end
     end
 
@@ -71,6 +71,16 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         extract_args(extra_args, :output).each do |key, val|
           expect(select_tag[key]).to eql(val)
         end
+      end
+    end
+
+    context 'when custom classes are supplied via html_options' do
+      let(:custom_classes) { %w(fancy-select purple) }
+
+      subject { builder.send(*args, html_options: { class: custom_classes }) }
+
+      specify %(the select element should have the provided classes) do
+        expect(subject).to have_tag('select', with: { class: custom_classes.push('govuk-select') })
       end
     end
 

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -73,5 +73,15 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
     end
+
+    context 'preselecting an option' do
+      # options are colours in this order: red, blue, green, yellow
+      let(:selected_colour) { green_option }
+      subject { builder.send(*args, options: { selected: selected_colour.id }) }
+
+      specify %(should add a 'selected' attribute to the preselected option) do
+        expect(subject).to have_tag('option', text: selected_colour.name, with: { selected: 'selected', value: selected_colour.id })
+      end
+    end
   end
 end

--- a/spec/support/shared/setup_examples.rb
+++ b/spec/support/shared/setup_examples.rb
@@ -1,12 +1,9 @@
 shared_context 'setup examples' do
-  let(:colours) do
-    [
-      OpenStruct.new(id: 'red', name: 'Red'),
-      OpenStruct.new(id: 'blue', name: 'Blue'),
-      OpenStruct.new(id: 'green', name: 'Green'),
-      OpenStruct.new(id: 'yellow', name: 'Yellow')
-    ]
-  end
+  let(:red_option) { OpenStruct.new(id: 'red', name: 'Red') }
+  let(:blue_option) { OpenStruct.new(id: 'blue', name: 'Blue') }
+  let(:green_option) { OpenStruct.new(id: 'green', name: 'Green') }
+  let(:yellow_option) { OpenStruct.new(id: 'yellow', name: 'Yellow') }
+  let(:colours) { [red_option, blue_option, green_option, yellow_option] }
 
   let(:red_label) { 'Rosso' }
   let(:green_label) { 'Verde' }


### PR DESCRIPTION
The `govuk_collection_select` method, which is a wrapper for Rails' `collection_select`, was missing documentation for the `options` and `html_options` keyword args. They are passed through to the wrapped method directly.

The spec covers example use of pre-selecting an option and ensures attributes are correctly set.

Additionally, there was a bug where the custom classes in `html_options` were being overwritten. This has been fixed by 1499941

Fixes #153 