### PR TITLE
Add prefix and suffix text support

### DIFF
--- a/guide/content/form-elements/text-field.slim
+++ b/guide/content/form-elements/text-field.slim
@@ -129,6 +129,16 @@ section
         more details on the reasoning behind this decision in #{link_to("the accompanying blog post", input_types_for_numbers_link).html_safe}.
 
   == render('/partials/example-fig.*',
+    caption: "Inputs with prefixes and suffixes",
+    code: text_field_with_prefix_and_suffix,
+    hide_html_output: false) do
+
+    p.govuk-body
+      | Prefixes and suffixes are useful when you use symbols and abbreviations
+        that are commonly known and understood. Symbols and abbreviations should
+        be explained in the label or hint.
+
+  == render('/partials/example-fig.*',
     caption: "Generating text inputs with custom widths",
     code: text_field_with_custom_width,
     hide_html_output: true) do

--- a/guide/lib/examples/text_input.rb
+++ b/guide/lib/examples/text_input.rb
@@ -39,5 +39,15 @@ module Examples
         = f.govuk_text_field :two,    width: 2
       SNIPPET
     end
+
+    def text_field_with_prefix_and_suffix
+      <<~SNIPPET
+        = f.govuk_text_field :price_per_kg,
+          width: 'one-quarter',
+          label: { text: 'Price per kilogram' },
+          prefix_text: '£',
+          suffix_text: 'per kg'
+      SNIPPET
+    end
   end
 end

--- a/guide/lib/helpers/person.rb
+++ b/guide/lib/helpers/person.rb
@@ -8,7 +8,8 @@ class Person
     :last_name,
     :job_title,
     :postcode,
-    :account_number
+    :account_number,
+    :price_per_kg
   )
 
   # width examples

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -49,8 +49,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_text_field :callsign,
     #     label: -> { tag.h3('Call-sign') }
     #
-    def govuk_text_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, **kwargs, &block)
-      Elements::Inputs::Text.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, **kwargs, &block).html
+    def govuk_text_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
+      Elements::Inputs::Text.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
     end
 
     # Generates a input of type +tel+
@@ -100,8 +100,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_phone_field :work_number,
     #     label: -> { tag.h3('Work number') }
     #
-    def govuk_phone_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, **kwargs, &block)
-      Elements::Inputs::Phone.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, **kwargs, &block).html
+    def govuk_phone_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
+      Elements::Inputs::Phone.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
     end
 
     # Generates a input of type +email+
@@ -149,8 +149,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_email_field :personal_email,
     #     label: -> { tag.h3('Personal email address') }
     #
-    def govuk_email_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, **kwargs, &block)
-      Elements::Inputs::Email.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, **kwargs, &block).html
+    def govuk_email_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
+      Elements::Inputs::Email.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
     end
 
     # Generates a input of type +password+
@@ -197,8 +197,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_password_field :passcode,
     #     label: -> { tag.h3('What is your secret pass code?') }
     #
-    def govuk_password_field(attribute_name, hint: {}, label: {}, width: nil, form_group: {}, caption: {}, **kwargs, &block)
-      Elements::Inputs::Password.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, **kwargs, &block).html
+    def govuk_password_field(attribute_name, hint: {}, label: {}, width: nil, form_group: {}, caption: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
+      Elements::Inputs::Password.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
     end
 
     # Generates a input of type +url+
@@ -246,8 +246,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_url_field :work_website,
     #     label: -> { tag.h3("Enter your company's website") }
     #
-    def govuk_url_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, **kwargs, &block)
-      Elements::Inputs::URL.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, **kwargs, &block).html
+    def govuk_url_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
+      Elements::Inputs::URL.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
     end
 
     # Generates a input of type +number+
@@ -298,8 +298,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_url_field :personal_best_over_100m,
     #     label: -> { tag.h3("How many seconds does it take you to run 100m?") }
     #
-    def govuk_number_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, **kwargs, &block)
-      Elements::Inputs::Number.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, **kwargs, &block).html
+    def govuk_number_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
+      Elements::Inputs::Number.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
     end
 
     # Generates a +textarea+ element with a label, optional hint. Also offers

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -26,6 +26,8 @@ module GOVUKDesignSystemFormBuilder
     # @param form_group [Hash] configures the form group
     # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
