### PR TITLE
Set legend text by default

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -425,7 +425,7 @@ module GOVUKDesignSystemFormBuilder
     #   supplied the hint will be wrapped in a +div+ instead of a +span+
     # @option hint text [String] the hint text
     # @option hint args [Hash] additional arguments are applied as attributes to the hint
-    # @param legend [Hash,Proc] options for configuring the legend
+    # @param legend [NilClass,Hash,Proc] options for configuring the legend. Legend will be omitted if +nil+.
     # @param inline [Boolean] controls whether the radio buttons are displayed inline or not
     # @param small [Boolean] controls whether small radio buttons are used instead of regular-sized ones
     # @param bold_labels [Boolean] controls whether the radio button labels are bold
@@ -504,7 +504,7 @@ module GOVUKDesignSystemFormBuilder
     #   supplied the hint will be wrapped in a +div+ instead of a +span+
     # @option hint text [String] the hint text
     # @option hint args [Hash] additional arguments are applied as attributes to the hint
-    # @param legend [Hash,Proc] options for configuring the legend
+    # @param legend [NilClass,Hash,Proc] options for configuring the legend. Legend will be omitted if +nil+.
     # @param inline [Boolean] controls whether the radio buttons are displayed inline or not
     # @param small [Boolean] controls whether small radio buttons are used instead of regular-sized ones
     # @option legend text [String] the fieldset legend's text content
@@ -599,7 +599,7 @@ module GOVUKDesignSystemFormBuilder
     # @option hint args [Hash] additional arguments are applied as attributes to the hint
     # @param small [Boolean] controls whether small check boxes are used instead of regular-sized ones
     # @param classes [Array,String] Classes to add to the checkbox container.
-    # @param legend [Hash,Proc] options for configuring the legend
+    # @param legend [NilClass,Hash,Proc] options for configuring the legend. Legend will be omitted if +nil+.
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
@@ -676,7 +676,7 @@ module GOVUKDesignSystemFormBuilder
     # @option hint text [String] the hint text
     # @option hint args [Hash] additional arguments are applied as attributes to the hint
     # @param small [Boolean] controls whether small check boxes are used instead of regular-sized ones
-    # @param legend [Hash,Proc] options for configuring the legend
+    # @param legend [NilClass,Hash,Proc] options for configuring the legend. Legend will be omitted if +nil+.
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
@@ -795,7 +795,7 @@ module GOVUKDesignSystemFormBuilder
     #   supplied the hint will be wrapped in a +div+ instead of a +span+
     # @option hint text [String] the hint text
     # @option hint args [Hash] additional arguments are applied as attributes to the hint
-    # @param legend [Hash,Proc] options for configuring the legend
+    # @param legend [NilClass,Hash,Proc] options for configuring the legend. Legend will be omitted if +nil+.
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
@@ -845,7 +845,7 @@ module GOVUKDesignSystemFormBuilder
 
     # Generates a fieldset containing the contents of the block
     #
-    # @param legend [Hash,Proc] options for configuring the legend
+    # @param legend [NilClass,Hash,Proc] options for configuring the legend. Legend will be omitted if +nil+.
     # @param described_by [Array<String>] the ids of the elements that describe this fieldset, usually hints and errors
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+

--- a/lib/govuk_design_system_formbuilder/elements/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/hint.rb
@@ -13,7 +13,7 @@ module GOVUKDesignSystemFormBuilder
         @html_attributes = kwargs
 
         if content
-          @content = capture { content.call }
+          @raw = capture { content.call }
         else
           @text  = retrieve_text(text)
           @value = value
@@ -21,7 +21,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def active?
-        [@text, @content].any?(&:present?)
+        [@text, @raw].any?(&:present?)
       end
 
       def html
@@ -43,11 +43,11 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def hint_tag
-        @content.presence ? 'div' : 'span'
+        @raw.presence ? 'div' : 'span'
       end
 
       def hint_body
-        @content || @text
+        @raw || @text
       end
 
       def retrieve_text(supplied)

--- a/lib/govuk_design_system_formbuilder/elements/legend.rb
+++ b/lib/govuk_design_system_formbuilder/elements/legend.rb
@@ -8,11 +8,13 @@ module GOVUKDesignSystemFormBuilder
         super(builder, object_name, attribute_name)
 
         case legend
