### PR TITLE
Form group custom classes

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -385,7 +385,7 @@ module GOVUKDesignSystemFormBuilder
     # @param inline [Boolean] controls whether the radio buttons are displayed inline or not
     # @param small [Boolean] controls whether small radio buttons are used instead of regular-sized ones
     # @param bold_labels [Boolean] controls whether the radio button labels are bold
-    # @param classes [String] Classes to add to the radio button container.
+    # @param classes [Array,String] Classes to add to the radio button container.
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
@@ -469,7 +469,7 @@ module GOVUKDesignSystemFormBuilder
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
     # @param block [Block] a block of HTML that will be used to populate the fieldset
-    # @param classes [String] Classes to add to the radio button container.
+    # @param classes [Array,String] Classes to add to the radio button container.
     # @see https://design-system.service.gov.uk/components/radios/ GOV.UK Radios
     # @see https://design-system.service.gov.uk/styles/typography/#headings-with-captions Headings with captions
     # @return [ActiveSupport::SafeBuffer] HTML output
@@ -543,7 +543,7 @@ module GOVUKDesignSystemFormBuilder
     #   When a +Proc+ is provided it must take a single argument that is a single member of the collection
     # @param hint_text [String] The content of the fieldset hint. No hint will be injected if left +nil+
     # @param small [Boolean] controls whether small check boxes are used instead of regular-sized ones
-    # @param classes [String] Classes to add to the checkbox container.
+    # @param classes [Array,String] Classes to add to the checkbox container.
     # @param legend [Hash,Proc] options for configuring the legend
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
@@ -624,7 +624,7 @@ module GOVUKDesignSystemFormBuilder
     # @param caption [Hash] configures or sets the caption content which is inserted above the legend
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
-    # @param classes [String] Classes to add to the checkbox container.
+    # @param classes [Array,String] Classes to add to the checkbox container.
     # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
     # @param block [Block] a block of HTML that will be used to populate the fieldset
     # @return [ActiveSupport::SafeBuffer] HTML output
@@ -695,7 +695,7 @@ module GOVUKDesignSystemFormBuilder
     # @param text [String] the button text
     # @param warning [Boolean] makes the button red ({https://design-system.service.gov.uk/components/button/#warning-buttons warning}) when true
     # @param secondary [Boolean] makes the button grey ({https://design-system.service.gov.uk/components/button/#secondary-buttons secondary}) when true
-    # @param classes [String] Classes to add to the submit button
+    # @param classes [Array,String] Classes to add to the submit button
     # @param prevent_double_click [Boolean] adds JavaScript to safeguard the
     #   form from being submitted more than once
     # @param validate [Boolean] adds the formnovalidate to the submit button when true, this disables all

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -17,6 +17,7 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
+    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -59,6 +60,7 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
+    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -102,6 +104,7 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
+    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -143,6 +146,7 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
+    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -183,6 +187,7 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
+    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -224,6 +229,7 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
+    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -272,6 +278,7 @@ module GOVUKDesignSystemFormBuilder
     # @param threshold [Integer] only show the +max_words+ and +max_chars+ warnings once a threshold (percentage) is reached
     # @param rows [Integer] sets the initial number of rows
     # @option args [Hash] args additional arguments are applied as attributes to the +textarea+ element
+    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/textarea/ GOV.UK text area component
@@ -314,6 +321,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @param options [Hash] Options hash passed through to Rails' +collection_select+ helper
     # @param html_options [Hash] HTML Options hash passed through to Rails' +collection_select+ helper
+    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @see https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-collection_select Rails collection_select (called by govuk_collection_select)
     # @return [ActiveSupport::SafeBuffer] HTML output
@@ -459,6 +467,7 @@ module GOVUKDesignSystemFormBuilder
     # @param caption [Hash] configures or sets the caption content which is inserted above the legend
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
+    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
     # @param block [Block] a block of HTML that will be used to populate the fieldset
     # @param classes [String] Classes to add to the radio button container.
     # @see https://design-system.service.gov.uk/components/radios/ GOV.UK Radios
@@ -543,6 +552,7 @@ module GOVUKDesignSystemFormBuilder
     # @param caption [Hash] configures or sets the caption content which is inserted above the legend
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
+    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
     # @param block [Block] any HTML passed in will be injected into the fieldset, after the hint and before the checkboxes
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
@@ -615,6 +625,7 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @param classes [String] Classes to add to the checkbox container.
+    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
     # @param block [Block] a block of HTML that will be used to populate the fieldset
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
@@ -725,6 +736,7 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @param omit_day [Boolean] do not render a day input, only capture month and year
+    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input group
     # @param date_of_birth [Boolean] if +true+ {https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Values birth date auto completion attributes}
     #   will be added to the inputs
