### PR TITLE
Always capture the output when calling procs

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -12,7 +12,7 @@ module GOVUKDesignSystemFormBuilder
         # content is passed in directly via a proc and overrides
         # the other display options
         if content
-          @content = content.call
+          @content = capture { content.call }
         else
           @value       = value # used by field_id
           @text        = retrieve_text(text, hidden)

--- a/lib/govuk_design_system_formbuilder/elements/legend.rb
+++ b/lib/govuk_design_system_formbuilder/elements/legend.rb
@@ -9,7 +9,7 @@ module GOVUKDesignSystemFormBuilder
 
         case legend
         when Proc
-          @raw = legend.call
+          @raw = capture { legend.call }
         when Hash
           defaults.merge(legend).tap do |l|
             @text    = text(l.dig(:text))

--- a/lib/govuk_design_system_formbuilder/traits/collection_item.rb
+++ b/lib/govuk_design_system_formbuilder/traits/collection_item.rb
@@ -8,7 +8,7 @@ module GOVUKDesignSystemFormBuilder
         when Symbol, String
           item.send(method)
         when Proc
-          method.call(item)
+          capture { method.call(item) }
         end
       end
     end


### PR DESCRIPTION
This fixes a bug where the contents of the proc would overwrite the rest of the element.

cc @paulrobertlloyd, @tvararu - the advice I gave on the #177 isn't actually necessary, having delved a bit deeper it seems that the way you were calling it originally is indeed legit!

Unfortunately it's a pain to test in the current manner, hence #179 

Either approach will work once this is merged and released.