### PR TITLE
Customise form group attributes

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -41,8 +41,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_text_field :callsign,
     #     label: -> { tag.h3('Call-sign') }
     #
-    def govuk_text_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group_classes: nil, **args, &block)
-      Elements::Inputs::Text.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group_classes: form_group_classes, **args, &block).html
+    def govuk_text_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group: {}, **args, &block)
+      Elements::Inputs::Text.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
     end
 
     # Generates a input of type +tel+
@@ -85,8 +85,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_phone_field :work_number,
     #     label: -> { tag.h3('Work number') }
     #
-    def govuk_phone_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group_classes: nil, **args, &block)
-      Elements::Inputs::Phone.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group_classes: form_group_classes, **args, &block).html
+    def govuk_phone_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group: {}, **args, &block)
+      Elements::Inputs::Phone.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
     end
 
     # Generates a input of type +email+
@@ -127,8 +127,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_email_field :personal_email,
     #     label: -> { tag.h3('Personal email address') }
     #
-    def govuk_email_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group_classes: nil, **args, &block)
-      Elements::Inputs::Email.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group_classes: form_group_classes, **args, &block).html
+    def govuk_email_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group: {}, **args, &block)
+      Elements::Inputs::Email.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
     end
 
     # Generates a input of type +password+
@@ -168,8 +168,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_password_field :passcode,
     #     label: -> { tag.h3('What is your secret pass code?') }
     #
-    def govuk_password_field(attribute_name, hint_text: nil, label: {}, width: nil, form_group_classes: nil, caption: {}, **args, &block)
-      Elements::Inputs::Password.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group_classes: form_group_classes, **args, &block).html
+    def govuk_password_field(attribute_name, hint_text: nil, label: {}, width: nil, form_group: {}, caption: {}, **args, &block)
+      Elements::Inputs::Password.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
     end
 
     # Generates a input of type +url+
@@ -210,8 +210,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_url_field :work_website,
     #     label: -> { tag.h3("Enter your company's website") }
     #
-    def govuk_url_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group_classes: nil, **args, &block)
-      Elements::Inputs::URL.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group_classes: form_group_classes, **args, &block).html
+    def govuk_url_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group: {}, **args, &block)
+      Elements::Inputs::URL.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
     end
 
     # Generates a input of type +number+
@@ -255,8 +255,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_url_field :personal_best_over_100m,
     #     label: -> { tag.h3("How many seconds does it take you to run 100m?") }
     #
-    def govuk_number_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group_classes: nil, **args, &block)
-      Elements::Inputs::Number.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group_classes: form_group_classes, **args, &block).html
+    def govuk_number_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group: {}, **args, &block)
+      Elements::Inputs::Number.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
     end
 
     # Generates a +textarea+ element with a label, optional hint. Also offers
@@ -304,8 +304,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_text_area :instructions,
     #     label: -> { tag.h3("How do you set it up?") }
     #
-    def govuk_text_area(attribute_name, hint_text: nil, label: {}, caption: {}, max_words: nil, max_chars: nil, rows: 5, threshold: nil, form_group_classes: nil, **args, &block)
-      Elements::TextArea.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, max_words: max_words, max_chars: max_chars, rows: rows, threshold: threshold, form_group_classes: form_group_classes, **args, &block).html
+    def govuk_text_area(attribute_name, hint_text: nil, label: {}, caption: {}, max_words: nil, max_chars: nil, rows: 5, threshold: nil, form_group: {}, **args, &block)
+      Elements::TextArea.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, max_words: max_words, max_chars: max_chars, rows: rows, threshold: threshold, form_group: form_group, **args, &block).html
     end
 
     # Generates a +select+ element containing +option+ for each member in the provided collection
@@ -343,7 +343,7 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_collection_select(:team, @teams, :id, :name) do
     #     label: -> { tag.h3("Which team did you represent?") }
     #
-    def govuk_collection_select(attribute_name, collection, value_method, text_method, options: {}, html_options: {}, hint_text: nil, label: {}, caption: {}, form_group_classes: nil, &block)
+    def govuk_collection_select(attribute_name, collection, value_method, text_method, options: {}, html_options: {}, hint_text: nil, label: {}, caption: {}, form_group: {}, &block)
       Elements::Select.new(
         self,
         object_name,
@@ -356,7 +356,7 @@ module GOVUKDesignSystemFormBuilder
         caption: caption,
         options: options,
         html_options: html_options,
-        form_group_classes: form_group_classes,
+        form_group: form_group,
         &block
       ).html
     end
