### PR TITLE
Make hint arguments follow convention set by label, legend, etc

### DIFF
--- a/guide/content/form-elements/select.slim
+++ b/guide/content/form-elements/select.slim
@@ -19,7 +19,7 @@ section
 
   == render('/partials/example-fig.*',
     caption: "Select field with a label and hint",
-    code: select_field_with_label_and_hint_text,
+    code: select_field_with_label_and_hint,
     sample_data: departments_data_raw)
 
 == render('/partials/related-info.*', links: select_info)

--- a/guide/lib/examples/checkboxes.rb
+++ b/guide/lib/examples/checkboxes.rb
@@ -41,7 +41,7 @@ module Examples
             :english,
             label: { text: "English" },
             link_errors: true,
-            hint_text: "Only select English if you have a GCSE at grade C or above"
+            hint: { text: "Only select English if you have a GCSE at grade C or above" }
 
           = f.govuk_check_box :languages,
             :welsh,

--- a/guide/lib/examples/date.rb
+++ b/guide/lib/examples/date.rb
@@ -5,7 +5,7 @@ module Examples
         = f.govuk_date_field :date_of_birth,
           date_of_birth: true,
           legend: { text: 'Enter your date of birth' },
-          hint_text: 'For example, 31 3 1980'
+          hint: { text: 'For example, 31 3 1980' }
       SNIPPET
     end
 
@@ -14,7 +14,7 @@ module Examples
         = f.govuk_date_field :graduation_month,
           omit_day: true,
           legend: { text: 'When did you graduate?' },
-          hint_text: 'For example, 3 2014'
+          hint: { text: 'For example, 3 2014' }
       SNIPPET
     end
   end

--- a/guide/lib/examples/file.rb
+++ b/guide/lib/examples/file.rb
@@ -4,7 +4,7 @@ module Examples
       <<~SNIPPET
         = f.govuk_file_field :profile_photo,
           label: { text: 'Identification photograph' },
-          hint_text: 'Upload a clear colour photograph of yourself looking straight at the camera'
+          hint: { text: 'Upload a clear colour photograph of yourself looking straight at the camera' }
       SNIPPET
     end
   end

--- a/guide/lib/examples/labels_captions_hints_and_legends.rb
+++ b/guide/lib/examples/labels_captions_hints_and_legends.rb
@@ -32,7 +32,7 @@ module Examples
       <<~SNIPPET
         = f.govuk_text_field :favourite_shade_of_blue,
           label: { text: 'What is your favourite shade of blue?' },
-          hint_text: 'The shade you reach for first when painting the sky'
+          hint: { text: 'The shade you reach for first when painting the sky' }
       SNIPPET
     end
 

--- a/guide/lib/examples/radios.rb
+++ b/guide/lib/examples/radios.rb
@@ -7,7 +7,7 @@ module Examples
           :id,
           :name,
           legend: { text: 'Which department do you work for?' },
-          hint_text: 'There should be a sign near your desk'
+          hint: { text: 'There should be a sign near your desk' }
       SNIPPET
     end
 

--- a/guide/lib/examples/select.rb
+++ b/guide/lib/examples/select.rb
@@ -1,13 +1,13 @@
 module Examples
   module Select
-    def select_field_with_label_and_hint_text
+    def select_field_with_label_and_hint
       <<~SNIPPET
         = f.govuk_collection_select :new_department_id,
           departments,
           :id,
           :name,
           label: { text: "Which department do you work in?" },
-          hint_text: "You can find it on your ID badge"
+          hint: { text: "You can find it on your ID badge" }
       SNIPPET
     end
   end

--- a/guide/lib/examples/text_area.rb
+++ b/guide/lib/examples/text_area.rb
@@ -8,7 +8,7 @@ module Examples
       <<~SNIPPET
         = f.govuk_text_area :job_description,
           label: { text: 'Job description' },
-          hint_text: 'Describe your typical day',
+          hint: { text: 'Describe your typical day' },
           rows: 9
       SNIPPET
     end

--- a/guide/lib/examples/text_input.rb
+++ b/guide/lib/examples/text_input.rb
@@ -4,7 +4,7 @@ module Examples
       <<~SNIPPET
         = f.govuk_text_field :first_name,
           label: { text: 'First name' },
-          hint_text: 'You can find it on your birth certificate'
+          hint: { text: 'You can find it on your birth certificate' }
       SNIPPET
     end
 

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -43,8 +43,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_text_field :callsign,
     #     label: -> { tag.h3('Call-sign') }
     #
-    def govuk_text_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group: {}, **args, &block)
-      Elements::Inputs::Text.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
+    def govuk_text_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, **args, &block)
+      Elements::Inputs::Text.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
     end
 
     # Generates a input of type +tel+
@@ -89,8 +89,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_phone_field :work_number,
     #     label: -> { tag.h3('Work number') }
     #
-    def govuk_phone_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group: {}, **args, &block)
-      Elements::Inputs::Phone.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
+    def govuk_phone_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, **args, &block)
+      Elements::Inputs::Phone.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
     end
 
     # Generates a input of type +email+
@@ -133,8 +133,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_email_field :personal_email,
     #     label: -> { tag.h3('Personal email address') }
     #
-    def govuk_email_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group: {}, **args, &block)
-      Elements::Inputs::Email.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
+    def govuk_email_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, **args, &block)
+      Elements::Inputs::Email.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
     end
 
     # Generates a input of type +password+
@@ -176,8 +176,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_password_field :passcode,
     #     label: -> { tag.h3('What is your secret pass code?') }
     #