@@ -803,6 +815,7 @@ module GOVUKDesignSystemFormBuilder
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
+    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     #
     # @example A photo upload field with file type specifier and injected content

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -40,8 +40,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_text_field :callsign,
     #     label: -> { tag.h3('Call-sign') }
     #
-    def govuk_text_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, **args, &block)
-      Elements::Inputs::Text.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, **args, &block).html
+    def govuk_text_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group_classes: nil, **args, &block)
+      Elements::Inputs::Text.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group_classes: form_group_classes, **args, &block).html
     end
 
     # Generates a input of type +tel+
@@ -83,8 +83,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_phone_field :work_number,
     #     label: -> { tag.h3('Work number') }
     #
-    def govuk_phone_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, **args, &block)
-      Elements::Inputs::Phone.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, **args, &block).html
+    def govuk_phone_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group_classes: nil, **args, &block)
+      Elements::Inputs::Phone.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group_classes: form_group_classes, **args, &block).html
     end
 
     # Generates a input of type +email+
@@ -124,8 +124,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_email_field :personal_email,
     #     label: -> { tag.h3('Personal email address') }
     #
-    def govuk_email_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, **args, &block)
-      Elements::Inputs::Email.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, **args, &block).html
+    def govuk_email_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group_classes: nil, **args, &block)
+      Elements::Inputs::Email.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group_classes: form_group_classes, **args, &block).html
     end
 
     # Generates a input of type +password+
@@ -164,8 +164,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_password_field :passcode,
     #     label: -> { tag.h3('What is your secret pass code?') }
     #
-    def govuk_password_field(attribute_name, hint_text: nil, label: {}, width: nil, caption: {}, **args, &block)
-      Elements::Inputs::Password.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, **args, &block).html
+    def govuk_password_field(attribute_name, hint_text: nil, label: {}, width: nil, form_group_classes: nil, caption: {}, **args, &block)
+      Elements::Inputs::Password.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group_classes: form_group_classes, **args, &block).html
     end
 
     # Generates a input of type +url+
@@ -205,8 +205,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_url_field :work_website,
     #     label: -> { tag.h3("Enter your company's website") }
     #
-    def govuk_url_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, **args, &block)
-      Elements::Inputs::URL.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, **args, &block).html
+    def govuk_url_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group_classes: nil, **args, &block)
+      Elements::Inputs::URL.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group_classes: form_group_classes, **args, &block).html
     end
 
     # Generates a input of type +number+
@@ -249,8 +249,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_url_field :personal_best_over_100m,
     #     label: -> { tag.h3("How many seconds does it take you to run 100m?") }
     #
-    def govuk_number_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, **args, &block)
-      Elements::Inputs::Number.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, **args, &block).html
+    def govuk_number_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group_classes: nil, **args, &block)
+      Elements::Inputs::Number.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group_classes: form_group_classes, **args, &block).html
     end
 
     # Generates a +textarea+ element with a label, optional hint. Also offers
@@ -297,8 +297,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_text_area :instructions,
     #     label: -> { tag.h3("How do you set it up?") }
     #
-    def govuk_text_area(attribute_name, hint_text: nil, label: {}, caption: {}, max_words: nil, max_chars: nil, rows: 5, threshold: nil, **args, &block)
-      Elements::TextArea.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, max_words: max_words, max_chars: max_chars, rows: rows, threshold: threshold, **args, &block).html
+    def govuk_text_area(attribute_name, hint_text: nil, label: {}, caption: {}, max_words: nil, max_chars: nil, rows: 5, threshold: nil, form_group_classes: nil, **args, &block)
+      Elements::TextArea.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, max_words: max_words, max_chars: max_chars, rows: rows, threshold: threshold, form_group_classes: form_group_classes, **args, &block).html
     end
 
     # Generates a +select+ element containing +option+ for each member in the provided collection
@@ -335,7 +335,7 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_collection_select(:team, @teams, :id, :name) do
     #     label: -> { tag.h3("Which team did you represent?") }
     #