+        when NilClass
+          @active = false
         when Proc
           @raw = capture { legend.call }
         when Hash
           defaults.merge(legend).tap do |l|
-            @text    = text(l.dig(:text))
+            @text    = retrieve_text(l.dig(:text))
             @hidden  = l.dig(:hidden)
             @tag     = l.dig(:tag)
             @size    = l.dig(:size)
@@ -29,8 +31,12 @@ module GOVUKDesignSystemFormBuilder
 
     private
 
+      def active?
+        [@text, @raw].any?(&:present?)
+      end
+
       def content
-        if @text.present?
+        if active?
           tag.legend(class: classes) do
             content_tag(@tag, class: heading_classes) do
               safe_join([caption_element, @text])
@@ -39,8 +45,8 @@ module GOVUKDesignSystemFormBuilder
         end
       end
 
-      def text(supplied_text)
-        supplied_text || localised_text(:legend)
+      def retrieve_text(supplied_text)
+        [supplied_text, localised_text(:legend), @attribute_name&.capitalize].compact.first
       end
 
       def classes

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
@@ -72,7 +72,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       context 'without a legend' do
-        let(:legend) { {} }
+        let(:legend) { nil }
 
         specify 'output should contain no caption at all' do
           expect(subject).not_to have_tag('span', with: { class: caption_class })

--- a/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
@@ -109,7 +109,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       context 'without a legend' do
-        let(:legend) { {} }
+        let(:legend) { nil }
 
         specify 'output should contain no caption at all' do
           expect(subject).not_to have_tag('span', with: { class: caption_class })

--- a/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
@@ -70,7 +70,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       context 'without a legend' do
-        let(:legend) { {} }
+        let(:legend) { nil }
 
         specify 'output should contain no caption at all' do
           expect(subject).not_to have_tag('span', with: { class: caption_class })

--- a/spec/support/shared/shared_caption_examples.rb
+++ b/spec/support/shared/shared_caption_examples.rb
@@ -50,7 +50,7 @@ shared_examples 'a field that supports captions on the legend' do
     let(:caption_container) { { legend: { text: legend_text, tag: caption_container_tag } } }
 
     context 'when no legend is present but a caption is' do
-      subject { builder.send(*args, caption: caption_args) }
+      subject { builder.send(*args, legend: nil, caption: caption_args) }
 
       specify 'no caption should be rendered' do
         expect(subject).not_to have_tag('span', with: { class: caption_class })
@@ -65,8 +65,6 @@ shared_examples 'a field that supports captions on the label' do
     let(:caption_container) { { label: { text: label_text, size: 'm' } } }
 
     context 'when no label is present but a caption is' do
-      # Unlike the legend, labels will fall back to their attribute name, so we
-      # can only test against an empty label
       subject { builder.send(*args, label: { text: '' }, caption: caption_args) }
 
       specify 'no caption should be rendered' do

--- a/spec/support/shared/shared_legend_examples.rb
+++ b/spec/support/shared/shared_legend_examples.rb
@@ -17,10 +17,10 @@ shared_examples 'a field that supports a fieldset with legend' do
     context 'when no text is supplied' do
       subject { builder.send(*args, legend: { text: nil }) }
 
-      specify 'output should not contain a header' do
+      specify 'output should contain a header set to the attribute name' do
         expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
           expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
-            expect(fs).not_to have_tag('h1')
+            expect(fs).to have_tag('h1', class: 'govuk-fieldset__legend', text: attribute.capitalize)
           end
         end
       end
@@ -111,6 +111,8 @@ shared_examples 'a field that supports a fieldset with legend' do
   end
 
   context 'when no legend is supplied' do
+    subject { builder.send(*args, legend: nil) }
+
     specify 'legend tag should not be present' do
       expect(subject).not_to have_tag('legend')
     end


### PR DESCRIPTION
To make the behaviour of fieldset legends more consistent with labels, they will now be added to the form by default if nothing is specified.

This is intended to act as a prompt for the developer to modify the content, so no additional formatting (ie removing underscores) is undertaken.

If the developer wants the legend to be omitted they can pass `nil` to in legend param.

Fieldsets with no attribute name (ie standalone fieldsets called via `govuk_fieldset`) will remain unaffected.