### PR TITLE
Fix localisation of collection labels/hints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,8 @@ AllCops:
     - govuk_design_system_formbuilder.gemspec
 Rails/Date:
   Enabled: false
+Rails/ActiveSupportAliases:
+  Enabled: false
 Style/StringLiterals:
   Enabled: false
 Style/TrailingCommaInArguments:

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -488,7 +488,7 @@ module GOVUKDesignSystemFormBuilder
     #    :name,
     #    legend: -> { tag.h3('Which category do you belong to?') }
     #
-    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method, hint_method = nil, hint: {}, legend: {}, caption: {}, inline: false, small: false, bold_labels: false, classes: nil, form_group: {}, &block)
+    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method = nil, hint_method = nil, hint: {}, legend: {}, caption: {}, inline: false, small: false, bold_labels: false, classes: nil, form_group: {}, &block)
       Elements::Radios::Collection.new(
         self,
         object_name,

--- a/lib/govuk_design_system_formbuilder/elements/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/hint.rb
@@ -8,6 +8,7 @@ module GOVUKDesignSystemFormBuilder
       def initialize(builder, object_name, attribute_name, value: nil, text: nil, content: nil, radio: false, checkbox: false, **kwargs)
         super(builder, object_name, attribute_name)
 
+        @value           = value
         @radio           = radio
         @checkbox        = checkbox
         @html_attributes = kwargs
@@ -15,8 +16,7 @@ module GOVUKDesignSystemFormBuilder
         if content
           @raw = capture { content.call }
         else
-          @text  = retrieve_text(text)
-          @value = value
+          @text = retrieve_text(text)
         end
       end
 

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
@@ -147,6 +147,11 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         let(:i18n_proc) { ->(item) { I18n.t("colours.#{item.name.downcase}") } }
         let(:args) { [method, attribute, colours, :id, :name].push(i18n_proc) }
       end
+
+      it_behaves_like 'a field that supports localised collection hints' do
+        let(:hint_class) { 'govuk-checkboxes__hint' }
+        let(:args) { [method, :department, departments, :code, :name] }
+      end
     end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -56,6 +56,16 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     it_behaves_like 'a field that supports setting the hint via localisation'
     it_behaves_like 'a field that supports setting the legend caption via localisation'
+
+    it_behaves_like 'a field that supports localised collection labels' do
+      let(:args) { [method, :department, departments, :code] }
+    end
+
+    it_behaves_like 'a field that supports localised collection hints' do
+      let(:hint_class) { 'govuk-radios__hint' }
+      let(:args) { [method, :department, departments, :code] }
+    end
+
     it_behaves_like 'a field that supports setting the legend via localisation'
     it_behaves_like 'a field that contains a customisable form group'
 

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -14,7 +14,8 @@ class Being
     :projects,
     :project_responsibilities,
     :cv,
-    :photo
+    :photo,
+    :department
   )
 end
 
@@ -68,5 +69,14 @@ class Guest < Being
       cv: 'Basic vocabulary',
       born_on: Date.new(1974, 7, 1)
     )
+  end
+end
+
+class Department
+  attr_accessor :code, :name
+
+  def initialize(code:, name:)
+    self.code = code
+    self.name = name
   end
 end

--- a/spec/support/locales/sample.en.yaml
+++ b/spec/support/locales/sample.en.yaml
@@ -9,6 +9,13 @@ helpers:
       projects_options:
         11: Eleven
       photo: Upload a recent passport photo
+      department: Department name
+      department_options:
+        it: Information technology
+        marketing: Marketing
+        finance: Finance
+        sales: Sales
+
   caption:
     person:
       name: Personal information
@@ -31,3 +38,8 @@ helpers:
       photo: Make sure your face is clear and you are looking at the camera
       born_on: Check your birth certificate or passport
       projects: If you cannot remember check with your teammates or manager
+      department_options:
+        it: Computers and stuff
+        marketing: Flyers, posters, etc
+        finance: What's worth doing is worth doing for money
+        # sales is intentionally missing

--- a/spec/support/shared/setup_examples.rb
+++ b/spec/support/shared/setup_examples.rb
@@ -16,4 +16,10 @@ shared_context 'setup examples' do
 
   let(:projects) { [project_x, project_y, project_z] }
   let(:projects_with_descriptions) { projects.select { |p| p.description.present? } }
+
+  let(:department_it) { Department.new(code: :it, name: "Computers shenanigans") }
+  let(:department_finance) { Department.new(code: :finance, name: "Monies") }
+  let(:department_marketing) { Department.new(code: :marketing, name: "Flyer distribution") }
+  let(:department_sales) { Department.new(code: :sales, name: "Selling stuff") }
+  let(:departments) { [department_it, department_finance, department_marketing, department_sales] }
 end

--- a/spec/support/shared/shared_localisation_examples.rb
+++ b/spec/support/shared/shared_localisation_examples.rb
@@ -213,3 +213,45 @@ shared_examples 'a field that allows the hint to be localised via a proc' do
     end
   end
 end
+
+shared_examples 'a field that supports localised collection labels' do
+  let(:localisations) { LOCALISATIONS }
+  let(:attribute) { :department }
+  subject { builder.send(*args) }
+
+  specify 'the labels should be set by localisation' do
+    with_localisations(localisations) do
+      departments.each do |department|
+        expected_label = I18n.translate(department.code, scope: 'helpers.label.person.department_options')
+        expect(subject).to have_tag('label', text: expected_label)
+      end
+    end
+  end
+end
+
+shared_examples 'a field that supports localised collection hints' do
+  let(:localisations) { LOCALISATIONS }
+  let(:attribute) { :department }
+  subject { builder.send(*args) }
+
+  specify 'the hints should be set by localisation' do
+    with_localisations(localisations) do
+      departments.each do |department|
+        expected_hint = I18n.translate(department.code, scope: 'helpers.hint.person.department_options', default: nil)
+
+        if expected_hint.present?
+          expect(subject).to have_tag('span', with: { class: %w(govuk-hint).append(hint_class) }, text: expected_hint)
+        end
+      end
+
+      # testing that the correct hint (sales) is missing is a bit 'involved',
+      # so now we've ensured that the ones we expect to be there are present
+      # let's make sure they're the only ones that are by counting them
+      departments_with_localised_hints = departments.count do |department|
+        I18n.translate(department.code, scope: 'helpers.hint.person.department_options', default: nil)
+      end
+
+      expect(subject).to have_tag('span', with: { class: %w(govuk-hint).append(hint_class) }, count: departments_with_localised_hints)
+    end
+  end
+end


### PR DESCRIPTION
This fixes a bug where @value wasn't being assigned when the hint_method param wasn't passed in, even though @value is required to localise it properly.

Tests have been added to ensure it works as expected; for radio collections both the label and hint can be set via localisation and for check boxes just the hint can.

Thanks @zheileman for reporting and diagnosing :+1: 