### PR TITLE
Use a non-false value to render hidden field

### DIFF
--- a/guide/content/form-elements/checkboxes.slim
+++ b/guide/content/form-elements/checkboxes.slim
@@ -74,7 +74,7 @@ section
     p.govuk-body
       | Single checkboxes can be used to toggle boolean fields. This pattern
         is most-commonly used for accepting terms and conditions or changing
-        settings
+        settings.
 
     p.govuk-body
       | When asking users questions, favour the use of 'Yes' and 'No' radio

--- a/guide/lib/examples/checkboxes.rb
+++ b/guide/lib/examples/checkboxes.rb
@@ -67,8 +67,6 @@ module Examples
           multiple: false,
           legend: { text: 'Terms and conditions', size: 'l' } do
 
-          = f.hidden_field :terms_and_conditions_agreed, value: false
-
           p.govuk-body
             | Our terms and conditions contain important information about:
 
@@ -79,7 +77,8 @@ module Examples
             li checking you're safe to work with children
 
           = f.govuk_check_box :terms_and_conditions_agreed,
-            true,
+            1,
+            0,
             multiple: false,
             link_errors: true,
             label: { text: "I agree to the terms and conditions" }


### PR DESCRIPTION
This example was out of date, we no longer need to manually specify the hidden field providing we pass a non-false negative value to the checkbox itself.