### PR TITLE
Fix hints within fieldsets

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection_check_box.rb
@@ -40,7 +40,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def hint_element
-          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_options, **@hint)
+          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_options, **hint_content)
         end
 
         def hint_options

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -62,7 +62,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def hint_element
-          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_options, **@hint)
+          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_options, **hint_content)
         end
 
         def hint_options

--- a/lib/govuk_design_system_formbuilder/elements/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/hint.rb
@@ -5,19 +5,19 @@ module GOVUKDesignSystemFormBuilder
 
       include Traits::Localisation
 
-      def initialize(builder, object_name, attribute_name, value: nil, text: nil, radio: false, content: nil, checkbox: false, **kwargs)
+      def initialize(builder, object_name, attribute_name, value: nil, text: nil, content: nil, radio: false, checkbox: false, **kwargs)
         super(builder, object_name, attribute_name)
+
+        @radio           = radio
+        @checkbox        = checkbox
+        @html_attributes = kwargs
 
         if content
           @content = content.call
         else
-          @value    = value
-          @text     = retrieve_text(text)
-          @radio    = radio
-          @checkbox = checkbox
+          @text  = retrieve_text(text)
+          @value = value
         end
-
-        @html_attributes = kwargs
       end
 
       def active?

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
@@ -41,7 +41,15 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def hint_element
-          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, value: @value, text: @hint_text, radio: true)
+          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_options, **hint_content)
+        end
+
+        def hint_content
+          { text: @hint_text }
+        end
+
+        def hint_options
+          { value: @value, radio: true }
         end
 
         def label_element

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -47,7 +47,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def hint_element
-          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_options, **@hint)
+          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_options, **hint_content)
         end
 
         def hint_options

--- a/lib/govuk_design_system_formbuilder/traits/hint.rb
+++ b/lib/govuk_design_system_formbuilder/traits/hint.rb
@@ -15,6 +15,8 @@ module GOVUKDesignSystemFormBuilder
 
       def hint_content
         case @hint
+        when NilClass
+          {}
         when Hash
           @hint
         when Proc

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
@@ -52,6 +52,18 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       specify 'the hint should have the correct classes' do
         expect(subject).to have_tag('span', with: { class: %w(govuk-hint govuk-checkboxes__hint) })
       end
+
+      context 'when the hint is supplied in a proc' do
+        subject do
+          builder.govuk_check_box(attribute, value, hint: -> { builder.tag.section(project_x.description) })
+        end
+
+        specify 'the proc-supplied hint content should be present and contained in a div' do
+          expect(subject).to have_tag('div', with: { class: %w(govuk-hint govuk-checkboxes__hint) }) do
+            with_tag('section', text: project_x.description)
+          end
+        end
+      end
     end
 
     context 'multiple' do

--- a/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
@@ -31,7 +31,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     it_behaves_like 'a field that supports setting the label via localisation'
 
-    context 'radio button hints' do
+    describe 'radio button hints' do
       subject do
         builder.govuk_radio_button(:favourite_colour, :red, hint: { text: red_hint })
       end
@@ -42,6 +42,18 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
       specify 'the hint should have the correct classes' do
         expect(subject).to have_tag('span', with: { class: %w(govuk-hint govuk-radios__hint) })
+      end
+
+      context 'when the hint is supplied in a proc' do
+        subject do
+          builder.govuk_radio_button(:favourite_colour, :red, hint: -> { builder.tag.section(red_hint) })
+        end
+
+        specify 'the proc-supplied hint content should be present and contained in a div' do
+          expect(subject).to have_tag('div', with: { class: %w(govuk-hint govuk-radios__hint) }) do
+            with_tag('section', text: red_hint)
+          end
+        end
       end
     end
 

--- a/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
@@ -6,6 +6,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   describe '#govuk_radio_button' do
     let(:method) { :govuk_radio_button }
     let(:value) { 'red' }
+    let(:attribute) { :favourite_colour }
     let(:args) { [method, attribute, value] }
 
     subject { builder.send(*args) }
@@ -33,7 +34,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     describe 'radio button hints' do
       subject do
-        builder.govuk_radio_button(:favourite_colour, :red, hint: { text: red_hint })
+        builder.govuk_radio_button(attribute, value, hint: { text: red_hint })
       end
 
       specify 'should contain a hint with the correct text' do
@@ -46,7 +47,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
       context 'when the hint is supplied in a proc' do
         subject do
-          builder.govuk_radio_button(:favourite_colour, :red, hint: -> { builder.tag.section(red_hint) })
+          builder.govuk_radio_button(attribute, value, hint: -> { builder.tag.section(red_hint) })
         end
 
         specify 'the proc-supplied hint content should be present and contained in a div' do
@@ -60,7 +61,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     context 'conditionally revealing content' do
       context 'when a block is given' do
         subject do
-          builder.govuk_radio_button(:favourite_colour, :red) do
+          builder.govuk_radio_button(attribute, value) do
             builder.govuk_text_field(:favourite_colour_reason)
           end
         end
@@ -85,12 +86,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         specify 'conditional_id contains the object, attribute and value name' do
           expect(
             parsed_subject.at_css("input[type='radio']")['data-aria-controls']
-          ).to eql('person-favourite-colour-red-conditional')
+          ).to eql(%(person-favourite-colour-#{value}-conditional))
         end
       end
 
       context 'when no block is given' do
-        subject { builder.govuk_radio_button(:favourite_colour, :red) }
+        subject { builder.govuk_radio_button(attribute, value) }
 
         specify "the data-aria-controls attribute should be blank" do
           input_data_aria_controls = parsed_subject.at_css("input[type='radio']")['data-aria-controls']

--- a/spec/support/shared/shared_hint_examples.rb
+++ b/spec/support/shared/shared_hint_examples.rb
@@ -68,6 +68,18 @@ shared_examples 'a field that supports hints' do
     end
   end
 
+  context 'when a hint is omitted with nil' do
+    subject { builder.send(*args, hint: nil) }
+
+    specify 'no hint should be present' do
+      expect(subject).not_to have_tag('span', with: { class: 'govuk-hint' })
+    end
+
+    specify 'output should have no empty aria-describedby attribute' do
+      expect(parsed_subject.at_css(field_type)['aria-describedby']).not_to be_present
+    end
+  end
+
   context 'when a hint is not provided' do
     subject { builder.send(*args) }
 


### PR DESCRIPTION
Since updating the `hint` behaviour in #174, the hint functionality for radio buttons and check boxes had fallen slightly out of sync. This change standardises the behaviour and allows them to be set via procs.