-    def govuk_password_field(attribute_name, hint_text: nil, label: {}, width: nil, form_group: {}, caption: {}, **args, &block)
-      Elements::Inputs::Password.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
+    def govuk_password_field(attribute_name, hint: {}, label: {}, width: nil, form_group: {}, caption: {}, **args, &block)
+      Elements::Inputs::Password.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
     end
 
     # Generates a input of type +url+
@@ -220,8 +220,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_url_field :work_website,
     #     label: -> { tag.h3("Enter your company's website") }
     #
-    def govuk_url_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group: {}, **args, &block)
-      Elements::Inputs::URL.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
+    def govuk_url_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, **args, &block)
+      Elements::Inputs::URL.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
     end
 
     # Generates a input of type +number+
@@ -267,8 +267,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_url_field :personal_best_over_100m,
     #     label: -> { tag.h3("How many seconds does it take you to run 100m?") }
     #
-    def govuk_number_field(attribute_name, hint_text: nil, label: {}, caption: {}, width: nil, form_group: {}, **args, &block)
-      Elements::Inputs::Number.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
+    def govuk_number_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, **args, &block)
+      Elements::Inputs::Number.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, **args, &block).html
     end
 
     # Generates a +textarea+ element with a label, optional hint. Also offers
@@ -318,8 +318,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_text_area :instructions,
     #     label: -> { tag.h3("How do you set it up?") }
     #
-    def govuk_text_area(attribute_name, hint_text: nil, label: {}, caption: {}, max_words: nil, max_chars: nil, rows: 5, threshold: nil, form_group: {}, **args, &block)
-      Elements::TextArea.new(self, object_name, attribute_name, hint_text: hint_text, label: label, caption: caption, max_words: max_words, max_chars: max_chars, rows: rows, threshold: threshold, form_group: form_group, **args, &block).html
+    def govuk_text_area(attribute_name, hint: {}, label: {}, caption: {}, max_words: nil, max_chars: nil, rows: 5, threshold: nil, form_group: {}, **args, &block)
+      Elements::TextArea.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, max_words: max_words, max_chars: max_chars, rows: rows, threshold: threshold, form_group: form_group, **args, &block).html
     end
 
     # Generates a +select+ element containing +option+ for each member in the provided collection
@@ -359,7 +359,7 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_collection_select(:team, @teams, :id, :name) do
     #     label: -> { tag.h3("Which team did you represent?") }
     #
-    def govuk_collection_select(attribute_name, collection, value_method, text_method, options: {}, html_options: {}, hint_text: nil, label: {}, caption: {}, form_group: {}, &block)
+    def govuk_collection_select(attribute_name, collection, value_method, text_method, options: {}, html_options: {}, hint: {}, label: {}, caption: {}, form_group: {}, &block)
       Elements::Select.new(
         self,
         object_name,
@@ -367,7 +367,7 @@ module GOVUKDesignSystemFormBuilder
         collection,
         value_method: value_method,
         text_method: text_method,
-        hint_text: hint_text,
+        hint: hint,
         label: label,
         caption: caption,
         options: options,
@@ -443,7 +443,7 @@ module GOVUKDesignSystemFormBuilder
     #    :name,
     #    legend: -> { tag.h3('Which category do you belong to?') }
     #
-    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, caption: {}, inline: false, small: false, bold_labels: false, classes: nil, form_group: {}, &block)
+    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method, hint_method = nil, hint: {}, legend: {}, caption: {}, inline: false, small: false, bold_labels: false, classes: nil, form_group: {}, &block)
       Elements::Radios::Collection.new(
         self,
         object_name,
@@ -452,7 +452,7 @@ module GOVUKDesignSystemFormBuilder
         value_method: value_method,
         text_method: text_method,
         hint_method: hint_method,
-        hint_text: hint_text,
+        hint: hint,
         legend: legend,
         caption: caption,
         inline: inline,
@@ -509,8 +509,8 @@ module GOVUKDesignSystemFormBuilder
     #      = f.govuk_radio_button :burger_id, :regular, label: { text: 'Hamburger' }, link_errors: true
     #      = f.govuk_radio_button :burger_id, :cheese, label: { text: 'Cheeseburger' }
     #
-    def govuk_radio_buttons_fieldset(attribute_name, hint_text: nil, legend: {}, caption: {}, inline: false, small: false, classes: nil, form_group: {}, &block)
-      Containers::RadioButtonsFieldset.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, caption: caption, inline: inline, small: small, classes: classes, form_group: form_group, &block).html
+    def govuk_radio_buttons_fieldset(attribute_name, hint: {}, legend: {}, caption: {}, inline: false, small: false, classes: nil, form_group: {}, &block)
+      Containers::RadioButtonsFieldset.new(self, object_name, attribute_name, hint: hint, legend: legend, caption: caption, inline: inline, small: small, classes: classes, form_group: form_group, &block).html
     end
 
     # Generates a radio button
@@ -535,8 +535,8 @@ module GOVUKDesignSystemFormBuilder
     #  = f.govuk_radio_buttons_fieldset :favourite_colour do
     #    = f.govuk_radio_button :favourite_colour, :red, label: { text: 'Red' }
     #
-    def govuk_radio_button(attribute_name, value, hint_text: nil, label: {}, link_errors: false, &block)
-      Elements::Radios::FieldsetRadioButton.new(self, object_name, attribute_name, value, hint_text: hint_text, label: label, link_errors: link_errors, &block).html
+    def govuk_radio_button(attribute_name, value, hint: {}, label: {}, link_errors: false, &block)
+      Elements::Radios::FieldsetRadioButton.new(self, object_name, attribute_name, value, hint: hint, label: label, link_errors: link_errors, &block).html
     end
 
     # Inserts a text divider into a list of radio buttons
