### PR TITLE
Add missing legend to guide proc example

### DIFF
--- a/guide/content/introduction/labels-captions-hints-and-legends.slim
+++ b/guide/content/introduction/labels-captions-hints-and-legends.slim
@@ -200,3 +200,8 @@ section
         a #{link_to('Ruby proc', ruby_proc_link).html_safe}. In this example
         we're using Slim but could just as easily call a helper method or
         render a partial, component or string of HTML.
+
+    p.govuk-body.important
+      | Procs allow for complete control of the legend's HTML, including the
+        legend element itself. This means that the legend element needs to be
+        added manually and it should wrap all of the fieldset's heading text.

--- a/guide/lib/examples/labels_captions_hints_and_legends.rb
+++ b/guide/lib/examples/labels_captions_hints_and_legends.rb
@@ -53,12 +53,13 @@ module Examples
           :id,
           :name,
           legend: -> do
-            h3.govuk-heading-l
-              ' Which
+            legend.govuk-fieldset__legend.govuk-fieldset__legend--l
+              h3.govuk-fieldset__heading
+                ' Which
 
-              span.ugly-gradient colour
+                span.ugly-gradient colour
 
-              ' do you hate most?
+                ' do you hate most?
       SNIPPET
     end
   end


### PR DESCRIPTION
In this case the proc completely overwrites the legend so the wrapping tag needs to be provided manually.