### PR TITLE
Test out the generation of ERB input examples

### DIFF
--- a/guide/content/css/guide.sass
+++ b/guide/content/css/guide.sass
@@ -87,6 +87,10 @@ figure.full-sample
     pre,.example-output
       @include light-grey-border
 
+    .govuk-tabs
+      pre,.example-output
+        border: none
+
     &:last-child
       margin-bottom: 0rem
 
@@ -99,6 +103,10 @@ pre
   > code.highlight
     font-family: FiraMono, monospace
     word-wrap: normal
+
+  > code.wrap
+    white-space: pre-wrap
+    word-wrap: break-word
 
   &.smaller > code.highlight
     font-size: 85%

--- a/guide/layouts/partials/example-fig.slim
+++ b/guide/layouts/partials/example-fig.slim
@@ -44,10 +44,30 @@ figure.full-sample
           | #{localisation}
 
   section
-    h4.govuk-heading-s.example-subheading.input Input
-    pre.example-input
-      code.highlight.language-slim
-        | #{code}
+
+    .govuk-tabs data-module='govuk-tabs'
+      h4.govuk-heading-s.govuk-tabs--title.example-subheading.input Input
+
+      ul.govuk-tabs__list
+        li.govuk-tabs__list-item.govuk-tabs__list-item--selected
+          a.govuk-tabs__tab href=%(#input-slim-#{anchor_id(caption)})
+            | Slim
+        li.govuk-tabs__list-item
+          a.govuk-tabs__tab href=%(#input-erb-#{anchor_id(caption)})
+            | ERB
+
+      .govuk-tabs__panel id=%(input-slim-#{anchor_id(caption)})
+        div
+          pre.example-input
+            code.highlight.language-slim
+              | #{code}
+
+      .govuk-tabs__panel.govuk-tabs__panel--hidden id=%(input-erb-#{anchor_id(caption)})
+        div
+          pre.example-input.smaller
+            code.highlight.language-erb.wrap
+              = format_erb(code)
+
 
   section
     - display_errors = defined?(show_errors) && show_errors

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -2,6 +2,8 @@ require 'pry'
 require 'action_view'
 require 'active_model'
 require 'htmlbeautifier'
+require 'slim/erb_converter'
+
 Dir.glob(File.join('./lib', '**', '*.rb')).sort.each { |f| require f }
 
 $LOAD_PATH.unshift(File.expand_path("../../lib", "lib"))

--- a/guide/lib/helpers/formatters.rb
+++ b/guide/lib/helpers/formatters.rb
@@ -5,7 +5,6 @@ module Helpers
     end
 
     def format_slim(raw, **args)
-      # FIXME: investigate pretty slim
       # FIXME: not sure why when we're several
       #        blocks deep we need to unescape more
       #        than once
@@ -15,6 +14,25 @@ module Helpers
             Slim::Template.new(format: :html) { raw }.render(OpenStruct.new(args))
           )
         )
+      )
+    end
+
+    def format_erb(raw)
+      # NOTE: this is many different kinds of bad. Thankfully we're
+      #       only using it for documentation purposes and it won't be
+      #       displayed by default
+      HtmlBeautifier.beautify(
+        Slim::ERBConverter.new(
+          disable_escape: true,
+          disable_capture: true,
+          generator: Temple::Generators::RailsOutputBuffer
+        )
+          .call(raw)
+          .gsub(/ _slim_controls[\d] =/, "=")        # remove _slim_controlsX assignment (where X is an integer)
+          .gsub(/do\n\s+%>/, "do %>")                # close blocks on the same line
+          .gsub(/%><%/, "%>\n<%")                    # ensure ERB tags are on separate lines
+          .gsub(/<%= _slim_controls[\d] %>/, '')     # remove _slim_controlsX var display, we've handled it above
+          .gsub(/,\n/, ', ')                         # don't leave newlines between args, it breaks indentation
       )
     end
 


### PR DESCRIPTION
This was brought up in #177 by @paulrobertlloyd where it was mentioned that [Slim](http://slim-lang.com/) templates might not make sense to people who are more used to [ERB](https://ruby-doc.org/stdlib-2.7.1/libdoc/erb/rdoc/ERB.html). In other documentation often multiple languages/syntaxes are listed, this is a quick test to see if it's feasible.

This approach, using Slim's built-in `Slim::ERBConverter` _mostly_ works:

| Slim | ERB |
| ---- | ---- |
| ![Screenshot from 2020-08-15 11-22-33](https://user-images.githubusercontent.com/128088/90310491-a9753b00-dee9-11ea-8e82-d3f67523163a.png) | ![Screenshot from 2020-08-15 11-07-50](https://user-images.githubusercontent.com/128088/90310476-7337bb80-dee9-11ea-9752-bceabdf87fc5.png) |


There are a couple of areas that don't:

* **Blocks** - the `Slim::ERBConverter` conversion is outputting  unwanted text like `_slim_controls1 =`. There might be a way of suppressing it. More investigation needed.

![Screenshot from 2020-08-15 11-08-14](https://user-images.githubusercontent.com/128088/90310326-7da58580-dee8-11ea-9728-c32d63edf599.png)


* **General formatting**, no space is left before heading tags and after ERB blocks. Using `beatify` half fixes this but causes problems elsewhere, including splitting procs made with arrow syntax across multiple lines. Perhaps there's a better formatting utility out there :man_shrugging: 

![Screenshot from 2020-08-15 11-15-25](https://user-images.githubusercontent.com/128088/90310350-ae85ba80-dee8-11ea-9bef-062be51cda16.png)
