### PR TITLE
Change the unchecked default value back to false

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -677,7 +677,7 @@ module GOVUKDesignSystemFormBuilder
     #     label: { text: 'Do you agree with our terms and conditions?' },
     #     hint_text: 'You will not be able to proceed unless you do'
     #
-    def govuk_check_box(attribute_name, checked_value, unchecked_value = 0, hint_text: nil, label: {}, link_errors: false, multiple: true, &block)
+    def govuk_check_box(attribute_name, checked_value, unchecked_value = false, hint_text: nil, label: {}, link_errors: false, multiple: true, &block)
       Elements::CheckBoxes::FieldsetCheckBox.new(
         self,
         object_name,

--- a/lib/govuk_design_system_formbuilder/version.rb
+++ b/lib/govuk_design_system_formbuilder/version.rb
@@ -1,3 +1,3 @@
 module GOVUKDesignSystemFormBuilder
-  VERSION = '1.2.8'.freeze
+  VERSION = '1.2.9'.freeze
 end

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
@@ -56,8 +56,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     context 'generating a hidden field for the unchecked value' do
       context 'when the unchecked_value is not provided' do
-        specify 'the hidden field should be present by default' do
-          expect(subject).to have_tag('input', with: { type: 'hidden', value: '0' })
+        specify 'the hidden field should not be present by default' do
+          expect(subject).not_to have_tag('input', with: { type: 'hidden' })
         end
       end
 
@@ -76,6 +76,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
       context 'when the unchecked_value is false' do
         subject { builder.send(*args, false) }
+
         specify %(the hidden field should not be present) do
           expect(subject).not_to have_tag('input', with: { type: 'hidden' })
         end


### PR DESCRIPTION
The new default behaviour causes too many changes to the HTML output for a minor release, it's been toggled back and changing it will be investigated in v2.0.0

The ability to override is still present.