@@ -427,7 +427,7 @@ module GOVUKDesignSystemFormBuilder
     #    :name,
     #    legend: -> { tag.h3('Which category do you belong to?') }
     #
-    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, caption: {}, inline: false, small: false, bold_labels: false, classes: nil, form_group_classes: nil, &block)
+    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, caption: {}, inline: false, small: false, bold_labels: false, classes: nil, form_group: {}, &block)
       Elements::Radios::Collection.new(
         self,
         object_name,
@@ -443,7 +443,7 @@ module GOVUKDesignSystemFormBuilder
         small: small,
         bold_labels: bold_labels,
         classes: classes,
-        form_group_classes: form_group_classes,
+        form_group: form_group,
         &block
       ).html
     end
@@ -491,8 +491,8 @@ module GOVUKDesignSystemFormBuilder
     #      = f.govuk_radio_button :burger_id, :regular, label: { text: 'Hamburger' }, link_errors: true
     #      = f.govuk_radio_button :burger_id, :cheese, label: { text: 'Cheeseburger' }
     #
-    def govuk_radio_buttons_fieldset(attribute_name, hint_text: nil, legend: {}, caption: {}, inline: false, small: false, classes: nil, form_group_classes: nil, &block)
-      Containers::RadioButtonsFieldset.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, caption: caption, inline: inline, small: small, classes: classes, form_group_classes: form_group_classes, &block).html
+    def govuk_radio_buttons_fieldset(attribute_name, hint_text: nil, legend: {}, caption: {}, inline: false, small: false, classes: nil, form_group: {}, &block)
+      Containers::RadioButtonsFieldset.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, caption: caption, inline: inline, small: small, classes: classes, form_group: form_group, &block).html
     end
 
     # Generates a radio button
@@ -589,7 +589,7 @@ module GOVUKDesignSystemFormBuilder
     #    :name,
     #    legend: -> { tag.h3('What kind of sandwich do you want?') }
     #
-    def govuk_collection_check_boxes(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, caption: {}, small: false, classes: nil, form_group_classes: nil, &block)
+    def govuk_collection_check_boxes(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, caption: {}, small: false, classes: nil, form_group: {}, &block)
       Elements::CheckBoxes::Collection.new(
         self,
         object_name,
@@ -603,7 +603,7 @@ module GOVUKDesignSystemFormBuilder
         caption: caption,
         small: small,
         classes: classes,
-        form_group_classes: form_group_classes,
+        form_group: form_group,
         &block
       ).html
     end
@@ -639,7 +639,7 @@ module GOVUKDesignSystemFormBuilder
     #    = f.govuk_check_box :desired_filling, :lemonade, label: { text: 'Lemonade' }, link_errors: true
     #    = f.govuk_check_box :desired_filling, :fizzy_orange, label: { text: 'Fizzy orange' }
     #
-    def govuk_check_boxes_fieldset(attribute_name, legend: {}, caption: {}, hint_text: {}, small: false, classes: nil, form_group_classes: nil, &block)
+    def govuk_check_boxes_fieldset(attribute_name, legend: {}, caption: {}, hint_text: {}, small: false, classes: nil, form_group: {}, &block)
       Containers::CheckBoxesFieldset.new(
         self,
         object_name,
@@ -649,7 +649,7 @@ module GOVUKDesignSystemFormBuilder
         caption: caption,
         small: small,
         classes: classes,
-        form_group_classes: form_group_classes,
+        form_group: form_group,
         &block
       ).html
     end
@@ -756,8 +756,8 @@ module GOVUKDesignSystemFormBuilder
     # @example A date input with legend supplied as a proc
     #  = f.govuk_date_field :finishes_on,
     #    legend: -> { tag.h3('Which category do you belong to?') }
-    def govuk_date_field(attribute_name, hint_text: nil, legend: {}, caption: {}, date_of_birth: false, omit_day: false, form_group_classes: nil, &block)
-      Elements::Date.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, caption: caption, date_of_birth: date_of_birth, omit_day: omit_day, form_group_classes: form_group_classes, &block).html
+    def govuk_date_field(attribute_name, hint_text: nil, legend: {}, caption: {}, date_of_birth: false, omit_day: false, form_group: {}, &block)
+      Elements::Date.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, caption: caption, date_of_birth: date_of_birth, omit_day: omit_day, form_group: form_group, &block).html
     end
 
     # Generates a summary of errors in the form, each linking to the corresponding