@@ -609,7 +609,7 @@ module GOVUKDesignSystemFormBuilder
     #    :name,
     #    legend: -> { tag.h3('What kind of sandwich do you want?') }
     #
-    def govuk_collection_check_boxes(attribute_name, collection, value_method, text_method, hint_method = nil, hint_text: nil, legend: {}, caption: {}, small: false, classes: nil, form_group: {}, &block)
+    def govuk_collection_check_boxes(attribute_name, collection, value_method, text_method, hint_method = nil, hint: {}, legend: {}, caption: {}, small: false, classes: nil, form_group: {}, &block)
       Elements::CheckBoxes::Collection.new(
         self,
         object_name,
@@ -618,7 +618,7 @@ module GOVUKDesignSystemFormBuilder
         value_method: value_method,
         text_method: text_method,
         hint_method: hint_method,
-        hint_text: hint_text,
+        hint: hint,
         legend: legend,
         caption: caption,
         small: small,
@@ -661,12 +661,12 @@ module GOVUKDesignSystemFormBuilder
     #    = f.govuk_check_box :desired_filling, :lemonade, label: { text: 'Lemonade' }, link_errors: true
     #    = f.govuk_check_box :desired_filling, :fizzy_orange, label: { text: 'Fizzy orange' }
     #
-    def govuk_check_boxes_fieldset(attribute_name, legend: {}, caption: {}, hint_text: {}, small: false, classes: nil, form_group: {}, &block)
+    def govuk_check_boxes_fieldset(attribute_name, legend: {}, caption: {}, hint: {}, small: false, classes: nil, form_group: {}, &block)
       Containers::CheckBoxesFieldset.new(
         self,
         object_name,
         attribute_name,
-        hint_text: hint_text,
+        hint: hint,
         legend: legend,
         caption: caption,
         small: small,
@@ -698,13 +698,13 @@ module GOVUKDesignSystemFormBuilder
     #     label: { text: 'Do you agree with our terms and conditions?' },
     #     hint_text: 'You will not be able to proceed unless you do'
     #
-    def govuk_check_box(attribute_name, value, hint_text: nil, label: {}, link_errors: false, multiple: true, &block)
+    def govuk_check_box(attribute_name, value, hint: {}, label: {}, link_errors: false, multiple: true, &block)
       Elements::CheckBoxes::FieldsetCheckBox.new(
         self,
         object_name,
         attribute_name,
         value,
-        hint_text: hint_text,
+        hint: hint,
         label: label,
         link_errors: link_errors,
         multiple: multiple,
@@ -780,8 +780,8 @@ module GOVUKDesignSystemFormBuilder
     # @example A date input with legend supplied as a proc
     #  = f.govuk_date_field :finishes_on,
     #    legend: -> { tag.h3('Which category do you belong to?') }
-    def govuk_date_field(attribute_name, hint_text: nil, legend: {}, caption: {}, date_of_birth: false, omit_day: false, form_group: {}, &block)
-      Elements::Date.new(self, object_name, attribute_name, hint_text: hint_text, legend: legend, caption: caption, date_of_birth: date_of_birth, omit_day: omit_day, form_group: form_group, &block).html
+    def govuk_date_field(attribute_name, hint: {}, legend: {}, caption: {}, date_of_birth: false, omit_day: false, form_group: {}, &block)
+      Elements::Date.new(self, object_name, attribute_name, hint: hint, legend: legend, caption: caption, date_of_birth: date_of_birth, omit_day: omit_day, form_group: form_group, &block).html
     end
 
     # Generates a summary of errors in the form, each linking to the corresponding
@@ -860,8 +860,8 @@ module GOVUKDesignSystemFormBuilder
     # @note Remember to set +multipart: true+ when creating a form with file
     #   uploads, {https://guides.rubyonrails.org/form_helpers.html#uploading-files see
     #   the Rails documentation} for more information
-    def govuk_file_field(attribute_name, label: {}, caption: {}, hint_text: nil, form_group: {}, **args, &block)
-      Elements::File.new(self, object_name, attribute_name, label: label, caption: caption, hint_text: hint_text, form_group: form_group, **args, &block).html
+    def govuk_file_field(attribute_name, label: {}, caption: {}, hint: {}, form_group: {}, **args, &block)
+      Elements::File.new(self, object_name, attribute_name, label: label, caption: caption, hint: hint, form_group: form_group, **args, &block).html
     end
   end
 end

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -5,7 +5,11 @@ module GOVUKDesignSystemFormBuilder
     # Generates a input of type +text+
     #
     # @param attribute_name [Symbol] The name of the attribute
-    # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint args [Hash] additional arguments are applied as attributes to the hint
+    #
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
     # @param label [Hash,Proc] configures or sets the associated label content
@@ -28,7 +32,7 @@ module GOVUKDesignSystemFormBuilder
     # @example A required full name field with a placeholder
     #   = f.govuk_text_field :name,
     #     label: { text: 'Full name' },
-    #     hint_text: 'It says it on your birth certificate',
+    #     hint: { text: 'It says it on your birth certificate' },
     #     required: true,
     #     placeholder: 'Ralph Wiggum'
     #
@@ -50,7 +54,10 @@ module GOVUKDesignSystemFormBuilder
     # Generates a input of type +tel+
     #
     # @param attribute_name [Symbol] The name of the attribute
-    # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint args [Hash] additional arguments are applied as attributes to the hint
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
     # @param label [Hash,Proc] configures or sets the associated label content
@@ -74,7 +81,7 @@ module GOVUKDesignSystemFormBuilder
     # @example A required phone number field with a placeholder
     #   = f.govuk_phone_field :phone_number,
     #     label: { text: 'UK telephone number' },
-    #     hint_text: 'Include the dialling code',
+    #     hint: { text: 'Include the dialling code' },
     #     required: true,
     #     placeholder: '0123 456 789'
     #
@@ -96,7 +103,10 @@ module GOVUKDesignSystemFormBuilder
     # Generates a input of type +email+
     #
     # @param attribute_name [Symbol] The name of the attribute
-    # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint args [Hash] additional arguments are applied as attributes to the hint
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
     # @param label [Hash,Proc] configures or sets the associated label content
@@ -140,7 +150,10 @@ module GOVUKDesignSystemFormBuilder
     # Generates a input of type +password+
     #
     # @param attribute_name [Symbol] The name of the attribute
-    # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint args [Hash] additional arguments are applied as attributes to the hint
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
     # @param label [Hash,Proc] configures or sets the associated label content
@@ -183,7 +196,10 @@ module GOVUKDesignSystemFormBuilder
     # Generates a input of type +url+
     #
     # @param attribute_name [Symbol] The name of the attribute
-    # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint args [Hash] additional arguments are applied as attributes to the hint
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
     # @param label [Hash,Proc] configures or sets the associated label content
@@ -227,7 +243,10 @@ module GOVUKDesignSystemFormBuilder
     # Generates a input of type +number+
     #
     # @param attribute_name [Symbol] The name of the attribute
-    # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint args [Hash] additional arguments are applied as attributes to the hint
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
     # @param label [Hash,Proc] configures or sets the associated label content
@@ -276,7 +295,10 @@ module GOVUKDesignSystemFormBuilder
     # automatically
     #
     # @param attribute_name [Symbol] The name of the attribute
-    # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint args [Hash] additional arguments are applied as attributes to the hint
     # @param label [Hash,Proc] configures or sets the associated label content
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
@@ -328,7 +350,10 @@ module GOVUKDesignSystemFormBuilder
     # @param collection [Enumerable<Object>] Options to be added to the +select+ element
     # @param value_method [Symbol] The method called against each member of the collection to provide the value
     # @param text_method [Symbol] The method called against each member of the collection to provide the text
-    # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint args [Hash] additional arguments are applied as attributes to the hint
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
@@ -347,7 +372,7 @@ module GOVUKDesignSystemFormBuilder
     #     @grades,
     #     :id,
     #     :name,
-    #     hint_text: "If you took the test more than once enter your highest grade"
+    #     hint: { text: "If you took the test more than once enter your highest grade" }
     #
     # @example A select box with injected content
     #   = f.govuk_collection_select(:favourite_colour, @colours, :id, :name) do
@@ -396,7 +421,10 @@ module GOVUKDesignSystemFormBuilder
     # @param hint_method [Symbol, Proc, nil] The method called against each member of the collection to provide the hint text.
     #   When a +Proc+ is provided it must take a single argument that is a single member of the collection.
     #   When a +nil+ value is provided the hint text will be retrieved from the locale. This is the default and param can be omitted.
-    # @param hint_text [String] The content of the fieldset hint. No hint will be injected if left +nil+
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint args [Hash] additional arguments are applied as attributes to the hint
     # @param legend [Hash,Proc] options for configuring the legend
     # @param inline [Boolean] controls whether the radio buttons are displayed inline or not
     # @param small [Boolean] controls whether small radio buttons are used instead of regular-sized ones
@@ -424,7 +452,7 @@ module GOVUKDesignSystemFormBuilder
     #    ->(option) { option.name.upcase },
     #    :description,
     #    legend: { text: 'Pick your favourite colour', size: 'm' },
-    #    hint_text: 'If you cannot find the exact match choose something close',
+    #    hint: { text: 'If you cannot find the exact match choose something close' },
     #    inline: false
     #
     # @example A collection of radio buttons for grades with injected content
@@ -472,7 +500,10 @@ module GOVUKDesignSystemFormBuilder
     #   is set to +link_errors: true+
     #
     # @param attribute_name [Symbol] The name of the attribute
-    # @param hint_text [String] The content of the fieldset hint. No hint will be injected if left +nil+
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint args [Hash] additional arguments are applied as attributes to the hint
     # @param legend [Hash,Proc] options for configuring the legend
     # @param inline [Boolean] controls whether the radio buttons are displayed inline or not
     # @param small [Boolean] controls whether small radio buttons are used instead of regular-sized ones
@@ -517,7 +548,10 @@ module GOVUKDesignSystemFormBuilder
     #
     # @note This should only be used from within a {#govuk_radio_buttons_fieldset}
     # @param attribute_name [Symbol] The name of the attribute
-    # @param hint_text [String] the contents of the hint
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint args [Hash] additional arguments are applied as attributes to the hint
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
@@ -559,7 +593,10 @@ module GOVUKDesignSystemFormBuilder
     # @param text_method [Symbol] The method called against each member of the collection to provide the label text
     # @param hint_method [Symbol, Proc] The method called against each member of the collection to provide the hint text.
     #   When a +Proc+ is provided it must take a single argument that is a single member of the collection
-    # @param hint_text [String] The content of the fieldset hint. No hint will be injected if left +nil+
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint args [Hash] additional arguments are applied as attributes to the hint
     # @param small [Boolean] controls whether small check boxes are used instead of regular-sized ones
     # @param classes [Array,String] Classes to add to the checkbox container.
     # @param legend [Hash,Proc] options for configuring the legend
@@ -589,7 +626,7 @@ module GOVUKDesignSystemFormBuilder
     #    :name,
     #    :description,
     #    legend: { text: 'What do you want in your sandwich?', size: 'm' },
-    #    hint_text: "If it isn't listed here, tough luck",
+    #    hint: { text: "If it isn't listed here, tough luck" },
     #    inline: false,
     #    classes: 'app-overflow-scroll',
     #
@@ -634,7 +671,10 @@ module GOVUKDesignSystemFormBuilder
     #   is set to +link_errors: true+
     #
     # @param attribute_name [Symbol] The name of the attribute
-    # @param hint_text [String] The content of the fieldset hint. No hint will be injected if left +nil+
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint args [Hash] additional arguments are applied as attributes to the hint
     # @param small [Boolean] controls whether small check boxes are used instead of regular-sized ones
     # @param legend [Hash,Proc] options for configuring the legend
     # @option legend text [String] the fieldset legend's text content
@@ -680,7 +720,10 @@ module GOVUKDesignSystemFormBuilder
     #
     # @param attribute_name [Symbol] The name of the attribute
     # @param value [Boolean,String,Symbol,Integer] The value of the checkbox when it is checked
-    # @param hint_text [String] the contents of the hint
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint args [Hash] additional arguments are applied as attributes to the hint
     # @param link_errors [Boolean] controls whether this radio button should be linked to from {#govuk_error_summary}
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
@@ -696,7 +739,7 @@ module GOVUKDesignSystemFormBuilder
     #     multiple: false,
     #     link_errors: true,
     #     label: { text: 'Do you agree with our terms and conditions?' },
-    #     hint_text: 'You will not be able to proceed unless you do'
+    #     hint: { text: 'You will not be able to proceed unless you do' }
     #
     def govuk_check_box(attribute_name, value, hint: {}, label: {}, link_errors: false, multiple: true, &block)
       Elements::CheckBoxes::FieldsetCheckBox.new(
@@ -748,7 +791,10 @@ module GOVUKDesignSystemFormBuilder
     #   of {https://bugs.ruby-lang.org/issues/5988 this} bug, so incorrect dates like +2019-09-31+ will
     #   be 'rounded' up to +2019-10-01+.
     # @param attribute_name [Symbol] The name of the attribute
-    # @param hint_text [String] the contents of the hint
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint args [Hash] additional arguments are applied as attributes to the hint
     # @param legend [Hash,Proc] options for configuring the legend
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
@@ -772,7 +818,7 @@ module GOVUKDesignSystemFormBuilder
     # @example A regular date input with a legend, hint and injected content
     #   = f.govuk_date_field :starts_on,
     #     legend: { 'When does your event start?' },
-    #     hint_text: 'Leave this field blank if you don't know exactly' } do
+    #     hint: { text: 'Leave this field blank if you don't know exactly' } do
     #
     #       p.govuk-inset-text
     #         | If you don't fill this in you won't be eligable for a refund
@@ -837,7 +883,10 @@ module GOVUKDesignSystemFormBuilder
     # @param caption [Hash] configures or sets the caption content which is inserted above the label
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
-    # @param hint_text [String] The content of the hint. No hint will be injected if left +nil+
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint args [Hash] additional arguments are applied as attributes to the hint
     # @option args [Hash] args additional arguments are applied as attributes to the +input+ element
     # @param form_group [Hash] configures the form group
     # @option form_group classes [Array,String] sets the form group's classes

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -4,12 +4,12 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Error
       include Traits::Hint
 
-      def initialize(builder, object_name, attribute_name, hint_text:, legend:, caption:, small:, classes:, form_group:, &block)
+      def initialize(builder, object_name, attribute_name, hint:, legend:, caption:, small:, classes:, form_group:, &block)
         super(builder, object_name, attribute_name, &block)
 
         @legend        = legend
         @caption       = caption
-        @hint_text     = hint_text
+        @hint          = hint
         @small         = small
         @classes       = classes
         @form_group    = form_group

--- a/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
@@ -4,14 +4,14 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Hint
       include Traits::Error
 
-      def initialize(builder, object_name, attribute_name, hint_text:, legend:, caption:, inline:, small:, classes:, form_group:, &block)
+      def initialize(builder, object_name, attribute_name, hint:, legend:, caption:, inline:, small:, classes:, form_group:, &block)
         super(builder, object_name, attribute_name)
 
         @inline        = inline
         @small         = small
         @legend        = legend
         @caption       = caption
-        @hint_text     = hint_text
+        @hint          = hint
         @classes       = classes
         @form_group    = form_group
         @block_content = block.call

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -6,7 +6,7 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Supplemental
 
-        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method: nil, hint_text:, legend:, caption:, small:, classes:, form_group:, &block)
+        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method: nil, hint:, legend:, caption:, small:, classes:, form_group:, &block)
           super(builder, object_name, attribute_name, &block)
 
           @collection   = collection
@@ -16,7 +16,7 @@ module GOVUKDesignSystemFormBuilder
           @small        = small
           @legend       = legend
           @caption      = caption
-          @hint_text    = hint_text
+          @hint         = hint
           @classes      = classes
           @form_group   = form_group
         end

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
@@ -11,7 +11,7 @@ module GOVUKDesignSystemFormBuilder
           @checkbox    = checkbox
           @item        = checkbox.object
           @value       = checkbox.value
-          @hint_text   = retrieve(@item, hint_method)
+          @hint        = { text: retrieve(@item, hint_method) }
           @link_errors = link_errors
         end
 
@@ -40,7 +40,11 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def hint_element
-          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text, @value, checkbox: true)
+          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_options, **@hint)
+        end
+
+        def hint_options
+          { value: @value, checkbox: true }
         end
       end
     end

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -8,12 +8,12 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Conditional
 
