### PR TITLE
Move instance variable assigns out of else block

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -9,19 +9,20 @@ module GOVUKDesignSystemFormBuilder
       def initialize(builder, object_name, attribute_name, text: nil, value: nil, size: nil, hidden: false, radio: false, checkbox: false, tag: nil, link_errors: true, content: nil, caption: nil)
         super(builder, object_name, attribute_name)
 
+        @value       = value # used by field_id
+        @tag         = tag
+        @radio       = radio
+        @checkbox    = checkbox
+        @link_errors = link_errors
+
         # content is passed in directly via a proc and overrides
         # the other display options
         if content
           @content = capture { content.call }
         else
-          @value       = value # used by field_id
-          @text        = retrieve_text(text, hidden)
-          @size_class  = size_class(size)
-          @radio       = radio
-          @checkbox    = checkbox
-          @tag         = tag
-          @link_errors = link_errors
-          @caption     = caption
+          @text       = retrieve_text(text, hidden)
+          @size_class = size_class(size)
+          @caption    = caption
         end
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -39,7 +39,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def label_element
-          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, **label_content, **label_options, **@label)
+          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, **label_content, **label_options)
         end
 
         def label_options

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
@@ -26,9 +26,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     it_behaves_like 'a field that supports labels' do
       let(:label_text) { 'Project X' }
-      # the reason we're specifying the type is that
-      # Rails injects a hidden input in addition to the
-      # checkbox
       let(:field_type) { "input[type='checkbox']" }
 
       specify 'the label should have a check box label class' do
@@ -38,11 +35,28 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     it_behaves_like 'a field that supports setting the label via localisation'
 
+    context 'labels set via procs' do
+      let(:label_text) { 'Project Y' }
+      let(:label_proc) { -> { label_text } }
+      subject { builder.send(*args, label: label_proc) }
+
+      specify 'the label should have a check box label class' do
+        expect(subject).to have_tag('label', with: { class: 'govuk-checkboxes__label' })
+      end
+
+      specify %(the label's for attribute should match the checkbox's id) do
+        label_for = parsed_subject.at_css('label')['for']
+        checkbox_id = parsed_subject.at_css('input')['id']
+
+        expect(label_for).to eql(checkbox_id)
+      end
+    end
+
     context 'check box hints' do
       let(:hint_text) { project_x.description }
 
       subject do
-        builder.govuk_check_box(attribute, value, hint: { text: hint_text })
+        builder.send(*args, hint: { text: hint_text })
       end
 
       specify 'should contain a hint with the correct text' do

--- a/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
@@ -32,6 +32,23 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     it_behaves_like 'a field that supports setting the label via localisation'
 
+    context 'labels set via procs' do
+      let(:label_text) { 'Orange' }
+      let(:label_proc) { -> { label_text } }
+      subject { builder.send(*args, label: label_proc) }
+
+      specify 'the label should have a radio label class' do
+        expect(subject).to have_tag('label', with: { class: 'govuk-radios__label' })
+      end
+
+      specify %(the label's for attribute should match the radio button's id) do
+        label_for = parsed_subject.at_css('label')['for']
+        radio_id = parsed_subject.at_css('input')['id']
+
+        expect(label_for).to eql(radio_id)
+      end
+    end
+
     describe 'radio button hints' do
       subject do
         builder.govuk_radio_button(attribute, value, hint: { text: red_hint })


### PR DESCRIPTION
Some of the instance variables set in Label's initializer are required for both proc and hash style labels. When set using a proc they are missed and it causes the ids and radio/checkbox-specific classes not to be set properly.

They have now been moved out, only the variables used to configure the appearance of the label are now set in the else clause.