### PR TITLE
Fix duplicating content bug

### DIFF
--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -88,7 +88,7 @@ module GOVUKDesignSystemFormBuilder
   end
 
   class FormBuilder < ActionView::Helpers::FormBuilder
-    delegate :content_tag, :tag, :safe_join, :link_to, to: :@template
+    delegate :content_tag, :tag, :safe_join, :link_to, :capture, to: :@template
 
     include GOVUKDesignSystemFormBuilder::Builder
   end

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -8,14 +8,14 @@ module GOVUKDesignSystemFormBuilder
   end
 
   class Base
-    delegate :content_tag, :safe_join, :tag, :link_to, to: :@builder
+    delegate :content_tag, :safe_join, :tag, :link_to, :capture, to: :@builder
     delegate :config, to: GOVUKDesignSystemFormBuilder
 
     def initialize(builder, object_name, attribute_name, &block)
       @builder        = builder
       @object_name    = object_name
       @attribute_name = attribute_name
-      @block_content  = block.call if block_given?
+      @block_content  = capture { block.call } if block_given?
     end
 
     # objects that implement #to_s can be passed directly into #safe_join

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -13,7 +13,7 @@ module GOVUKDesignSystemFormBuilder
         @small              = small
         @classes            = classes
         @form_group_classes = form_group_classes
-        @block_content      = block.call
+        @block_content      = capture { block.call }
       end
 
       def html

--- a/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
@@ -14,7 +14,7 @@ module GOVUKDesignSystemFormBuilder
         @hint_text          = hint_text
         @classes            = classes
         @form_group_classes = form_group_classes
-        @block_content      = block.call
+        @block_content      = capture { block.call }
       end
 
       def html

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -14,7 +14,7 @@ module GOVUKDesignSystemFormBuilder
         @classes              = classes
         @validate             = validate
         @disabled             = disabled
-        @block_content        = block.call if block_given?
+        @block_content        = capture { block.call } if block_given?
       end
 
       def html

--- a/lib/govuk_design_system_formbuilder/traits/conditional.rb
+++ b/lib/govuk_design_system_formbuilder/traits/conditional.rb
@@ -8,7 +8,9 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def wrap_conditional(block)
-        tag.div(class: conditional_classes, id: conditional_id) { block.call }
+        tag.div(class: conditional_classes, id: conditional_id) do
+          capture { block.call }
+        end
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/version.rb
+++ b/lib/govuk_design_system_formbuilder/version.rb
@@ -1,3 +1,3 @@
 module GOVUKDesignSystemFormBuilder
-  VERSION = '1.2.6'.freeze
+  VERSION = '1.2.7'.freeze
 end


### PR DESCRIPTION
This fixes a bug in `govuk_radio_button_fieldset` and `govuk_checkbox_fieldset` where the block content was rendered twice. It was caused by the removal of `capture` in 08fe4ffc05 and not picked up by the test suite, probably due to it not using a templating engine and using Ruby directly.

There's probably a case for more investigation on this and perhaps some tests that do fire up Slim and ensure things are as they seem.