### PR TITLE
Add multiple flag to govuk_collection_check_boxes

### DIFF
--- a/guide/content/css/guide.sass
+++ b/guide/content/css/guide.sass
@@ -195,3 +195,13 @@ p, li, dt, dd, td, th
   background: govuk-tint(govuk-colour('pink'), 92%)
   border: 1px solid govuk-tint(govuk-colour('pink'), 80%)
   padding: 1em 1em
+
+blockquote
+  background: govuk-tint(govuk-colour('light-grey'), 35%)
+  padding: 1em
+
+  > p
+    font-style: italic
+
+  > footer
+    font-style

--- a/guide/content/form-elements/checkboxes.slim
+++ b/guide/content/form-elements/checkboxes.slim
@@ -53,6 +53,20 @@ section
         the results. Using smaller checkboxes lets users see and change search
         filters without distracting them from the main content.
 
+    blockquote
+      p.govuk-body
+        | If a checkbox is unchecked when its form is submitted, there is no value
+          submitted to the server to represent its unchecked state
+
+      footer
+        == link_to('Mozilla Developer Network Documentation', 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#Value')
+
+    p.govuk-body
+      | To address the empty submission problem outlined above, Rails generates hidden fields with no
+        value to represent the unchecked state. This is taken care of by default when using <code>govuk_collection_check_boxes</code>
+        and <code>govuk_collection_check_boxes</code> for multiple values. When using <code>govuk_collection_check_boxes</code> for a single value,
+        usually a boolean toggle or confirmation, we need to take an exta step and pass in <code>multiple: false</code>.
+
   == render('/partials/example-fig.*',
     caption: "Generating a single checkbox",
     code: single_checkbox) do
@@ -66,5 +80,11 @@ section
       | When asking users questions, favour the use of 'Yes' and 'No' radio
         buttons. This ensures the user has understood the question and is
         actively selecting the appropriate answer.
+
+    p.govuk-body.important
+      | Note that the <code>multiple</code> keyword on
+        <code>govuk_check_boxes_fieldset</code> changes the hidden field's
+        <code>name</code> attribute to the Rails' single attribute syntax. It is
+        required to prevent unnecessary hidden fields from being generated.
 
 == render('/partials/related-info.*', links: checkbox_info)

--- a/guide/lib/examples/checkboxes.rb
+++ b/guide/lib/examples/checkboxes.rb
@@ -64,6 +64,7 @@ module Examples
       <<~SNIPPET
 
         = f.govuk_check_boxes_fieldset :terms_and_conditions_agreed,
+          multiple: false,
           legend: { text: 'Terms and conditions', size: 'l' } do
 
           = f.hidden_field :terms_and_conditions_agreed, value: false
@@ -81,7 +82,7 @@ module Examples
             true,
             multiple: false,
             link_errors: true,
-            label: { text: 'I agree to the terms and conditions' }
+            label: { text: "I agree to the terms and conditions" }
       SNIPPET
     end
   end

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -710,6 +710,8 @@ module GOVUKDesignSystemFormBuilder
     # @option caption kwargs [Hash] additional arguments are applied as attributes on the caption +span+ element
     # @param classes [Array,String] Classes to add to the checkbox container.
     # @param form_group [Hash] configures the form group
+    # @param multiple [Boolean] when true adds a +[]+ suffix the +name+ of the automatically-generated hidden field
+    #   (ie. <code>project[invoice_attributes][]</code>). When false, no +[]+ suffix is added (ie. <code>project[accepted]</code>)
     # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @param block [Block] a block of HTML that will be used to populate the fieldset
@@ -725,7 +727,7 @@ module GOVUKDesignSystemFormBuilder
     #    = f.govuk_check_box :desired_filling, :lemonade, label: { text: 'Lemonade' }, link_errors: true
     #    = f.govuk_check_box :desired_filling, :fizzy_orange, label: { text: 'Fizzy orange' }
     #
-    def govuk_check_boxes_fieldset(attribute_name, legend: {}, caption: {}, hint: {}, small: false, classes: nil, form_group: {}, &block)
+    def govuk_check_boxes_fieldset(attribute_name, legend: {}, caption: {}, hint: {}, small: false, classes: nil, form_group: {}, multiple: true, &block)
       Containers::CheckBoxesFieldset.new(
         self,
         object_name,
@@ -736,6 +738,7 @@ module GOVUKDesignSystemFormBuilder
         small: small,
         classes: classes,
         form_group: form_group,
+        multiple: multiple,
         &block
       ).html
     end

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -4,7 +4,7 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Error
       include Traits::Hint
 
-      def initialize(builder, object_name, attribute_name, hint:, legend:, caption:, small:, classes:, form_group:, &block)
+      def initialize(builder, object_name, attribute_name, hint:, legend:, caption:, small:, classes:, form_group:, multiple:, &block)
         super(builder, object_name, attribute_name, &block)
 
         @legend        = legend
@@ -13,6 +13,7 @@ module GOVUKDesignSystemFormBuilder
         @small         = small
         @classes       = classes
         @form_group    = form_group
+        @multiple      = multiple
         @block_content = capture { block.call }
       end
 
@@ -27,6 +28,8 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def hidden_field
+        return unless @multiple
+
         @builder.hidden_field(@attribute_name, value: "", name: hidden_field_name)
       end
 

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
@@ -6,6 +6,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     let(:attribute) { :projects }
     let(:method) { :govuk_check_boxes_fieldset }
     let(:field_type) { 'input' }
+    let(:kwargs) { {} }
     let(:aria_described_by_target) { 'fieldset' }
     let(:args) { [method, attribute] }
 
@@ -19,7 +20,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
-    subject { builder.send(*args, &example_block) }
+    subject { builder.send(*args, **kwargs, &example_block) }
 
     include_examples 'HTML formatting checks'
 
@@ -93,11 +94,23 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
 
-      specify 'there should be a hidden field to represent deselection' do
-        expected_name = %(#{object_name}[#{attribute}][])
+      context 'multiple options' do
+        specify 'there should be a hidden field to represent deselection' do
+          expected_name = %(#{object_name}[#{attribute}][])
 
-        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-          expect(fg).to have_tag('input', with: { type: 'hidden', name: expected_name })
+          expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
+            expect(fg).to have_tag('input', with: { type: 'hidden', name: expected_name })
+          end
+        end
+      end
+
+      context 'single option' do
+        let(:kwargs) { { multiple: false } }
+
+        specify 'no hidden field should be present' do
+          expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
+            expect(fg).not_to have_tag('input', with: { type: 'hidden' })
+          end
         end
       end
 


### PR DESCRIPTION
This allows us to suppress the generation of a hidden field by the fieldset helper and allows Rails's `check_box` helper to generate its own, providing `multiple: true` is set on both the fieldset and the check box.

As this is a little unintuitive it has been documented in the guide and API docs