@@ -834,8 +834,8 @@ module GOVUKDesignSystemFormBuilder
     # @note Remember to set +multipart: true+ when creating a form with file
     #   uploads, {https://guides.rubyonrails.org/form_helpers.html#uploading-files see
     #   the Rails documentation} for more information
-    def govuk_file_field(attribute_name, label: {}, caption: {}, hint_text: nil, form_group_classes: nil, **args, &block)
-      Elements::File.new(self, object_name, attribute_name, label: label, caption: caption, hint_text: hint_text, form_group_classes: form_group_classes, **args, &block).html
+    def govuk_file_field(attribute_name, label: {}, caption: {}, hint_text: nil, form_group: {}, **args, &block)
+      Elements::File.new(self, object_name, attribute_name, label: label, caption: caption, hint_text: hint_text, form_group: form_group, **args, &block).html
     end
   end
 end

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -17,7 +17,9 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
-    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
+    # @param form_group [Hash] configures the form group
+    # @option form_group classes [Array,String] sets the form group's classes
+    # @option form_group args [Hash] additional attributes added to the form group
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -60,7 +62,9 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
-    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
+    # @param form_group [Hash] configures the form group
+    # @option form_group classes [Array,String] sets the form group's classes
+    # @option form_group args [Hash] additional attributes added to the form group
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -104,7 +108,9 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
-    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
+    # @param form_group [Hash] configures the form group
+    # @option form_group classes [Array,String] sets the form group's classes
+    # @option form_group args [Hash] additional attributes added to the form group
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -146,7 +152,9 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
-    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
+    # @param form_group [Hash] configures the form group
+    # @option form_group classes [Array,String] sets the form group's classes
+    # @option form_group args [Hash] additional attributes added to the form group
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -187,7 +195,9 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
-    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
+    # @param form_group [Hash] configures the form group
+    # @option form_group classes [Array,String] sets the form group's classes
+    # @option form_group args [Hash] additional attributes added to the form group
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -229,7 +239,9 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
-    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
+    # @param form_group [Hash] configures the form group
+    # @option form_group classes [Array,String] sets the form group's classes
+    # @option form_group args [Hash] additional attributes added to the form group
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/text-input/ GOV.UK Text input
@@ -278,7 +290,9 @@ module GOVUKDesignSystemFormBuilder
     # @param threshold [Integer] only show the +max_words+ and +max_chars+ warnings once a threshold (percentage) is reached
     # @param rows [Integer] sets the initial number of rows
     # @option args [Hash] args additional arguments are applied as attributes to the +textarea+ element
-    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
+    # @param form_group [Hash] configures the form group
+    # @option form_group classes [Array,String] sets the form group's classes
+    # @option form_group args [Hash] additional attributes added to the form group
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/textarea/ GOV.UK text area component
@@ -321,7 +335,9 @@ module GOVUKDesignSystemFormBuilder
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @param options [Hash] Options hash passed through to Rails' +collection_select+ helper
     # @param html_options [Hash] HTML Options hash passed through to Rails' +collection_select+ helper
-    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
+    # @param form_group [Hash] configures the form group
+    # @option form_group classes [Array,String] sets the form group's classes
+    # @option form_group args [Hash] additional attributes added to the form group
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @see https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-collection_select Rails collection_select (called by govuk_collection_select)
     # @return [ActiveSupport::SafeBuffer] HTML output
@@ -467,7 +483,9 @@ module GOVUKDesignSystemFormBuilder
     # @param caption [Hash] configures or sets the caption content which is inserted above the legend
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
-    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
+    # @param form_group [Hash] configures the form group
+    # @option form_group classes [Array,String] sets the form group's classes
+    # @option form_group args [Hash] additional attributes added to the form group
     # @param block [Block] a block of HTML that will be used to populate the fieldset
     # @param classes [Array,String] Classes to add to the radio button container.
     # @see https://design-system.service.gov.uk/components/radios/ GOV.UK Radios
