### PR TITLE
Refactor tags and remove unused delegations

### DIFF
--- a/guide/content/building-blocks/injecting-content.slim
+++ b/guide/content/building-blocks/injecting-content.slim
@@ -49,7 +49,7 @@ ul.govuk-list.govuk-list--bullet
 section
 
   == render('/partials/example-fig.*',
-    caption: "A collection of radio buttons with a paragraph explaining what will happen when the form is submitted",
+    caption: "A radio button collection with a custom warning",
     code: text_area_with_injected_content,
     sample_data: departments_data_raw) do
 

--- a/guide/content/css/guide.sass
+++ b/guide/content/css/guide.sass
@@ -180,3 +180,10 @@ p, li, dt, dd, td, th
 .orange-underline
   text-decoration: underline orange solid 2px
   text-underline-offset: 4px
+
+.final-decision-warning
+  @extend %govuk-body-s
+
+  background: govuk-tint(govuk-colour('pink'), 92%)
+  border: 1px solid govuk-tint(govuk-colour('pink'), 80%)
+  padding: 1em 1em

--- a/guide/content/introduction/labels-captions-hints-and-legends.slim
+++ b/guide/content/introduction/labels-captions-hints-and-legends.slim
@@ -79,9 +79,6 @@ section
           can enforce consistency between the label's <code>for</code> attribute
           and the associated form element.
 
-      p.govuk-body.important
-        | This example contains raw html but Rails' built-in tag helpers are fully-supported.
-
 section
 
   h2.govuk-heading-l Captions
@@ -200,7 +197,6 @@ section
 
     p.govuk-body
       | To take even more control of legends the content can be passed in using
-        a #{link_to('Ruby proc', ruby_proc_link).html_safe}.
-
-    p.govuk-body.important
-      | This example contains raw html but Rails' built-in tag helpers are fully-supported.
+        a #{link_to('Ruby proc', ruby_proc_link).html_safe}. In this example
+        we're using Slim but could just as easily call a helper method or
+        render a partial, component or string of HTML.

--- a/guide/layouts/partials/head.slim
+++ b/guide/layouts/partials/head.slim
@@ -19,6 +19,6 @@ head
   link rel='apple-touch-icon' href='/assets/images/govuk-apple-touch-icon.png'
 
   link href='/css/rouge.css' rel='stylesheet'
-  link href='/css/govuk-design-system-formbuilder-guide.css' rel='stylesheet'
+  link href='/css/guide.css' rel='stylesheet'
 
   meta property='og:image' content='/assets/images/govuk-opengraph-image.png'

--- a/guide/lib/examples/injecting_content.rb
+++ b/guide/lib/examples/injecting_content.rb
@@ -6,17 +6,10 @@ module Examples
           departments,
           :id,
           :name,
-          legend: { text: "Who do you want to nominate for the Best Department award?" },
-          hint_text: "The department will not be notified they've been nominated for an award until the annual awards evening." do
+          legend: { text: "Which department do you want to nominate?" } do
 
-            .govuk-warning-text
-              span.govuk-warning-text__icon aria-hidden=true !
-              strong.govuk-warning-text__text
-                span.govuk-warning-text__assistive
-                  | Warning
-                | Unlike in previous years, nominations are not anonymous. The
-                  list of voters will be published after the prizes have been
-                  awarded.
+            p.final-decision-warning
+              | Your decision is final and cannot be edited later
       SNIPPET
     end
   end

--- a/guide/lib/examples/labels_captions_hints_and_legends.rb
+++ b/guide/lib/examples/labels_captions_hints_and_legends.rb
@@ -14,7 +14,9 @@ module Examples
     def text_field_with_label_proc
       <<~SNIPPET
         = f.govuk_text_field :favourite_shade_of_orange,
