### PR TITLE
Change Haml link from http to https

### DIFF
--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -67,7 +67,7 @@ module Helpers
     end
 
     def haml_link
-      'http://haml.info'
+      'https://haml.info'
     end
 
     def version_supporting_design_system_v2


### PR DESCRIPTION
Now http://haml.info (correctly) redirects to https://haml.info - this new behaviour was making the guide's external link checks fail