@@ -552,7 +570,9 @@ module GOVUKDesignSystemFormBuilder
     # @param caption [Hash] configures or sets the caption content which is inserted above the legend
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
-    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
+    # @param form_group [Hash] configures the form group
+    # @option form_group classes [Array,String] sets the form group's classes
+    # @option form_group args [Hash] additional attributes added to the form group
     # @param block [Block] any HTML passed in will be injected into the fieldset, after the hint and before the checkboxes
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
@@ -625,7 +645,9 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @param classes [Array,String] Classes to add to the checkbox container.
-    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
+    # @param form_group [Hash] configures the form group
+    # @option form_group classes [Array,String] sets the form group's classes
+    # @option form_group args [Hash] additional attributes added to the form group
     # @param block [Block] a block of HTML that will be used to populate the fieldset
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
@@ -736,7 +758,9 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @param omit_day [Boolean] do not render a day input, only capture month and year
-    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
+    # @param form_group [Hash] configures the form group
+    # @option form_group classes [Array,String] sets the form group's classes
+    # @option form_group args [Hash] additional attributes added to the form group
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input group
     # @param date_of_birth [Boolean] if +true+ {https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Values birth date auto completion attributes}
     #   will be added to the inputs
@@ -815,7 +839,9 @@ module GOVUKDesignSystemFormBuilder
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
-    # @param form_group_classes [Array,String] Classes to add to the surrounding +form-group+
+    # @param form_group [Hash] configures the form group
+    # @option form_group classes [Array,String] sets the form group's classes
+    # @option form_group args [Hash] additional attributes added to the form group
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     #
     # @example A photo upload field with file type specifier and injected content

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -4,20 +4,20 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Error
       include Traits::Hint
 
-      def initialize(builder, object_name, attribute_name, hint_text:, legend:, caption:, small:, classes:, form_group_classes:, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, legend:, caption:, small:, classes:, form_group:, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @legend             = legend
-        @caption            = caption
-        @hint_text          = hint_text
-        @small              = small
-        @classes            = classes
-        @form_group_classes = form_group_classes
-        @block_content      = block.call
+        @legend        = legend
+        @caption       = caption
+        @hint_text     = hint_text
+        @small         = small
+        @classes       = classes
+        @form_group    = form_group
+        @block_content = block.call
       end
 
       def html
-        Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
+        Containers::FormGroup.new(@builder, @object_name, @attribute_name, **@form_group).html do
           Containers::Fieldset.new(@builder, @object_name, @attribute_name, **fieldset_options).html do
             safe_join([hint_element, error_element, checkboxes])
           end

--- a/lib/govuk_design_system_formbuilder/containers/form_group.rb
+++ b/lib/govuk_design_system_formbuilder/containers/form_group.rb
@@ -1,14 +1,15 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
     class FormGroup < Base
-      def initialize(builder, object_name, attribute_name, classes: nil)
+      def initialize(builder, object_name, attribute_name, classes: nil, **kwargs)
         super(builder, object_name, attribute_name)
 
-        @classes = classes
+        @classes       = classes
+        @extra_options = kwargs
       end
 
       def html
-        tag.div(class: classes) { yield }
+        tag.div(class: classes, **@extra_options) { yield }
       end
 
     private

--- a/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
@@ -4,21 +4,21 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Hint
       include Traits::Error
 
-      def initialize(builder, object_name, attribute_name, hint_text:, legend:, caption:, inline:, small:, classes:, form_group_classes:, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, legend:, caption:, inline:, small:, classes:, form_group:, &block)
         super(builder, object_name, attribute_name)
 
-        @inline             = inline
-        @small              = small
-        @legend             = legend
-        @caption            = caption
-        @hint_text          = hint_text
-        @classes            = classes
-        @form_group_classes = form_group_classes
-        @block_content      = block.call
+        @inline        = inline
+        @small         = small
+        @legend        = legend
+        @caption       = caption
+        @hint_text     = hint_text
+        @classes       = classes
+        @form_group    = form_group
+        @block_content = block.call
       end
 
       def html
-        Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
+        Containers::FormGroup.new(@builder, @object_name, @attribute_name, **@form_group).html do
           Containers::Fieldset.new(@builder, @object_name, @attribute_name, **fieldset_options).html do
             safe_join([hint_element, error_element, radios])
           end

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -6,23 +6,23 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Supplemental
 
-        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method: nil, hint_text:, legend:, caption:, small:, classes:, form_group_classes:, &block)
+        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method: nil, hint_text:, legend:, caption:, small:, classes:, form_group:, &block)
           super(builder, object_name, attribute_name, &block)
 
