### PR TITLE
Bump GOV.UK Design System support to version 3.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/fde73b5dc9476197281b/test_coverage)](https://codeclimate.com/github/DFE-Digital/govuk_design_system_formbuilder/test_coverage)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=DFE-Digital/govuk_design_system_formbuilder)](https://dependabot.com)
 [![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk_design_system_formbuilder)](https://github.com/DFE-Digital/govuk_design_system_formbuilder/blob/master/LICENSE)
-[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.8.0-brightgreen)](https://design-system.service.gov.uk)
+[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.8.1-brightgreen)](https://design-system.service.gov.uk)
 
 This gem provides a easy-to-use form builder that generates forms that are
-fully-compliant with version 3.8.0 of the [GOV.UK Design System](https://design-system.service.gov.uk/),
+fully-compliant with version 3.8.1 of the [GOV.UK Design System](https://design-system.service.gov.uk/),
 minimising the amount of markup you need to write.
 
 In addition to the basic markup, the more-advanced functionality of the Design

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -16,7 +16,7 @@ dl.govuk-summary-list
       ul.govuk-list
         li
           span.govuk-tag.govuk-tag-govuk
-            | Version 3.8.0
+            | Version 3.8.1
 
   .govuk-summary-list__row
     dt.govuk-summary-list__key

--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "govuk-frontend": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.8.0.tgz",
-      "integrity": "sha512-+vgXzFsh7wpLRGjFSDvDcA2zNA2wOxT6gGs/KUpkTjF1Uop9BerW/1W/YB1BMpeTEJoPlmrkA19+DS1fqJtL9Q=="
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.8.1.tgz",
+      "integrity": "sha512-1995FVvBSnwizhJ63BHFzd7T8uoOLUKO6NOOT0fAOYE7bdl8Ncf6yC5n3TqiwCJ4lPMc/dCGkN9Z4QRJchwoYQ=="
     }
   }
 }

--- a/guide/package.json
+++ b/guide/package.json
@@ -12,6 +12,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "govuk-frontend": "^3.8.0"
+    "govuk-frontend": "^3.8.1"
   }
 }


### PR DESCRIPTION
The Design System received a minor bugfix update, change supported versions accordingly