-    def govuk_collection_select(attribute_name, collection, value_method, text_method, options: {}, html_options: {}, hint_text: nil, label: {}, caption: {}, &block)
+    def govuk_collection_select(attribute_name, collection, value_method, text_method, options: {}, html_options: {}, hint_text: nil, label: {}, caption: {}, form_group_classes: nil, &block)
       Elements::Select.new(
         self,
         object_name,
@@ -348,6 +348,7 @@ module GOVUKDesignSystemFormBuilder
         caption: caption,
         options: options,
         html_options: html_options,
+        form_group_classes: form_group_classes,
         &block
       ).html
     end
@@ -418,7 +419,7 @@ module GOVUKDesignSystemFormBuilder
     #    :name,
     #    legend: -> { tag.h3('Which category do you belong to?') }
     #
-    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, caption: {}, inline: false, small: false, bold_labels: false, classes: nil, &block)
+    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, caption: {}, inline: false, small: false, bold_labels: false, classes: nil, form_group_classes: nil, &block)
       Elements::Radios::Collection.new(
         self,
         object_name,
@@ -434,6 +435,7 @@ module GOVUKDesignSystemFormBuilder
         small: small,
         bold_labels: bold_labels,
         classes: classes,
+        form_group_classes: form_group_classes,
         &block
       ).html
     end
@@ -480,8 +482,8 @@ module GOVUKDesignSystemFormBuilder
     #      = f.govuk_radio_button :burger_id, :regular, label: { text: 'Hamburger' }, link_errors: true
     #      = f.govuk_radio_button :burger_id, :cheese, label: { text: 'Cheeseburger' }
     #
-    def govuk_radio_buttons_fieldset(attribute_name, hint_text: nil, legend: {}, caption: {}, inline: false, small: false, classes: nil, &block)
-      Containers::RadioButtonsFieldset.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, caption: caption, inline: inline, small: small, classes: classes, &block).html
+    def govuk_radio_buttons_fieldset(attribute_name, hint_text: nil, legend: {}, caption: {}, inline: false, small: false, classes: nil, form_group_classes: nil, &block)
+      Containers::RadioButtonsFieldset.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, caption: caption, inline: inline, small: small, classes: classes, form_group_classes: form_group_classes, &block).html
     end
 
     # Generates a radio button
@@ -577,7 +579,7 @@ module GOVUKDesignSystemFormBuilder
     #    :name,
     #    legend: -> { tag.h3('What kind of sandwich do you want?') }
     #
-    def govuk_collection_check_boxes(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, caption: {}, small: false, classes: nil, &block)
+    def govuk_collection_check_boxes(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, caption: {}, small: false, classes: nil, form_group_classes: nil, &block)
       Elements::CheckBoxes::Collection.new(
         self,
         object_name,
@@ -591,6 +593,7 @@ module GOVUKDesignSystemFormBuilder
         caption: caption,
         small: small,
         classes: classes,
+        form_group_classes: form_group_classes,
         &block
       ).html
     end
@@ -625,7 +628,7 @@ module GOVUKDesignSystemFormBuilder
     #    = f.govuk_check_box :desired_filling, :lemonade, label: { text: 'Lemonade' }, link_errors: true
     #    = f.govuk_check_box :desired_filling, :fizzy_orange, label: { text: 'Fizzy orange' }
     #
-    def govuk_check_boxes_fieldset(attribute_name, legend: {}, caption: {}, hint_text: {}, small: false, classes: nil, &block)
+    def govuk_check_boxes_fieldset(attribute_name, legend: {}, caption: {}, hint_text: {}, small: false, classes: nil, form_group_classes: nil, &block)
       Containers::CheckBoxesFieldset.new(
         self,
         object_name,
@@ -635,6 +638,7 @@ module GOVUKDesignSystemFormBuilder
         caption: caption,
         small: small,
         classes: classes,
+        form_group_classes: form_group_classes,
         &block
       ).html
     end
@@ -740,8 +744,8 @@ module GOVUKDesignSystemFormBuilder
     # @example A date input with legend supplied as a proc
     #  = f.govuk_date_field :finishes_on,
     #    legend: -> { tag.h3('Which category do you belong to?') }