-        def initialize(builder, object_name, attribute_name, value, label:, hint_text:, link_errors:, multiple:, &block)
+        def initialize(builder, object_name, attribute_name, value, label:, hint:, link_errors:, multiple:, &block)
           super(builder, object_name, attribute_name)
 
           @value       = value
           @label       = label
-          @hint_text   = hint_text
+          @hint        = hint
           @multiple    = multiple
           @link_errors = link_errors
 
@@ -62,7 +62,11 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def hint_element
-          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text, @value, checkbox: true)
+          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_options, **@hint)
+        end
+
+        def hint_options
+          { checkbox: true }
         end
 
         def conditional_classes

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -9,12 +9,12 @@ module GOVUKDesignSystemFormBuilder
 
       SEGMENTS = { day: '3i', month: '2i', year: '1i' }.freeze
 
-      def initialize(builder, object_name, attribute_name, legend:, caption:, hint_text:, date_of_birth: false, omit_day:, form_group:, &block)
+      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, date_of_birth: false, omit_day:, form_group:, &block)
         super(builder, object_name, attribute_name, &block)
 
         @legend        = legend
         @caption       = caption
-        @hint_text     = hint_text
+        @hint          = hint
         @date_of_birth = date_of_birth
         @omit_day      = omit_day
         @form_group    = form_group

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -8,12 +8,12 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Label
       include Traits::Supplemental
 
