### PR TITLE
Downgrade simplecov to 0.17.1 to fix CodeClimate

### DIFF
--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("pry-byebug", "~> 3.9", ">= 3.9.0")
   s.add_development_dependency("rspec-html-matchers", "~> 0")
   s.add_development_dependency("rspec-rails", "~> 4.0")
-  s.add_development_dependency("simplecov", "~> 0.18.5")
+  s.add_development_dependency("simplecov", "~> 0.17.1")
 
   # Required for the guide
   s.add_development_dependency("htmlbeautifier", "~> 1.3.1")


### PR DESCRIPTION
CodeClimate isn't compatible with SimpleCov 0.18.x, I mistakenly allowed Dependabot to upgrade it in #136 (8b77598b) and it's not been reporting since 🤦

For more info see https://github.com/codeclimate/test-reporter/issues/418