-          label: -> { %(<h2 class="govuk-header-m orange-underline">What's your favourite shade of orange?</h2>) }
+          label: -> do
+            h2.orange-underline.govuk-header-m
+              | What's your favourite shade of orange?
       SNIPPET
     end
 
@@ -50,7 +52,13 @@ module Examples
           primary_colours,
           :id,
           :name,
-          legend: -> { %(<h3 class="govuk-heading-l">Which <span class="ugly-gradient">colour</span> do you hate most?</h3>) }
+          legend: -> do
+            h3.govuk-heading-l
+              ' Which
+
+              span.ugly-gradient colour
+
+              ' do you hate most?
       SNIPPET
     end
   end

--- a/guide/lib/helpers/person.rb
+++ b/guide/lib/helpers/person.rb
@@ -83,8 +83,8 @@ class Person
 
   validates :welcome_pack_reference_number, presence: { message: 'Enter the reference number you received in your welcome pack' }
   validates :welcome_pack_received_on, presence: { message: 'Enter the date you received your welcome pack' }
+  validates :department_id, presence: { message: %(Select the department to which you've been assigned) }
   validates :welcome_lunch_choice, presence: { message: 'Select a lunch choice for your first day' }
-  validates :department_id, presence: { message: "Choose the department you'll be working in" }
 
   # fieldset
   attr_accessor(

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -88,7 +88,7 @@ module GOVUKDesignSystemFormBuilder
   end
 
   class FormBuilder < ActionView::Helpers::FormBuilder
-    delegate :content_tag, :tag, :safe_join, :link_to, :raw, to: :@template
+    delegate :content_tag, :tag, :safe_join, :link_to, to: :@template
 
     include GOVUKDesignSystemFormBuilder::Builder
   end

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -88,7 +88,7 @@ module GOVUKDesignSystemFormBuilder
   end
 
   class FormBuilder < ActionView::Helpers::FormBuilder
-    delegate :content_tag, :tag, :safe_join, :safe_concat, :capture, :link_to, :raw, to: :@template
+    delegate :content_tag, :tag, :safe_join, :link_to, :raw, to: :@template
 
     include GOVUKDesignSystemFormBuilder::Builder
   end

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -8,7 +8,7 @@ module GOVUKDesignSystemFormBuilder
   end
 
   class Base
-    delegate :content_tag, :safe_join, :tag, :raw, :link_to, to: :@builder
+    delegate :content_tag, :safe_join, :tag, :link_to, to: :@builder
     delegate :config, to: GOVUKDesignSystemFormBuilder
 
     def initialize(builder, object_name, attribute_name, &block)

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -8,14 +8,14 @@ module GOVUKDesignSystemFormBuilder
   end
 
   class Base
-    delegate :capture, :content_tag, :safe_join, :tag, :raw, :link_to, to: :@builder
+    delegate :content_tag, :safe_join, :tag, :raw, :link_to, to: :@builder
     delegate :config, to: GOVUKDesignSystemFormBuilder
 
     def initialize(builder, object_name, attribute_name, &block)
       @builder        = builder
       @object_name    = object_name
       @attribute_name = attribute_name
-      @block_content  = capture { block.call } if block_given?
+      @block_content  = block.call if block_given?
     end
 
     # objects that implement #to_s can be passed directly into #safe_join

--- a/lib/govuk_design_system_formbuilder/containers/character_count.rb
+++ b/lib/govuk_design_system_formbuilder/containers/character_count.rb
@@ -14,7 +14,7 @@ module GOVUKDesignSystemFormBuilder
       def html
         return yield unless limit?
 
-        content_tag('div', **options) { yield }
+        tag.div(**options) { yield }
       end
 
     private

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
@@ -8,7 +8,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        content_tag('div', **options) { yield }
+        tag.div(**options) { yield }
       end
 
     private

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -13,7 +13,7 @@ module GOVUKDesignSystemFormBuilder
         @small              = small
         @classes            = classes
         @form_group_classes = form_group_classes
-        @block_content      = capture { block.call }
+        @block_content      = block.call
       end
 
       def html

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -11,7 +11,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        content_tag('fieldset', **options) do
+        tag.fieldset(**options) do
           safe_join([legend_element, (@block_content || yield)])
         end
       end

--- a/lib/govuk_design_system_formbuilder/containers/form_group.rb
+++ b/lib/govuk_design_system_formbuilder/containers/form_group.rb
@@ -8,7 +8,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        content_tag('div', class: classes) { yield }
+        tag.div(class: classes) { yield }
       end
 
     private

--- a/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
@@ -14,7 +14,7 @@ module GOVUKDesignSystemFormBuilder
         @hint_text          = hint_text
         @classes            = classes
         @form_group_classes = form_group_classes
-        @block_content      = capture { block.call }
+        @block_content      = block.call
       end
 
       def html

--- a/lib/govuk_design_system_formbuilder/containers/radios.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radios.rb
@@ -11,7 +11,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        content_tag('div', **options) { yield }
+        tag.div(**options) { yield }
       end
 
     private

--- a/lib/govuk_design_system_formbuilder/containers/supplemental.rb
+++ b/lib/govuk_design_system_formbuilder/containers/supplemental.rb
@@ -10,7 +10,7 @@ module GOVUKDesignSystemFormBuilder
       def html
         return nil if @content.blank?
 
-        content_tag('div', id: supplemental_id) { @content }
+        tag.div(id: supplemental_id) { @content }
       end
 
     private

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
@@ -18,7 +18,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def html
-          content_tag('div', class: %(#{brand}-checkboxes__item)) do
+          tag.div(class: %(#{brand}-checkboxes__item)) do
             safe_join([check_box, label_element, hint_element])
           end
         end

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
@@ -2,8 +2,6 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module CheckBoxes
       class CollectionCheckBox < Base
-        using PrefixableArray
-
         include Traits::CollectionItem
         include Traits::Hint
 

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -30,7 +30,7 @@ module GOVUKDesignSystemFormBuilder
       private
 
         def item
-          content_tag('div', class: %(#{brand}-checkboxes__item)) do
+          tag.div(class: %(#{brand}-checkboxes__item)) do
             safe_join([check_box, label_element, hint_element])
           end
         end

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -35,7 +35,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def date
-        content_tag('div', class: %(#{brand}-date-input)) do
+        tag.div(class: %(#{brand}-date-input)) do
           safe_join([day, month, year])
         end
       end
@@ -61,8 +61,8 @@ module GOVUKDesignSystemFormBuilder
       def date_part(segment, width:, link_errors: false)
         value = @builder.object.try(@attribute_name).try(segment)
 
-        content_tag('div', class: %w(date-input__item).prefix(brand)) do
-          content_tag('div', class: %w(form-group).prefix(brand)) do
+        tag.div(class: %w(date-input__item).prefix(brand)) do
+          tag.div(class: %w(form-group).prefix(brand)) do
             safe_join([label(segment, link_errors), input(segment, link_errors, width, value)])
           end
         end

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -61,8 +61,8 @@ module GOVUKDesignSystemFormBuilder
       def date_part(segment, width:, link_errors: false)
         value = @builder.object.try(@attribute_name).try(segment)
 
-        tag.div(class: %w(date-input__item).prefix(brand)) do
-          tag.div(class: %w(form-group).prefix(brand)) do
+        tag.div(class: %(#{brand}-date-input__item)) do
+          tag.div(class: %(#{brand}-form-group)) do
             safe_join([label(segment, link_errors), input(segment, link_errors, width, value)])
           end
         end

--- a/lib/govuk_design_system_formbuilder/elements/error_message.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_message.rb
@@ -12,7 +12,7 @@ module GOVUKDesignSystemFormBuilder
       def html
         return nil unless has_errors?
 
-        content_tag('span', class: %(#{brand}-error-message), id: error_id) do
+        tag.span(class: %(#{brand}-error-message), id: error_id) do
           safe_join([prefix, message])
         end
       end

--- a/lib/govuk_design_system_formbuilder/elements/error_message.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_message.rb
@@ -13,13 +13,13 @@ module GOVUKDesignSystemFormBuilder
         return nil unless has_errors?
 
         tag.span(class: %(#{brand}-error-message), id: error_id) do
-          safe_join([prefix, message])
+          safe_join([hidden_prefix, message])
         end
       end
 
     private
 
-      def prefix
+      def hidden_prefix
         tag.span('Error: ', class: %(#{brand}-visually-hidden))
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -12,7 +12,7 @@ module GOVUKDesignSystemFormBuilder
       def html
         return nil unless object_has_errors?
 
-        content_tag('div', class: summary_class, **summary_options) do
+        tag.div(class: summary_class, **summary_options) do
           safe_join([title, summary])
         end
       end
@@ -24,8 +24,8 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def summary
-        content_tag('div', class: summary_class('body')) do
-          content_tag('ul', class: [%(#{brand}-list), summary_class('list')]) do
+        tag.div(class: summary_class('body')) do
+          tag.ul(class: [%(#{brand}-list), summary_class('list')]) do
             safe_join(list)
           end
         end

--- a/lib/govuk_design_system_formbuilder/elements/inputs/email.rb
+++ b/lib/govuk_design_system_formbuilder/elements/inputs/email.rb
@@ -2,8 +2,6 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module Inputs
       class Email < Base
-        using PrefixableArray
-
         include Traits::Input
         include Traits::Error
         include Traits::Hint

--- a/lib/govuk_design_system_formbuilder/elements/inputs/number.rb
+++ b/lib/govuk_design_system_formbuilder/elements/inputs/number.rb
@@ -2,8 +2,6 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module Inputs
       class Number < Base
-        using PrefixableArray
-
         include Traits::Input
         include Traits::Error
         include Traits::Hint

--- a/lib/govuk_design_system_formbuilder/elements/inputs/password.rb
+++ b/lib/govuk_design_system_formbuilder/elements/inputs/password.rb
@@ -2,8 +2,6 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module Inputs
       class Password < Base
-        using PrefixableArray
-
         include Traits::Input
         include Traits::Error
         include Traits::Hint

--- a/lib/govuk_design_system_formbuilder/elements/inputs/phone.rb
+++ b/lib/govuk_design_system_formbuilder/elements/inputs/phone.rb
@@ -2,8 +2,6 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module Inputs
       class Phone < Base
-        using PrefixableArray
-
         include Traits::Input
         include Traits::Error
         include Traits::Hint

--- a/lib/govuk_design_system_formbuilder/elements/inputs/text.rb
+++ b/lib/govuk_design_system_formbuilder/elements/inputs/text.rb
@@ -2,8 +2,6 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module Inputs
       class Text < Base
-        using PrefixableArray
-
         include Traits::Input
         include Traits::Error
         include Traits::Hint

--- a/lib/govuk_design_system_formbuilder/elements/inputs/url.rb
+++ b/lib/govuk_design_system_formbuilder/elements/inputs/url.rb
@@ -2,8 +2,6 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module Inputs
       class URL < Base
-        using PrefixableArray
-
         include Traits::Input
         include Traits::Error
         include Traits::Hint

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -47,7 +47,7 @@ module GOVUKDesignSystemFormBuilder
         text = [option_text, localised_text(:label), @attribute_name.capitalize].compact.first.to_s
 
         if hidden
-          tag.span(text, class: %w(visually-hidden).prefix(brand))
+          tag.span(text, class: %(#{brand}-visually-hidden))
         else
           text
         end

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -44,7 +44,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def retrieve_text(option_text, hidden)
-        text = [option_text, localised_text(:label), @attribute_name.capitalize].compact.first.to_s
+        text = [option_text, localised_text(:label), @attribute_name.capitalize].compact.first
 
         if hidden
           tag.span(text, class: %(#{brand}-visually-hidden))

--- a/lib/govuk_design_system_formbuilder/elements/legend.rb
+++ b/lib/govuk_design_system_formbuilder/elements/legend.rb
@@ -31,7 +31,7 @@ module GOVUKDesignSystemFormBuilder
 
       def content
         if @text.present?
-          content_tag('legend', class: classes) do
+          tag.legend(class: classes) do
             content_tag(@tag, class: heading_classes) do
               safe_join([caption_element, @text])
             end

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
@@ -2,8 +2,6 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     module Radios
       class CollectionRadioButton < Base
-        using PrefixableArray
-
         include Traits::Hint
         include Traits::CollectionItem
 
@@ -38,7 +36,7 @@ module GOVUKDesignSystemFormBuilder
           {
             id: field_id(link_errors: @link_errors),
             aria: { describedby: hint_id },
-            class: %w(radios__input).prefix(brand)
+            class: %(#{brand}-radios__input)
           }
         end
 

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
@@ -23,7 +23,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def html
-          content_tag('div', class: %(#{brand}-radios__item)) do
+          tag.div(class: %(#{brand}-radios__item)) do
             safe_join([radio, label_element, hint_element])
           end
         end

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -29,7 +29,7 @@ module GOVUKDesignSystemFormBuilder
       private
 
         def radio
-          content_tag('div', class: %(#{brand}-radios__item)) do
+          tag.div(class: %(#{brand}-radios__item)) do
             safe_join([input, label_element, hint_element])
           end
         end

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -14,7 +14,7 @@ module GOVUKDesignSystemFormBuilder
         @classes              = classes
         @validate             = validate
         @disabled             = disabled
-        @block_content        = capture { block.call } if block_given?
+        @block_content        = block.call if block_given?
       end
 
       def html

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -79,7 +79,7 @@ module GOVUKDesignSystemFormBuilder
       def limit_description
         return nil unless limit?
 
-        content_tag('span', id: limit_id, class: limit_description_classes, aria: { live: 'polite' }) do
+        tag.span(id: limit_id, class: limit_description_classes, aria: { live: 'polite' }) do
           "You can enter up to #{limit_quantity} #{limit_type}"
         end
       end

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -11,15 +11,15 @@ module GOVUKDesignSystemFormBuilder
       def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, rows:, max_words:, max_chars:, threshold:, form_group_classes:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @label           = label
-        @caption         = caption
-        @hint_text       = hint_text
-        @max_words       = max_words
-        @max_chars       = max_chars
-        @threshold       = threshold
-        @rows            = rows
+        @label              = label
+        @caption            = caption
+        @hint_text          = hint_text
+        @max_words          = max_words
+        @max_chars          = max_chars
+        @threshold          = threshold
+        @rows               = rows
         @form_group_classes = form_group_classes
-        @html_attributes = kwargs
+        @html_attributes    = kwargs
       end
 
       def html
@@ -42,7 +42,7 @@ module GOVUKDesignSystemFormBuilder
 
       def classes
         %w(textarea).prefix(brand).tap do |classes|
-          classes.push(%(#{brand}-textarea--error)) if has_errors?
+          classes.push(%(#{brand}-textarea--error))    if has_errors?
           classes.push(%(#{brand}-js-character-count)) if limit?
         end
       end

--- a/lib/govuk_design_system_formbuilder/traits/conditional.rb
+++ b/lib/govuk_design_system_formbuilder/traits/conditional.rb
@@ -8,9 +8,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def wrap_conditional(block)
-        content_tag('div', class: conditional_classes, id: conditional_id) do
-          capture { block.call }
-        end
+        tag.div(class: conditional_classes, id: conditional_id) { block.call }
       end
     end
   end

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -90,14 +90,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             let(:object) { Person.new(favourite_colour: nil) }
             let(:identifier) { 'person-favourite-colour-field-error' }
             subject do
-              builder.capture do
-                builder.safe_join(
-                  [
-                    builder.govuk_error_summary,
-                    builder.govuk_collection_select(:favourite_colour, colours, :id, :name)
-                  ]
-                )
-              end
+              builder.safe_join(
+                [
+                  builder.govuk_error_summary,
+                  builder.govuk_collection_select(:favourite_colour, colours, :id, :name)
+                ]
+              )
             end
 
             specify "the error message should link directly to the govuk_collection_select field" do
@@ -111,14 +109,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             let(:identifier) { 'person-favourite-colour-field-error' }
             subject do
               builder.content_tag('div') do
-                builder.capture do
-                  builder.safe_join(
-                    [
-                      builder.govuk_error_summary,
-                      builder.govuk_collection_radio_buttons(:favourite_colour, colours, :id, :name)
-                    ]
-                  )
-                end
+                builder.safe_join(
+                  [
+                    builder.govuk_error_summary,
+                    builder.govuk_collection_radio_buttons(:favourite_colour, colours, :id, :name)
+                  ]
+                )
               end
             end
 
@@ -141,22 +137,20 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             let(:object) { Person.new(favourite_colour: nil) }
             let(:identifier) { 'person-favourite-colour-field-error' }
             subject do
-              builder.content_tag('div') do
-                builder.capture do
-                  builder.safe_join(
-                    [
-                      builder.govuk_error_summary,
-                      builder.govuk_radio_buttons_fieldset(:favourite_colour) do
-                        builder.safe_join(
-                          [
-                            builder.govuk_radio_button(:favourite_colour, :red, label: { text: red_label }, link_errors: true),
-                            builder.govuk_radio_button(:favourite_colour, :green, label: { text: green_label })
-                          ]
-                        )
-                      end
-                    ]
-                  )
-                end
+              builder.tag.div do
+                builder.safe_join(
+                  [
+                    builder.govuk_error_summary,
+                    builder.govuk_radio_buttons_fieldset(:favourite_colour) do
+                      builder.safe_join(
+                        [
+                          builder.govuk_radio_button(:favourite_colour, :red, label: { text: red_label }, link_errors: true),
+                          builder.govuk_radio_button(:favourite_colour, :green, label: { text: green_label })
+                        ]
+                      )
+                    end
+                  ]
+                )
               end
             end
 
@@ -179,15 +173,13 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             let(:object) { Person.new(projects: nil) }
             let(:identifier) { 'person-projects-field-error' }
             subject do
-              builder.content_tag('div') do
-                builder.capture do
-                  builder.safe_join(
-                    [
-                      builder.govuk_error_summary,
-                      builder.govuk_collection_check_boxes(:projects, projects, :id, :name)
-                    ]
-                  )
-                end
+              builder.tag.div do
+                builder.safe_join(
+                  [
+                    builder.govuk_error_summary,
+                    builder.govuk_collection_check_boxes(:projects, projects, :id, :name)
+                  ]
+                )
               end
             end
 
@@ -210,22 +202,20 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             let(:object) { Person.new }
             let(:identifier) { 'person-projects-field-error' }
             subject do
-              builder.content_tag('div') do
-                builder.capture do
-                  builder.safe_join(
-                    [
-                      builder.govuk_error_summary,
-                      builder.govuk_check_boxes_fieldset(:projects) do
-                        builder.safe_join(
-                          [
-                            builder.govuk_check_box(:projects, project_x.id, label: { text: project_x.name }, link_errors: true),
-                            builder.govuk_check_box(:projects, project_y.id, label: { text: project_y.name })
-                          ]
-                        )
-                      end
-                    ]
-                  )
-                end
+              builder.tag.div do
+                builder.safe_join(
+                  [
+                    builder.govuk_error_summary,
+                    builder.govuk_check_boxes_fieldset(:projects) do
+                      builder.safe_join(
+                        [
+                          builder.govuk_check_box(:projects, project_x.id, label: { text: project_x.name }, link_errors: true),
+                          builder.govuk_check_box(:projects, project_y.id, label: { text: project_y.name })
+                        ]
+                      )
+                    end
+                  ]
+                )
               end
             end
 
@@ -253,15 +243,13 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
               context "when omit_day is #{omit_day}" do
                 let(:first_date_segment_name) { "person[born_on(#{segment})]" }
                 subject do
-                  builder.content_tag('div') do
-                    builder.capture do
-                      builder.safe_join(
-                        [
-                          builder.govuk_error_summary,
-                          builder.govuk_date_field(:born_on, omit_day: omit_day)
-                        ]
-                      )
-                    end
+                  builder.tag.div do
+                    builder.safe_join(
+                      [
+                        builder.govuk_error_summary,
+                        builder.govuk_date_field(:born_on, omit_day: omit_day)
+                      ]
+                    )
                   end
                 end
 

--- a/spec/support/shared/shared_error_summary_examples.rb
+++ b/spec/support/shared/shared_error_summary_examples.rb
@@ -4,14 +4,12 @@ shared_examples 'an error summary linking directly to a form element' do |method
 
   let(:object) { Person.new(name: nil) }
   subject do
-    builder.capture do
-      builder.safe_join(
-        [
-          builder.govuk_error_summary,
-          builder.send(method, :name)
-        ]
-      )
-    end
+    builder.safe_join(
+      [
+        builder.govuk_error_summary,
+        builder.send(method, :name)
+      ]
+    )
   end
 
   specify "the error message should link directly to the #{method} field" do


### PR DESCRIPTION
* Favour `#tag` over `#content_tag` when the element is known/fixed
* Remove unused delegations: `#raw`, `#capture`
* Remove unnecessary `#to_s` call
* Improve documentation on content injection
* Fix the error summary ordering in the guide so it matches the form
* Remove some uses of `Array#prefix` where string interpolation is more straightforward, as a result some classes no longer need to be refined :tophat: 
* Improve documentation on using procs for labels and legends