-      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, form_group:, **kwargs, &block)
+      def initialize(builder, object_name, attribute_name, hint:, label:, caption:, form_group:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
         @label         = label
         @caption       = caption
-        @hint_text     = hint_text
+        @hint          = hint
         @extra_options = kwargs
         @form_group    = form_group
       end

--- a/lib/govuk_design_system_formbuilder/elements/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/hint.rb
@@ -5,7 +5,7 @@ module GOVUKDesignSystemFormBuilder
 
       include Traits::Localisation
 
-      def initialize(builder, object_name, attribute_name, value: nil, text: nil, radio: false, content: nil, checkbox: false)
+      def initialize(builder, object_name, attribute_name, value: nil, text: nil, radio: false, content: nil, checkbox: false, **kwargs)
         super(builder, object_name, attribute_name)
 
         if content
@@ -16,6 +16,8 @@ module GOVUKDesignSystemFormBuilder
           @radio    = radio
           @checkbox = checkbox
         end
+
+        @html_attributes = kwargs
       end
 
       def active?
@@ -25,7 +27,7 @@ module GOVUKDesignSystemFormBuilder
       def html
         return nil unless active?
 
-        content_tag(hint_tag, **hint_options) { hint_body }
+        content_tag(hint_tag, **hint_options, **@html_attributes) { hint_body }
       end
 
       def hint_id

--- a/lib/govuk_design_system_formbuilder/elements/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/hint.rb
@@ -5,23 +5,27 @@ module GOVUKDesignSystemFormBuilder
 
       include Traits::Localisation
 
-      def initialize(builder, object_name, attribute_name, value: nil, text: nil, radio: false, checkbox: false)
+      def initialize(builder, object_name, attribute_name, value: nil, text: nil, radio: false, content: nil, checkbox: false)
         super(builder, object_name, attribute_name)
 
-        @value    = value
-        @text     = retrieve_text(text)
-        @radio    = radio
-        @checkbox = checkbox
+        if content
+          @content = content.call
+        else
+          @value    = value
+          @text     = retrieve_text(text)
+          @radio    = radio
+          @checkbox = checkbox
+        end
       end
 
       def active?
-        @text.present?
+        [@text, @content].any?(&:present?)
       end
 
       def html
         return nil unless active?
 
-        tag.span(@text, class: classes, id: hint_id)
+        content_tag(hint_tag, **hint_options) { hint_body }
       end
 
       def hint_id
@@ -31,6 +35,18 @@ module GOVUKDesignSystemFormBuilder
       end
 
     private
+
+      def hint_options
+        { class: classes, id: hint_id }
+      end
+
+      def hint_tag
+        @content.presence ? 'div' : 'span'
+      end
+
+      def hint_body
+        @content || @text
+      end
 
       def retrieve_text(supplied)
         supplied.presence || localised_text(:hint)

--- a/lib/govuk_design_system_formbuilder/elements/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/hint.rb
@@ -3,22 +3,31 @@ module GOVUKDesignSystemFormBuilder
     class Hint < Base
       using PrefixableArray
 
-      include Traits::Hint
       include Traits::Localisation
 
-      def initialize(builder, object_name, attribute_name, text, value = nil, radio: false, checkbox: false)
+      def initialize(builder, object_name, attribute_name, value: nil, text: nil, radio: false, checkbox: false)
         super(builder, object_name, attribute_name)
 
-        @value     = value
-        @hint_text = retrieve_text(text)
-        @radio     = radio
-        @checkbox  = checkbox
+        @value    = value
+        @text     = retrieve_text(text)
+        @radio    = radio
+        @checkbox = checkbox
+      end
+
+      def active?
+        @text.present?
       end
 
       def html
-        return nil if @hint_text.blank?
+        return nil unless active?
 
-        tag.span(@hint_text, class: classes, id: hint_id)
+        tag.span(@text, class: classes, id: hint_id)
+      end
+
+      def hint_id
+        return nil unless active?
+
+        build_id('hint')
       end
 
     private

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -26,13 +26,17 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        return nil if [@content, @text].all?(&:blank?)
+        return nil unless active?
 
         if @tag.present?
           content_tag(@tag, class: %(#{brand}-label-wrapper)) { label }
         else
           label
         end
+      end
+
+      def active?
+        [@content, @text].any?(&:present?)
       end
 
     private

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -6,7 +6,7 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Supplemental
 
-        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method:, hint_text:, legend:, caption:, inline:, small:, bold_labels:, classes:, form_group:, &block)
+        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method:, hint:, legend:, caption:, inline:, small:, bold_labels:, classes:, form_group:, &block)
           super(builder, object_name, attribute_name, &block)
 
           @collection   = collection
@@ -17,7 +17,7 @@ module GOVUKDesignSystemFormBuilder
           @small        = small
           @legend       = legend
           @caption      = caption
-          @hint_text    = hint_text
+          @hint         = hint
           @classes      = classes
           @form_group   = form_group
           @bold_labels  = hint_method.present? || bold_labels

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
@@ -41,7 +41,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def hint_element
-          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text, @value, radio: true)
+          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, value: @value, text: @hint_text, radio: true)
         end
 
         def label_element

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -8,12 +8,12 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Conditional
 