-          @collection         = collection
-          @value_method       = value_method
-          @text_method        = text_method
-          @hint_method        = hint_method
-          @small              = small
-          @legend             = legend
-          @caption            = caption
-          @hint_text          = hint_text
-          @classes            = classes
-          @form_group_classes = form_group_classes
+          @collection   = collection
+          @value_method = value_method
+          @text_method  = text_method
+          @hint_method  = hint_method
+          @small        = small
+          @legend       = legend
+          @caption      = caption
+          @hint_text    = hint_text
+          @classes      = classes
+          @form_group   = form_group
         end
 
         def html
-          Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
+          Containers::FormGroup.new(@builder, @object_name, @attribute_name, **@form_group).html do
             Containers::Fieldset.new(@builder, @object_name, @attribute_name, **fieldset_options).html do
               safe_join([supplemental_content, hint_element, error_element, check_boxes])
             end

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -9,19 +9,19 @@ module GOVUKDesignSystemFormBuilder
 
       SEGMENTS = { day: '3i', month: '2i', year: '1i' }.freeze
 
-      def initialize(builder, object_name, attribute_name, legend:, caption:, hint_text:, date_of_birth: false, omit_day:, form_group_classes:, &block)
+      def initialize(builder, object_name, attribute_name, legend:, caption:, hint_text:, date_of_birth: false, omit_day:, form_group:, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @legend             = legend
-        @caption            = caption
-        @hint_text          = hint_text
-        @date_of_birth      = date_of_birth
-        @omit_day           = omit_day
-        @form_group_classes = form_group_classes
+        @legend        = legend
+        @caption       = caption
+        @hint_text     = hint_text
+        @date_of_birth = date_of_birth
+        @omit_day      = omit_day
+        @form_group    = form_group
       end
 
       def html
-        Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
+        Containers::FormGroup.new(@builder, @object_name, @attribute_name, **@form_group).html do
           Containers::Fieldset.new(@builder, @object_name, @attribute_name, **fieldset_options).html do
             safe_join([supplemental_content, hint_element, error_element, date])
           end

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -8,18 +8,18 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Label
       include Traits::Supplemental
 
-      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, form_group_classes:, **kwargs, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, form_group:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @label              = label
-        @caption            = caption
-        @hint_text          = hint_text
-        @extra_options      = kwargs
-        @form_group_classes = form_group_classes
+        @label         = label
+        @caption       = caption
+        @hint_text     = hint_text
+        @extra_options = kwargs
+        @form_group    = form_group
       end
 
       def html
-        Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
+        Containers::FormGroup.new(@builder, @object_name, @attribute_name, **@form_group).html do
           safe_join([label_element, supplemental_content, hint_element, error_element, file])
         end
       end

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -6,25 +6,25 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Supplemental
 
-        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method:, hint_text:, legend:, caption:, inline:, small:, bold_labels:, classes:, form_group_classes:, &block)
+        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method:, hint_text:, legend:, caption:, inline:, small:, bold_labels:, classes:, form_group:, &block)
           super(builder, object_name, attribute_name, &block)
 
-          @collection         = collection
-          @value_method       = value_method
-          @text_method        = text_method
-          @hint_method        = hint_method
-          @inline             = inline
-          @small              = small
-          @legend             = legend
-          @caption            = caption
-          @hint_text          = hint_text
-          @classes            = classes
-          @form_group_classes = form_group_classes
-          @bold_labels        = hint_method.present? || bold_labels
+          @collection   = collection
+          @value_method = value_method
+          @text_method  = text_method
+          @hint_method  = hint_method
+          @inline       = inline
+          @small        = small
+          @legend       = legend
+          @caption      = caption
+          @hint_text    = hint_text
+          @classes      = classes
+          @form_group   = form_group
+          @bold_labels  = hint_method.present? || bold_labels
         end
 
         def html
-          Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
+          Containers::FormGroup.new(@builder, @object_name, @attribute_name, **@form_group).html do
             Containers::Fieldset.new(@builder, @object_name, @attribute_name, **fieldset_options).html do
               safe_join([supplemental_content, hint_element, error_element, radios])
             end

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -6,22 +6,22 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Hint
       include Traits::Supplemental
 