+    # @param prefix_text [String] the text placed before the input. No prefix will be added if left +nil+
+    # @param suffix_text [String] the text placed after the input. No suffix will be added if left +nil+
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -76,6 +78,8 @@ module GOVUKDesignSystemFormBuilder
     # @param form_group [Hash] configures the form group
     # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
+    # @param prefix_text [String] the text placed before the input. No prefix will be added if left +nil+
+    # @param suffix_text [String] the text placed after the input. No suffix will be added if left +nil+
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -127,6 +131,8 @@ module GOVUKDesignSystemFormBuilder
     # @param form_group [Hash] configures the form group
     # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
+    # @param prefix_text [String] the text placed before the input. No prefix will be added if left +nil+
+    # @param suffix_text [String] the text placed after the input. No suffix will be added if left +nil+
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -176,6 +182,8 @@ module GOVUKDesignSystemFormBuilder
     # @param form_group [Hash] configures the form group
     # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
+    # @param prefix_text [String] the text placed before the input. No prefix will be added if left +nil+
+    # @param suffix_text [String] the text placed after the input. No suffix will be added if left +nil+
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -224,6 +232,8 @@ module GOVUKDesignSystemFormBuilder
     # @param form_group [Hash] configures the form group
     # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
+    # @param prefix_text [String] the text placed before the input. No prefix will be added if left +nil+
+    # @param suffix_text [String] the text placed after the input. No suffix will be added if left +nil+
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -273,6 +283,8 @@ module GOVUKDesignSystemFormBuilder
     # @param form_group [Hash] configures the form group
     # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
+    # @param prefix_text [String] the text placed before the input. No prefix will be added if left +nil+
+    # @param suffix_text [String] the text placed after the input. No suffix will be added if left +nil+
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input

--- a/lib/govuk_design_system_formbuilder/traits/input.rb
+++ b/lib/govuk_design_system_formbuilder/traits/input.rb
@@ -88,13 +88,17 @@ module GOVUKDesignSystemFormBuilder
       def prefix
         return nil if @prefix_text.blank?
 
