### PR TITLE
Investigate adding fixture-based specs

### DIFF
--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -5,9 +5,8 @@
   "requires": true,
   "dependencies": {
     "govuk-frontend": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.7.0.tgz",
-      "integrity": "sha512-G3bqoKGGF8YQ18UJH9tTARrwB8i7iPwN1xc8RXwWyx91q0p/Xl10uNywZLkzGWcJDzEz1vwmBTTL3SLDU/KxNg=="
+      "version": "github:alphagov/govuk-frontend#634eeca76ee6f4399cba54cc13a11bd38f5c450a",
+      "from": "github:alphagov/govuk-frontend#634eeca76ee6f4399cba54cc13a11bd38f5c450a"
     }
   }
 }

--- a/guide/package.json
+++ b/guide/package.json
@@ -12,6 +12,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "govuk-frontend": "^3.7.0"
+    "govuk-frontend": "github:alphagov/govuk-frontend#634eeca76ee6f4399cba54cc13a11bd38f5c450a"
   }
 }

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -716,7 +716,7 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_submit "Proceed", prevent_double_click: true do
     #     = link_to 'Cancel', some_other_path, class: 'govuk-button__secondary'
     #
-    def govuk_submit(text = config.default_submit_button_text, warning: false, secondary: false, classes: nil, prevent_double_click: true, validate: false, disabled: false, &block)
+    def govuk_submit(text = config.default_submit_button_text, warning: false, secondary: false, classes: nil, prevent_double_click: false, validate: true, disabled: false, &block)
       Elements::Submit.new(self, text, warning: warning, secondary: secondary, classes: classes, prevent_double_click: prevent_double_click, validate: validate, disabled: disabled, &block).html
     end
 

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -39,9 +39,16 @@ module GOVUKDesignSystemFormBuilder
         {
           formnovalidate: !@validate,
           disabled: @disabled,
+          name: @text.parameterize,
           data: {
             module: %(#{brand}-button),
-            'prevent-double-click': @prevent_double_click
+            'prevent-double-click': @prevent_double_click,
+
+            # this is an attempt to prevent Rails from adding a
+            # data-disable-with attr to the input element.
+            #
+            # it doesn't work (╯°□°）╯︵ ┻━┻
+            disable_with: false
           }.select { |_k, v| v.present? }
         }
       end

--- a/spec/fixtures/button_spec.rb
+++ b/spec/fixtures/button_spec.rb
@@ -1,0 +1,32 @@
+describe GOVUKDesignSystemFormBuilder::FormBuilder do
+  include_context 'setup builder'
+
+  describe 'Button' do
+    # we only generate `<input type=submit...` so ignore everything else like `<button>`
+    applicable = ['input']
+    
+    fixtures = JSON
+      .parse(File.read('guide/node_modules/govuk-frontend/govuk/components/button/fixtures.json'))
+      .select { |f| f['name'].in?(applicable) }
+
+    fixtures.each do |fixture|
+      describe fixture['name'] do
+        let(:expected) { fixture['html'] }
+
+        let(:button_text) { fixture.dig('options', 'text') }
+        subject { builder.govuk_submit(button_text) }
+
+        # name: input
+        # options:
+        #   element: input
+        #   name: start-now
+        #   text: Start now
+        #   html: <input value="Start now" type="submit" name="start-now" class="govuk-button" data-module="govuk-button">
+
+        specify 'should match the HTML' do
+          expect(subject).to eql(expected)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is an initial attempt at using [GOV.UK Frontend's recent fixtures addition](https://github.com/alphagov/govuk-frontend/issues/1830) to ensure the HTML we're generating is in accordance with the Design System.

After flipping a few default values it's not a million miles off, but there are some snags:

1. Rails insists on [adding a `data-disable-with` attribute to the submit](https://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-submit_tag), even when I attempt to [disable it by passing `false`](https://github.com/DFE-Digital/govuk_design_system_formbuilder/pull/166/files#diff-2c10b5e6f11bb65361b9cc8fbca59fcfR47)

2. Because in all cases (other than `#govuk_date_field`) we are merely wrapping the built-in Rails form helpers, we're not in control of the order of attributes. Comparing them directly will fail.

Both of these problems are demonstrated in the RSpec output:

```diff
- <input value="Start now" type="submit" name="start-now" class="govuk-button" data-module="govuk-button">
+ <input type="submit" name="start-now" value="Start now" class="govuk-button" data-module="govuk-button" data-disable-with="Start now" />
```

While using the fixtures would be nice, it's clearly aimed at ports rather than supporting libraries. Getting it all in sync is probably going to be a headache compared to the succinct specs we already have.

Is there a better way of approaching this?