-        def initialize(builder, object_name, attribute_name, value, label:, hint_text:, link_errors:, &block)
+        def initialize(builder, object_name, attribute_name, value, label:, hint:, link_errors:, &block)
           super(builder, object_name, attribute_name)
 
           @value       = value
           @label       = label
-          @hint_text   = hint_text
+          @hint        = hint
           @link_errors = has_errors? && link_errors
 
           if block_given?
@@ -34,16 +34,24 @@ module GOVUKDesignSystemFormBuilder
           end
         end
 
+        def radio_options
+          { radio: true }
+        end
+
         def label_element
-          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, **label_content, **label_options)
+          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, **label_content, **label_options, **@label)
         end
 
         def label_options
-          { radio: true, value: @value, link_errors: @link_errors }
+          { value: @value, link_errors: @link_errors }.merge(radio_options)
         end
 
         def hint_element
-          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text, @value, radio: true)
+          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_options, **@hint)
+        end
+
+        def hint_options
+          { value: @value }.merge(radio_options)
         end
 
         def input

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -6,7 +6,7 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Hint
       include Traits::Supplemental
 
-      def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, options: {}, html_options: {}, hint_text:, label:, caption:, form_group:, &block)
+      def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, options: {}, html_options: {}, hint:, label:, caption:, form_group:, &block)
         super(builder, object_name, attribute_name, &block)
 
         @collection   = collection