-        tag.span(@prefix_text, class: %(#{brand}-input__prefix))
+        tag.span(@prefix_text, class: %(#{brand}-input__prefix), **affix_options)
       end
 
       def suffix
         return nil if @suffix_text.blank?
 
-        tag.span(@suffix_text, class: %(#{brand}-input__suffix))
+        tag.span(@suffix_text, class: %(#{brand}-input__suffix), **affix_options)
+      end
+
+      def affix_options
+        { aria: { hidden: true } }
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/traits/input.rb
+++ b/lib/govuk_design_system_formbuilder/traits/input.rb
@@ -1,38 +1,58 @@
 module GOVUKDesignSystemFormBuilder
   module Traits
     module Input
-      def initialize(builder, object_name, attribute_name, hint:, label:, caption:, width:, form_group:, **kwargs, &block)
+      def initialize(builder, object_name, attribute_name, hint:, label:, caption:, prefix_text:, suffix_text:, width:, form_group:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
         @width           = width
         @label           = label
         @caption         = caption
         @hint            = hint
+        @prefix_text     = prefix_text
+        @suffix_text     = suffix_text
         @html_attributes = kwargs
         @form_group      = form_group
       end
 
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name, **@form_group).html do
-          safe_join([label_element, supplemental_content, hint_element, error_element, input])
+          safe_join([label_element, supplemental_content, hint_element, error_element, content])
         end
       end
 
     private
 
-      def input
-        @builder.send(builder_method, @attribute_name, **input_options, **@html_attributes)
+      def content
+        if affixed?
+          affixed_input
+        else
+          input
+        end
       end
 
-      def input_options
+      def affixed_input
+        content_tag('div', class: %(#{brand}-input__wrapper)) do
+          safe_join([prefix, input, suffix])
+        end
+      end
+
+      def input
+        @builder.send(builder_method, @attribute_name, **options, **@html_attributes)
+      end
+
+      def affixed?
+        [@prefix_text, @suffix_text].any?
+      end
+
+      def options
         {
           id: field_id(link_errors: true),
-          class: input_classes,
+          class: classes,
           aria: { describedby: described_by(hint_id, error_id, supplemental_id) }
         }
       end
 
-      def input_classes
+      def classes
         [%(#{brand}-input)].push(width_classes, error_classes).compact
       end
 
@@ -63,6 +83,18 @@ module GOVUKDesignSystemFormBuilder
 
         else fail(ArgumentError, "invalid width '#{@width}'")
         end
+      end
+
+      def prefix
+        return nil if @prefix_text.blank?
+
+        tag.span(@prefix_text, class: %(#{brand}-input__prefix))
+      end
+
+      def suffix
+        return nil if @suffix_text.blank?
+
+        tag.span(@suffix_text, class: %(#{brand}-input__suffix))
       end
     end
   end

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -110,4 +110,73 @@ shared_examples 'a regular input' do |method_identifier, field_type|
       end
     end
   end
+
+  describe 'affixes' do
+    let(:prefix_text) { '£' }
+    let(:suffix_text) { 'per item' }
+
+    shared_examples 'prefixes' do
+      specify 'the wrapper and prefix should be present' do
+        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+          with_tag('div', with: { class: 'govuk-input__wrapper' }) do
+            with_tag('span', with: { class: 'govuk-input__prefix' }, text: prefix_text)
+            with_tag('input')
+          end
+        end
+      end
+    end
+
+    shared_examples 'suffixes' do
+      specify 'the wrapper and suffix should be present' do
+        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+          with_tag('div', with: { class: 'govuk-input__wrapper' }) do
+            with_tag('span', with: { class: 'govuk-input__suffix' }, text: suffix_text)
+            with_tag('input')
+          end
+        end
+      end
+    end
+
+    shared_examples 'no prefix' do
+      specify 'prefix should not be present' do
+        expect(subject).not_to have_tag('span', with: { class: 'govuk-input__prefix' })
+        expect(subject).to have_tag('input')
+      end
+    end
+
+    shared_examples 'no suffix' do
+      specify 'suffix should not be present' do
+        expect(subject).not_to have_tag('span', with: { class: 'govuk-input__suffix' })
+        expect(subject).to have_tag('input')
+      end
+    end
+
+    context 'when a prefix is supplied' do
+      subject { builder.send(*args, prefix_text: prefix_text) }
+
+      include_examples 'prefixes'
+      include_examples 'no suffix'
+    end
+
+    context 'when a suffix is supplied' do
+      subject { builder.send(*args, suffix_text: suffix_text) }
+
+      include_examples 'suffixes'
+      include_examples 'no prefix'
+    end
+
+    context 'when both a prefix and suffix are supplied' do
+      subject { builder.send(*args, prefix_text: prefix_text, suffix_text: suffix_text) }
+
+      include_examples 'prefixes'
+      include_examples 'suffixes'
+    end
+
+    context 'when neither a prefix or suffix is supplied' do
+      subject { builder.send(*args) }
+
+      include_examples 'no prefix'
+      include_examples 'no suffix'
+    end
+  end
 end

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -119,7 +119,7 @@ shared_examples 'a regular input' do |method_identifier, field_type|
       specify 'the wrapper and prefix should be present' do
         expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
           with_tag('div', with: { class: 'govuk-input__wrapper' }) do
-            with_tag('span', with: { class: 'govuk-input__prefix' }, text: prefix_text)
+            with_tag('span', with: { class: 'govuk-input__prefix', 'aria-hidden': true }, text: prefix_text)
             with_tag('input')
           end
         end
@@ -130,7 +130,7 @@ shared_examples 'a regular input' do |method_identifier, field_type|
       specify 'the wrapper and suffix should be present' do
         expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
           with_tag('div', with: { class: 'govuk-input__wrapper' }) do
-            with_tag('span', with: { class: 'govuk-input__suffix' }, text: suffix_text)
+            with_tag('span', with: { class: 'govuk-input__suffix', 'aria-hidden': true }, text: suffix_text)
             with_tag('input')
           end
         end


### PR DESCRIPTION
This change adds support for the new prefix and suffix text support in GOV.UK frontend. It allows text to be added before and after text inputs in a grey box to give users more context around the data, for example stating the currency of a expected monetary value.

* [x] Wait for version ~`3.8.0`~ `3.9.0` of the Design System to be released and make sure everything looks ok

Fixes #159