### PR TITLE
Fix bug where checkbox hidden field isn't rendered

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -658,6 +658,7 @@ module GOVUKDesignSystemFormBuilder
     #
     # @param attribute_name [Symbol] The name of the attribute
     # @param value [Boolean,String,Symbol,Integer] The value of the checkbox when it is checked
+    # @param unchecked_value [Boolean,String,Symbol,Integer] The value of the checkbox when it is unchecked
     # @param hint_text [String] the contents of the hint
     # @param link_errors [Boolean] controls whether this radio button should be linked to from {#govuk_error_summary}
     # @option label text [String] the label text
@@ -676,12 +677,13 @@ module GOVUKDesignSystemFormBuilder
     #     label: { text: 'Do you agree with our terms and conditions?' },
     #     hint_text: 'You will not be able to proceed unless you do'
     #
-    def govuk_check_box(attribute_name, value, hint_text: nil, label: {}, link_errors: false, multiple: true, &block)
+    def govuk_check_box(attribute_name, checked_value, unchecked_value = 0, hint_text: nil, label: {}, link_errors: false, multiple: true, &block)
       Elements::CheckBoxes::FieldsetCheckBox.new(
         self,
         object_name,
         attribute_name,
-        value,
+        checked_value,
+        unchecked_value,
         hint_text: hint_text,
         label: label,
         link_errors: link_errors,

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -8,14 +8,15 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Conditional
 
-        def initialize(builder, object_name, attribute_name, value, label:, hint_text:, link_errors:, multiple:, &block)
+        def initialize(builder, object_name, attribute_name, value, unchecked_value, label:, hint_text:, link_errors:, multiple:, &block)
           super(builder, object_name, attribute_name)
 
-          @value       = value
-          @label       = label
-          @hint_text   = hint_text
-          @multiple    = multiple
-          @link_errors = link_errors
+          @value           = value
+          @unchecked_value = unchecked_value
+          @label           = label
+          @hint_text       = hint_text
+          @multiple        = multiple
+          @link_errors     = link_errors
 
           if block_given?
             @conditional_content = wrap_conditional(block)
@@ -36,7 +37,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def check_box
-          @builder.check_box(@attribute_name, options, @value, false)
+          @builder.check_box(@attribute_name, options, @value, @unchecked_value)
         end
 
         def options

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
@@ -54,6 +54,34 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
+    context 'generating a hidden field for the unchecked value' do
+      context 'when the unchecked_value is not provided' do
+        specify 'the hidden field should be present by default' do
+          expect(subject).to have_tag('input', with: { type: 'hidden', value: '0' })
+        end
+      end
+
+      context %(unchecked values) do
+        subject { builder.send(*args, '0') }
+
+        [0, -1, 'nope'].each do |uv|
+          context uv.to_s do
+            subject { builder.send(*args, uv) }
+            specify %(the hidden field value should be '#{uv}') do
+              expect(subject).to have_tag('input', with: { type: 'hidden', value: uv })
+            end
+          end
+        end
+      end
+
+      context 'when the unchecked_value is false' do
+        subject { builder.send(*args, false) }
+        specify %(the hidden field should not be present) do
+          expect(subject).not_to have_tag('input', with: { type: 'hidden' })
+        end
+      end
+    end
+
     context 'multiple' do
       context 'default to multiple' do
         specify 'check box name should allow multiple values' do

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -225,7 +225,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             end
 
             specify 'the radio button linked to should be first' do
-              expect(parsed_subject.css('input').first['id']).to eql(identifier)
+              expect(parsed_subject.css(%(input[type='checkbox'])).first['id']).to eql(identifier)
               expect(parsed_subject.css('label').first['for']).to eql(identifier)
             end
 


### PR DESCRIPTION
When web forms are submitted, [check boxes in their unchecked state are not submitted](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#Value) so Rails' `#check_box` helper, which we wrap in `#govuk_check_box`, should automatically create a hidden field with the unchecked value.

This has not been happening because Rails omits the hidden field when the unchecked value is `false`. The form builder always forced the false value to be false and the hidden field wasn't covered by the test suite. The documentation recommends that [a value of `0` should be used to represent it instead](https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-check_box).

This fix does two things:
* changes the default unchecked value from `false` to `0`
* allows custom unchecked values to be set in a way that matches Rails' API

Fixes #186 