@@ -16,7 +16,7 @@ module GOVUKDesignSystemFormBuilder
         @html_options = html_options
         @label        = label
         @caption      = caption
-        @hint_text    = hint_text
+        @hint         = hint
         @form_group   = form_group
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -8,12 +8,12 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Label
       include Traits::Supplemental
 
-      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, rows:, max_words:, max_chars:, threshold:, form_group:, **kwargs, &block)
+      def initialize(builder, object_name, attribute_name, hint:, label:, caption:, rows:, max_words:, max_chars:, threshold:, form_group:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
         @label           = label
         @caption         = caption
-        @hint_text       = hint_text
+        @hint            = hint
         @max_words       = max_words
         @max_chars       = max_chars
         @threshold       = threshold

--- a/lib/govuk_design_system_formbuilder/traits/hint.rb
+++ b/lib/govuk_design_system_formbuilder/traits/hint.rb
@@ -10,11 +10,18 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def hint_element
-        @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_options)
+        @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_content)
       end
 
-      def hint_options
-        @hint || {}
+      def hint_content
+        case @hint
+        when Hash
+          @hint
+        when Proc
+          { content: @hint }
+        else
+          fail(ArgumentError, %(hint must be a Proc or Hash))
+        end
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/traits/hint.rb
+++ b/lib/govuk_design_system_formbuilder/traits/hint.rb
@@ -2,7 +2,7 @@ module GOVUKDesignSystemFormBuilder
   module Traits
     module Hint
       def hint_id
-        return nil if @hint_text.blank?
+        return nil unless hint_element.active?
 
         build_id('hint')
       end
@@ -10,7 +10,11 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def hint_element
-        @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, @hint_text)
+        @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_options)
+      end
+
+      def hint_options
+        @hint || {}
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/traits/input.rb
+++ b/lib/govuk_design_system_formbuilder/traits/input.rb
@@ -1,13 +1,13 @@
 module GOVUKDesignSystemFormBuilder
   module Traits
     module Input
-      def initialize(builder, object_name, attribute_name, hint_text:, label:, caption:, width:, form_group:, **kwargs, &block)
+      def initialize(builder, object_name, attribute_name, hint:, label:, caption:, width:, form_group:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
         @width           = width
         @label           = label
         @caption         = caption
-        @hint_text       = hint_text
+        @hint            = hint
         @html_attributes = kwargs
         @form_group      = form_group
       end

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
@@ -42,7 +42,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:hint_text) { project_x.description }
 
       subject do
-        builder.govuk_check_box(attribute, value, hint_text: hint_text)
+        builder.govuk_check_box(attribute, value, hint: { text: hint_text })
       end
 
       specify 'should contain a hint with the correct text' do

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -48,7 +48,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         let(:paragraph) { 'A descriptive paragraph all about dates' }
 
         subject do