-      def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, options: {}, html_options: {}, hint_text:, label:, caption:, form_group_classes:, &block)
+      def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, options: {}, html_options: {}, hint_text:, label:, caption:, form_group:, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @collection         = collection
-        @value_method       = value_method
-        @text_method        = text_method
-        @options            = options
-        @html_options       = html_options
-        @label              = label
-        @caption            = caption
-        @hint_text          = hint_text
-        @form_group_classes = form_group_classes
+        @collection   = collection
+        @value_method = value_method
+        @text_method  = text_method
+        @options      = options
+        @html_options = html_options
+        @label        = label
+        @caption      = caption
+        @hint_text    = hint_text
+        @form_group   = form_group
       end
 
       def html
-        Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
+        Containers::FormGroup.new(@builder, @object_name, @attribute_name, **@form_group).html do
           safe_join([label_element, supplemental_content, hint_element, error_element, select])
         end
       end

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -8,23 +8,23 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Label
       include Traits::Supplemental
 
-      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, rows:, max_words:, max_chars:, threshold:, form_group_classes:, **kwargs, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, rows:, max_words:, max_chars:, threshold:, form_group:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @label              = label
-        @caption            = caption
-        @hint_text          = hint_text
-        @max_words          = max_words
-        @max_chars          = max_chars
-        @threshold          = threshold
-        @rows               = rows
-        @form_group_classes = form_group_classes
-        @html_attributes    = kwargs
+        @label           = label
+        @caption         = caption
+        @hint_text       = hint_text
+        @max_words       = max_words
+        @max_chars       = max_chars
+        @threshold       = threshold
+        @rows            = rows
+        @form_group      = form_group
+        @html_attributes = kwargs
       end
 
       def html
         Containers::CharacterCount.new(@builder, **character_count_options).html do
-          Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
+          Containers::FormGroup.new(@builder, @object_name, @attribute_name, **@form_group).html do
             safe_join([label_element, supplemental_content, hint_element, error_element, text_area, limit_description])
           end
         end

--- a/lib/govuk_design_system_formbuilder/traits/input.rb
+++ b/lib/govuk_design_system_formbuilder/traits/input.rb
@@ -1,19 +1,19 @@
 module GOVUKDesignSystemFormBuilder
   module Traits
     module Input
-      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, width:, form_group_classes:, **kwargs, &block)
+      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, width:, form_group:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @width              = width
-        @label              = label
-        @caption            = caption
-        @hint_text          = hint_text
-        @html_attributes    = kwargs
-        @form_group_classes = form_group_classes
+        @width           = width
+        @label           = label
+        @caption         = caption
+        @hint_text       = hint_text
+        @html_attributes = kwargs
+        @form_group      = form_group
       end
 
       def html
-        Containers::FormGroup.new(@builder, @object_name, @attribute_name, classes: @form_group_classes).html do
+        Containers::FormGroup.new(@builder, @object_name, @attribute_name, **@form_group).html do
           safe_join([label_element, supplemental_content, hint_element, error_element, input])
         end
       end

--- a/spec/support/shared/shared_form_group_examples.rb
+++ b/spec/support/shared/shared_form_group_examples.rb
@@ -1,10 +1,11 @@
 shared_examples 'a field that contains a customisable form group' do
+  let(:block_content) { %(Are you acquainted with our state's stringent usury laws?) }
+
   example_group 'when custom classes are provided' do
     let(:default_class) { %w(govuk-form-group) }
-    let(:block_content) { %(Are you acquainted with our state's stringent usury laws?) }
 
     subject do
-      builder.send(*args, form_group_classes: custom_classes) { builder.tag.span(block_content) }
+      builder.send(*args, form_group: { classes: custom_classes }) { builder.tag.span(block_content) }
     end
 
     context 'classes passed in as an array' do
@@ -21,6 +22,18 @@ shared_examples 'a field that contains a customisable form group' do
       specify 'the form group should contain the additional classes' do
         expect(subject).to have_tag('div', with: { class: default_class + custom_classes.split })
       end
+    end
+  end
+
+  example_group 'when a custom id is provided' do
+    let(:custom_id) { %(xyz-123) }
+
+    subject do
+      builder.send(*args, form_group: { id: custom_id }) { builder.tag.span(block_content) }
+    end
+
+    specify 'the form group should contain the additional classes' do
+      expect(subject).to have_tag('div', with: { id: custom_id })
     end
   end
 end


### PR DESCRIPTION
Instead of only allowing a form group's classes to be configured, this change replaces the `form_group_classes` argument with `form_group` which takes a hash.

Adding a classes key to the hash will append these extra classes to the required ones (`.govuk-form-group`). Any other key/value pairs will be added as attributes to the form group element.