### PR TITLE
Set Slim's template format to HTML

### DIFF
--- a/guide/Rules
+++ b/guide/Rules
@@ -5,7 +5,7 @@ compile '/index.slim' do
 end
 
 compile '/**/*.slim' do
-  filter :slim
+  filter :slim, format: :html
   filter :colorize_syntax, default_colorizer: :rouge
   filter :rubypants
   layout '/default.*'

--- a/guide/lib/helpers/formatters.rb
+++ b/guide/lib/helpers/formatters.rb
@@ -12,7 +12,7 @@ module Helpers
       beautify(
         CGI.unescapeHTML(
           CGI.unescapeHTML(
-            Slim::Template.new { raw }.render(OpenStruct.new(args))
+            Slim::Template.new(format: :html) { raw }.render(OpenStruct.new(args))
           )
         )
       )


### PR DESCRIPTION
It defaults to XHTML and this causes a few minor 'oddities' in the output when supplying boolean values to attributes; rather than the value being omitted it's set to an empty string `""`.

In the guide, `aria-hidden` is set to `true` in the following style:

```slim
  span.govuk-warning-text__icon aria-hidden=true !
```

Changing the format to HTML results in the following change to the output:

```diff
- <span aria-hidden="" class="govuk-warning-text__icon">
+ <span aria-hidden class="govuk-warning-text__icon">
    !
  </span>
```