-          builder.send(*args, legend: { text: legend_text }, hint_text: hint_text) do
+          builder.send(*args, legend: { text: legend_text }, hint: { text: hint_text }) do
             builder.tag.p(paragraph, class: 'block-content')
           end
         end

--- a/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
@@ -153,13 +153,13 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
-    context 'with hint_text' do
+    context 'with a hint' do
       subject do
         builder.send(*args) do
           builder.safe_join(
             [
-              builder.govuk_radio_button(:favourite_colour, :red, label: { text: red_label }, hint_text: 'red'),
-              builder.govuk_radio_button(:favourite_colour, :green, label: { text: green_label }, hint_text: 'green')
+              builder.govuk_radio_button(:favourite_colour, :red, label: { text: red_label }, hint: { text: 'red' }),
+              builder.govuk_radio_button(:favourite_colour, :green, label: { text: green_label }, hint: { text: 'green' })
             ]
           )
         end

--- a/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
@@ -33,7 +33,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     context 'radio button hints' do
       subject do
-        builder.govuk_radio_button(:favourite_colour, :red, hint_text: red_hint)
+        builder.govuk_radio_button(:favourite_colour, :red, hint: { text: red_hint })
       end
 
       specify 'should contain a hint with the correct text' do

--- a/spec/support/shared/shared_hint_examples.rb
+++ b/spec/support/shared/shared_hint_examples.rb
@@ -1,8 +1,8 @@
 shared_examples 'a field that supports hints' do
-  context 'when a hint is provided' do
+  context 'when a hint is provided as a string' do
     subject { builder.send(*args, hint: { text: hint_text }) }
 
-    specify 'output should contain a hint' do
+    specify 'output should contain a hint in a span tag' do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
         expect(fg).to have_tag('span', text: hint_text, with: { class: 'govuk-hint' })
       end
@@ -18,6 +18,42 @@ shared_examples 'a field that supports hints' do
       input_aria_describedby = parsed_subject.at_css(aria_described_by_target)['aria-describedby'].split
       hint_id = parsed_subject.at_css('span.govuk-hint')['id']
       expect(input_aria_describedby).to include(hint_id)
+    end
+  end
+
+  context 'when the hint is supplied as a proc' do
+    let(:paragraph_1) { 'paragraph number one' }
+    let(:paragraph_2) { 'paragraph number two' }
+
+    let(:hint) do
+      proc do
+        builder.safe_join([builder.tag.p(paragraph_1), builder.tag.p(paragraph_2)])
+      end
+    end
+
+    subject { builder.send(*args, hint: hint) }
+
+    specify 'output should contain a hint in a div tag' do
+      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
+        expect(fg).to have_tag('div', with: { class: 'govuk-hint' })
+      end
+    end
+
+    specify 'output should contain the content from the block' do
+      expect(subject).to have_tag('div', with: { class: 'govuk-hint' }) do
+        with_tag('p', text: paragraph_1)
+        with_tag('p', text: paragraph_2)
+      end
+    end
+  end
+
+  context 'when a hint is provided as something other than a string or proc' do
+    let(:some_array) { %w(a b c) }
+
+    subject { builder.send(*args, hint: some_array) }
+
+    specify 'should raise an error' do
+      expect { subject }.to raise_error('hint must be a Proc or Hash')
     end
   end
 

--- a/spec/support/shared/shared_hint_examples.rb
+++ b/spec/support/shared/shared_hint_examples.rb
@@ -1,6 +1,6 @@
 shared_examples 'a field that supports hints' do
   context 'when a hint is provided' do
-    subject { builder.send(*args, hint_text: hint_text) }
+    subject { builder.send(*args, hint: { text: hint_text }) }
 
     specify 'output should contain a hint' do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|

--- a/spec/support/shared/shared_hint_examples.rb
+++ b/spec/support/shared/shared_hint_examples.rb
@@ -19,6 +19,17 @@ shared_examples 'a field that supports hints' do
       hint_id = parsed_subject.at_css('span.govuk-hint')['id']
       expect(input_aria_describedby).to include(hint_id)
     end
+
+    context 'extra attributes' do
+      let(:component_id) { 'xyz' }
+      let(:dir) { 'rtl' }
+
+      subject { builder.send(*args, hint: { text: hint_text, dir: dir, data: { component: component_id } }) }
+
+      specify 'the custom attributes should be set on the hint' do
+        expect(subject).to have_tag('span', with: { class: 'govuk-hint', 'data-component': component_id, dir: dir })
+      end
+    end
   end
 
   context 'when the hint is supplied as a proc' do

--- a/spec/support/shared/shared_localisation_examples.rb
+++ b/spec/support/shared/shared_localisation_examples.rb
@@ -122,7 +122,7 @@ shared_examples 'a field that supports setting the hint via localisation' do
     let(:expected_hint) { "It's quite a straightforward question!" }
 
     subject do
-      builder.send(*args, hint_text: expected_hint) { arbitrary_html_content }
+      builder.send(*args, hint: { text: expected_hint }) { arbitrary_html_content }
     end
 
     specify 'should use the supplied hint text' do


### PR DESCRIPTION
Following on from #173, this PR replaces the `hint_text` param with `hint`. It takes a `Hash` and works in the same way as `label`, `legend`, etc.

* [x] replace `hint_text` with `hint`
* [x] allow `hint` to take a `Proc` in addition to the usual `Hash` args
* [x] ensure any extra args are added to the `hint` tag as HTML attributes
* [x] when text is passed into the hint args the hint element should be a `span`, when a proc is passed in it should be a `div`
* [x] update the docs
* [x] update the guide