-    def govuk_date_field(attribute_name, hint_text: nil, legend: {}, caption: {}, date_of_birth: false, omit_day: false, &block)
-      Elements::Date.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, caption: caption, date_of_birth: date_of_birth, omit_day: omit_day, &block).html
+    def govuk_date_field(attribute_name, hint_text: nil, legend: {}, caption: {}, date_of_birth: false, omit_day: false, form_group_classes: nil, &block)
+      Elements::Date.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, caption: caption, date_of_birth: date_of_birth, omit_day: omit_day, form_group_classes: form_group_classes, &block).html
     end
 
     # Generates a summary of errors in the form, each linking to the corresponding
@@ -817,8 +821,8 @@ module GOVUKDesignSystemFormBuilder
     # @note Remember to set +multipart: true+ when creating a form with file
     #   uploads, {https://guides.rubyonrails.org/form_helpers.html#uploading-files see
     #   the Rails documentation} for more information
-    def govuk_file_field(attribute_name, label: {}, caption: {}, hint_text: nil, **args, &block)
-      Elements::File.new(self, object_name, attribute_name, label: label, caption: caption, hint_text: hint_text, **args, &block).html
+    def govuk_file_field(attribute_name, label: {}, caption: {}, hint_text: nil, form_group_classes: nil, **args, &block)
+      Elements::File.new(self, object_name, attribute_name, label: label, caption: caption, hint_text: hint_text, form_group_classes: form_group_classes, **args, &block).html
     end
   end
 end

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
@@ -21,11 +21,15 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def classes
-        [%(#{brand}-checkboxes), small_class, @classes].compact
+        [%(#{brand}-checkboxes), small_class, custom_classes].flatten.compact
       end
 
       def small_class
         %(#{brand}-checkboxes--small) if @small
+      end
+
+      def custom_classes
+        Array.wrap(@classes)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -4,19 +4,20 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Error
       include Traits::Hint
 
-      def initialize(builder, object_name, attribute_name, hint_text:, legend:, caption:, small:, classes:, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, legend:, caption:, small:, classes:, form_group_classes:, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @legend        = legend
-        @caption       = caption
-        @hint_text     = hint_text
-        @small         = small
-        @classes       = classes
-        @block_content = capture { block.call }
+        @legend             = legend
+        @caption            = caption
+        @hint_text          = hint_text
+        @small              = small
+        @classes            = classes
+        @form_group_classes = form_group_classes
+        @block_content      = capture { block.call }
       end
 
       def html
-        Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
+        Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
           Containers::Fieldset.new(@builder, @object_name, @attribute_name, **fieldset_options).html do
             safe_join([hint_element, error_element, checkboxes])
           end

--- a/lib/govuk_design_system_formbuilder/containers/form_group.rb
+++ b/lib/govuk_design_system_formbuilder/containers/form_group.rb
@@ -1,8 +1,10 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
     class FormGroup < Base
-      def initialize(builder, object_name, attribute_name)
+      def initialize(builder, object_name, attribute_name, classes: nil)
         super(builder, object_name, attribute_name)
+
+        @classes = classes
       end
 
       def html
@@ -12,7 +14,7 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def classes
-        [form_group_class, error_class].compact
+        [form_group_class, error_class, custom_classes].flatten.compact
       end
 
       def form_group_class
@@ -21,6 +23,10 @@ module GOVUKDesignSystemFormBuilder
 
       def error_class
         %(#{brand}-form-group--error) if has_errors?
+      end
+
+      def custom_classes
+        Array.wrap(@classes)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
@@ -4,20 +4,21 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Hint
       include Traits::Error
 
-      def initialize(builder, object_name, attribute_name, hint_text:, legend:, caption:, inline:, small:, classes:, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, legend:, caption:, inline:, small:, classes:, form_group_classes:, &block)
         super(builder, object_name, attribute_name)
 
-        @inline        = inline
-        @small         = small
-        @legend        = legend
-        @caption       = caption
-        @hint_text     = hint_text
-        @classes       = classes
-        @block_content = capture { block.call }
+        @inline             = inline
+        @small              = small
+        @legend             = legend
+        @caption            = caption
+        @hint_text          = hint_text
+        @classes            = classes
+        @form_group_classes = form_group_classes
+        @block_content      = capture { block.call }
       end
 
       def html
-        Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
+        Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
           Containers::Fieldset.new(@builder, @object_name, @attribute_name, **fieldset_options).html do
             safe_join([hint_element, error_element, radios])
           end

--- a/lib/govuk_design_system_formbuilder/containers/radios.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radios.rb
@@ -24,7 +24,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def classes
-        [%(#{brand}-radios), inline_class, small_class, @classes].compact
+        [%(#{brand}-radios), inline_class, small_class, custom_classes].flatten.compact
       end
 
       def inline_class
@@ -33,6 +33,10 @@ module GOVUKDesignSystemFormBuilder
 
       def small_class
         %(#{brand}-radios--small)  if @small
+      end
+
+      def custom_classes
+        Array.wrap(@classes)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -6,22 +6,23 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Supplemental
 
-        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method: nil, hint_text:, legend:, caption:, small:, classes:, &block)
+        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method: nil, hint_text:, legend:, caption:, small:, classes:, form_group_classes:, &block)
           super(builder, object_name, attribute_name, &block)
 
-          @collection    = collection
-          @value_method  = value_method
-          @text_method   = text_method
-          @hint_method   = hint_method
-          @small         = small
-          @legend        = legend
-          @caption       = caption
-          @hint_text     = hint_text
-          @classes       = classes
+          @collection         = collection
+          @value_method       = value_method
+          @text_method        = text_method
+          @hint_method        = hint_method
+          @small              = small
+          @legend             = legend
+          @caption            = caption
+          @hint_text          = hint_text
+          @classes            = classes
+          @form_group_classes = form_group_classes
         end
 
         def html
-          Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
+          Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
             Containers::Fieldset.new(@builder, @object_name, @attribute_name, **fieldset_options).html do
               safe_join([supplemental_content, hint_element, error_element, check_boxes])
             end

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -9,18 +9,19 @@ module GOVUKDesignSystemFormBuilder
 
       SEGMENTS = { day: '3i', month: '2i', year: '1i' }.freeze
 
-      def initialize(builder, object_name, attribute_name, legend:, caption:, hint_text:, date_of_birth: false, omit_day:, &block)
+      def initialize(builder, object_name, attribute_name, legend:, caption:, hint_text:, date_of_birth: false, omit_day:, form_group_classes:, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @legend        = legend
-        @caption       = caption
-        @hint_text     = hint_text
-        @date_of_birth = date_of_birth
-        @omit_day      = omit_day
+        @legend             = legend
+        @caption            = caption
+        @hint_text          = hint_text
+        @date_of_birth      = date_of_birth
+        @omit_day           = omit_day
+        @form_group_classes = form_group_classes
       end
 
       def html
-        Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
+        Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
           Containers::Fieldset.new(@builder, @object_name, @attribute_name, **fieldset_options).html do
             safe_join([supplemental_content, hint_element, error_element, date])
           end

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -8,17 +8,18 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Label
       include Traits::Supplemental
 
-      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, **kwargs, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, form_group_classes:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @label         = label
-        @caption       = caption
-        @hint_text     = hint_text
-        @extra_options = kwargs
+        @label              = label
+        @caption            = caption
+        @hint_text          = hint_text
+        @extra_options      = kwargs
+        @form_group_classes = form_group_classes
       end
 
       def html
-        Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
+        Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
           safe_join([label_element, supplemental_content, hint_element, error_element, file])
         end
       end

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -6,24 +6,25 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Supplemental
 
-        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method:, hint_text:, legend:, caption:, inline:, small:, bold_labels:, classes:, &block)
+        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method:, hint_text:, legend:, caption:, inline:, small:, bold_labels:, classes:, form_group_classes:, &block)
           super(builder, object_name, attribute_name, &block)
 
-          @collection    = collection
-          @value_method  = value_method
-          @text_method   = text_method
-          @hint_method   = hint_method
-          @inline        = inline
-          @small         = small
-          @legend        = legend
-          @caption       = caption
-          @hint_text     = hint_text
-          @classes       = classes
-          @bold_labels   = hint_method.present? || bold_labels
+          @collection         = collection
+          @value_method       = value_method
+          @text_method        = text_method
+          @hint_method        = hint_method
+          @inline             = inline
+          @small              = small
+          @legend             = legend
+          @caption            = caption
+          @hint_text          = hint_text
+          @classes            = classes
+          @form_group_classes = form_group_classes
+          @bold_labels        = hint_method.present? || bold_labels
         end
 
         def html
-          Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
+          Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
             Containers::Fieldset.new(@builder, @object_name, @attribute_name, **fieldset_options).html do
               safe_join([supplemental_content, hint_element, error_element, radios])
             end

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -6,21 +6,22 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Hint
       include Traits::Supplemental
 
-      def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, options: {}, html_options: {}, hint_text:, label:, caption:, &block)
+      def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, options: {}, html_options: {}, hint_text:, label:, caption:, form_group_classes:, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @collection    = collection
-        @value_method  = value_method
-        @text_method   = text_method
-        @options       = options
-        @html_options  = html_options
-        @label         = label
-        @caption       = caption
-        @hint_text     = hint_text
+        @collection         = collection
+        @value_method       = value_method
+        @text_method        = text_method
+        @options            = options
+        @html_options       = html_options
+        @label              = label
+        @caption            = caption
+        @hint_text          = hint_text
+        @form_group_classes = form_group_classes
       end
 
       def html
-        Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
+        Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
           safe_join([label_element, supplemental_content, hint_element, error_element, select])
         end
       end

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -30,7 +30,8 @@ module GOVUKDesignSystemFormBuilder
       def classes
         %w(button)
           .prefix(brand)
-          .push(warning_class, secondary_class, disabled_class, padding_class, @classes)
+          .push(warning_class, secondary_class, disabled_class, padding_class, custom_classes)
+          .flatten
           .compact
       end
 
@@ -59,6 +60,10 @@ module GOVUKDesignSystemFormBuilder
 
       def disabled_class
         %(#{brand}-button--disabled) if @disabled
+      end
+
+      def custom_classes
+        Array.wrap(@classes)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -8,7 +8,7 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Label
       include Traits::Supplemental
 
-      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, rows:, max_words:, max_chars:, threshold:, **kwargs, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, rows:, max_words:, max_chars:, threshold:, form_group_classes:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
         @label           = label
@@ -18,12 +18,13 @@ module GOVUKDesignSystemFormBuilder
         @max_chars       = max_chars
         @threshold       = threshold
         @rows            = rows
+        @form_group_classes = form_group_classes
         @html_attributes = kwargs
       end
 
       def html
         Containers::CharacterCount.new(@builder, **character_count_options).html do
-          Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
+          Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
             safe_join([label_element, supplemental_content, hint_element, error_element, text_area, limit_description])
           end
         end

--- a/lib/govuk_design_system_formbuilder/traits/input.rb
+++ b/lib/govuk_design_system_formbuilder/traits/input.rb
@@ -1,18 +1,19 @@
 module GOVUKDesignSystemFormBuilder
   module Traits
     module Input
-      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, width:, **kwargs, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, width:, form_group_classes:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @width           = width
-        @label           = label
-        @caption         = caption
-        @hint_text       = hint_text
-        @html_attributes = kwargs
+        @width              = width
+        @label              = label
+        @caption            = caption
+        @hint_text          = hint_text
+        @html_attributes    = kwargs
+        @form_group_classes = form_group_classes
       end
 
       def html
-        Containers::FormGroup.new(@builder, @object_name, @attribute_name).html do
+        Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
           safe_join([label_element, supplemental_content, hint_element, error_element, input])
         end
       end

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
@@ -42,6 +42,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that supports custom branding'
+    it_behaves_like 'a field that contains a customisable form group'
 
     it_behaves_like 'a field that supports setting the legend via localisation'
     it_behaves_like 'a field that supports setting the legend caption via localisation'

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
@@ -42,6 +42,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that supports custom branding'
+
+    it_behaves_like 'a field that supports custom classes' do
+      let(:element) { 'div' }
+      let(:default_classes) { %w(govuk-checkboxes) }
+    end
+
     it_behaves_like 'a field that contains a customisable form group'
 
     it_behaves_like 'a field that supports setting the legend via localisation'
@@ -74,16 +80,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
           specify "should not have the additional class 'govuk-checkboxes--small'" do
             expect(parsed_subject.at_css('.govuk-checkboxes')['class']).to eql('govuk-checkboxes')
-          end
-        end
-      end
-
-      context 'check box classes' do
-        context 'when extra css classes are specified in the options' do
-          subject { builder.send(*args, classes: 'foo') }
-
-          specify "should have the additional class 'foo'" do
-            expect(subject).to have_tag('div', with: { class: %w(govuk-checkboxes foo) })
           end
         end
       end

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
@@ -30,6 +30,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that supports custom branding'
+
+    it_behaves_like 'a field that supports custom classes' do
+      let(:element) { 'div' }
+      let(:default_classes) { %w(govuk-checkboxes) }
+    end
+
     it_behaves_like 'a field that contains a customisable form group'
 
     it_behaves_like 'a field that supports setting the hint via localisation'
@@ -84,16 +90,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       specify 'output should contain check boxes' do
         expect(subject).to have_tag('div', with: { class: 'govuk-checkboxes', 'data-module' => 'govuk-checkboxes' }) do
           expect(subject).to have_tag('input', with: { type: 'checkbox' }, count: 3)
-        end
-      end
-
-      context 'check boxes classes' do
-        context 'when extra css classes are specified in the options' do
-          subject { builder.send(*args, classes: 'foo', &example_block) }
-
-          specify "should have the additional class 'foo'" do
-            expect(subject).to have_tag('div', with: { class: %w(govuk-checkboxes foo) })
-          end
         end
       end
 

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
@@ -30,6 +30,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that supports custom branding'
+    it_behaves_like 'a field that contains a customisable form group'
 
     it_behaves_like 'a field that supports setting the hint via localisation'
     it_behaves_like 'a field that supports setting the legend via localisation'

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -66,6 +66,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports setting the hint via localisation'
 
     it_behaves_like 'a field that supports custom branding'
+    it_behaves_like 'a field that contains a customisable form group'
+
     it_behaves_like 'a field that supports a fieldset with legend'
     it_behaves_like 'a field that supports captions on the legend'
 

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -24,6 +24,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports labels as procs'
     it_behaves_like 'a field that supports captions on the label'
     it_behaves_like 'a field that supports custom branding'
+    it_behaves_like 'a field that contains a customisable form group'
 
     it_behaves_like 'a field that accepts arbitrary blocks of HTML' do
       let(:described_element) { 'input' }

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -27,6 +27,11 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     it_behaves_like 'a field that supports custom branding'
 
+    it_behaves_like 'a field that supports custom classes' do
+      let(:element) { 'div' }
+      let(:default_classes) { %w(govuk-radios) }
+    end
+
     it_behaves_like 'a field that supports a fieldset with legend' do
       let(:legend_text) { 'Pick your favourite colour' }
     end
@@ -203,16 +208,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         context 'when bold labels are not specified in the options' do
           specify 'no labels should be bold when hints are enabled' do
             expect(subject).not_to have_tag('label', with: { class: bold_label_class })
-          end
-        end
-      end
-
-      context 'radio button classes' do
-        context 'when extra css classes are specified in the options' do
-          subject { builder.send(*args, classes: 'foo') }
-
-          specify "should have the additional class 'foo'" do
-            expect(subject).to have_tag('div', with: { class: %w(govuk-radios foo) })
           end
         end
       end

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -52,6 +52,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports setting the hint via localisation'
     it_behaves_like 'a field that supports setting the legend caption via localisation'
     it_behaves_like 'a field that supports setting the legend via localisation'
+    it_behaves_like 'a field that contains a customisable form group'
 
     it_behaves_like 'a field that accepts a plain ruby object' do
       let(:described_element) { ['input', { with: { type: 'radio' }, count: colours.size }] }

--- a/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
@@ -33,6 +33,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that supports custom branding'
+    it_behaves_like 'a field that supports custom classes' do
+      let(:element) { 'div' }
+      let(:default_classes) { %w(govuk-radios) }
+    end
     it_behaves_like 'a field that contains a customisable form group'
 
     it_behaves_like 'a field that supports setting the hint via localisation'
@@ -119,16 +123,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
           specify "should not have the additional class 'govuk-radios--small'" do
             expect(parsed_subject.at_css('.govuk-radios')['class']).to eql('govuk-radios')
-          end
-        end
-      end
-
-      context 'radio button classes' do
-        context 'when extra css classes are specified in the options' do
-          subject { builder.send(*args, classes: 'foo', &example_block) }
-
-          specify "should have the additional class 'foo'" do
-            expect(subject).to have_tag('div', with: { class: %w(govuk-radios foo) })
           end
         end
       end

--- a/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
@@ -33,6 +33,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that supports custom branding'
+    it_behaves_like 'a field that contains a customisable form group'
 
     it_behaves_like 'a field that supports setting the hint via localisation'
     it_behaves_like 'a field that supports setting the legend via localisation'

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -21,6 +21,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     it_behaves_like 'a field that supports hints'
     it_behaves_like 'a field that supports custom branding'
+    it_behaves_like 'a field that contains a customisable form group'
 
     it_behaves_like 'a field that supports errors' do
       let(:error_message) { /Choose a favourite colour/ }

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -11,6 +11,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     it_behaves_like 'a field that supports custom branding'
 
+    it_behaves_like 'a field that supports custom classes' do
+      let(:element) { 'input' }
+      let(:default_classes) { %w(govuk-button) }
+      let(:block_content) { -> { %(Example) } }
+    end
+
     specify 'output should be a submit input' do
       expect(subject).to have_tag('input', with: { type: 'submit' })
     end
@@ -61,7 +67,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       context 'classes' do
-        subject { builder.send(*args.push('Create'), classes: 'custom-class--one custom-class--two') }
+        subject { builder.send(*args.push('Create'), classes: %w(custom-class--one custom-class--two)) }
 
         specify 'button should have the custom class' do
           expect(subject).to have_tag('input', with: { class: %w(govuk-button custom-class--one custom-class--two) })

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -45,6 +45,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   it_behaves_like 'a field that supports labels', 'textarea'
   it_behaves_like 'a field that supports captions on the label'
   it_behaves_like 'a field that supports labels as procs'
+  it_behaves_like 'a field that contains a customisable form group'
 
   it_behaves_like 'a field that supports hints' do
     let(:aria_described_by_target) { 'textarea' }

--- a/spec/support/shared/shared_custom_class_examples.rb
+++ b/spec/support/shared/shared_custom_class_examples.rb
@@ -1,0 +1,20 @@
+shared_examples 'a field that supports custom classes' do
+  let(:block_content) { -> { %(You there, fill it up with petroleum distillate, and re-vulcanize my tires, post-haste!) } }
+  subject { builder.send(*args, classes: custom_classes, &block_content) }
+
+  context 'when classes are supplied in an array' do
+    let(:custom_classes) { %w(custom-class--one custom-class--two) }
+
+    specify "should have the custom classes" do
+      expect(subject).to have_tag(element, with: { class: default_classes + custom_classes })
+    end
+  end
+
+  context 'when classes are supplied in a string' do
+    let(:custom_classes) { %(custom-class--one custom-class--two) }
+
+    specify "should have the custom classes" do
+      expect(subject).to have_tag(element, with: { class: default_classes + custom_classes.split })
+    end
+  end
+end

--- a/spec/support/shared/shared_form_group_examples.rb
+++ b/spec/support/shared/shared_form_group_examples.rb
@@ -1,7 +1,11 @@
 shared_examples 'a field that contains a customisable form group' do
   example_group 'when custom classes are provided' do
     let(:default_class) { %w(govuk-form-group) }
-    subject { builder.send(*args, form_group_classes: custom_classes) }
+    let(:block_content) { %(Are you acquainted with our state's stringent usury laws?) }
+
+    subject do
+      builder.send(*args, form_group_classes: custom_classes) { builder.tag.span(block_content) }
+    end
 
     context 'classes passed in as an array' do
       let(:custom_classes) { %w(red speckled) }

--- a/spec/support/shared/shared_form_group_examples.rb
+++ b/spec/support/shared/shared_form_group_examples.rb
@@ -1,0 +1,22 @@
+shared_examples 'a field that contains a customisable form group' do
+  example_group 'when custom classes are provided' do
+    let(:default_class) { %w(govuk-form-group) }
+    subject { builder.send(*args, form_group_classes: custom_classes) }
+
+    context 'classes passed in as an array' do
+      let(:custom_classes) { %w(red speckled) }
+
+      specify 'the form group should contain the additional classes' do
+        expect(subject).to have_tag('div', with: { class: default_class + custom_classes })
+      end
+    end
+
+    context 'classes passed in as a string' do
+      let(:custom_classes) { 'red speckled' }
+
+      specify 'the form group should contain the additional classes' do
+        expect(subject).to have_tag('div', with: { class: default_class + custom_classes.split })
+      end
+    end
+  end
+end

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -28,6 +28,7 @@ shared_examples 'a regular input' do |method_identifier, field_type|
   it_behaves_like 'a field that supports captions on the label'
   it_behaves_like 'a field that supports hints'
   it_behaves_like 'a field that supports custom branding'
+  it_behaves_like 'a field that contains a customisable form group'
 
   it_behaves_like 'a field that accepts arbitrary blocks of HTML' do
     let(:described_element) { 'input' }


### PR DESCRIPTION
Allow extra classes to be set on form groups via a `form_group_classes` keyword arg on all helpers that wrap contents in a `govuk-form-group`.

Also standardise the other helpers that allow custom `classes` so they all take either an array or a string.

Fixes #158