### PR TITLE
Add missing hidden field needed for check box deselection

### DIFF
--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -19,12 +19,20 @@ module GOVUKDesignSystemFormBuilder
       def html
         Containers::FormGroup.new(@builder, @object_name, @attribute_name, **@form_group).html do
           Containers::Fieldset.new(@builder, @object_name, @attribute_name, **fieldset_options).html do
-            safe_join([hint_element, error_element, checkboxes])
+            safe_join([hint_element, error_element, hidden_field, checkboxes])
           end
         end
       end
 
     private
+
+      def hidden_field
+        @builder.hidden_field(@attribute_name, value: "", name: hidden_field_name)
+      end
+
+      def hidden_field_name
+        format("%<object_name>s[%<attribute_name>s][]", object_name: @object_name, attribute_name: @attribute_name)
+      end
 
       def fieldset_options
         {

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
@@ -93,6 +93,14 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
 
+      specify 'there should be a hidden field to represent deselection' do
+        expected_name = %(#{object_name}[#{attribute}][])
+
+        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
+          expect(fg).to have_tag('input', with: { type: 'hidden', name: expected_name })
+        end
+      end
+
       context 'check box size' do
         context 'when small is specified in the options' do
           subject do


### PR DESCRIPTION
When forms are submitted, if a field has no checked check boxes [it's omitted from the form's payload entirely](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#Value). To combat this, Rails adds a hidden field with no value before the check boxes are rendered. This form builder doesn't take that step.

This change makes the form builder add a hidden field within `#govuk_check_boxes_fieldset` and adds a spec to ensure its presence.

This behaviour is already provided by `#govuk_collection_check_boxes` which wraps Rails' functionality more closely.

![Screenshot from 2020-09-05 09-51-33](https://user-images.githubusercontent.com/128088/92301745-18c8d280-ef5e-11ea-8ebd-3f4b63a4cbe1.png)
