### PR TITLE
Remove default header tag from legends

### DIFF
--- a/guide/content/introduction/configuration.slim
+++ b/guide/content/introduction/configuration.slim
@@ -21,7 +21,7 @@ p.govuk-body
 
           conf.default_submit_button_text   = 'Apply'                       # Continue
           conf.default_error_summary_title  = 'Uh-oh, spaghettios'          # There is a problem
-          conf.default_legend_tag           = 'h3'                          # h1
+          conf.default_legend_tag           = 'h3'                          # nil
           conf.default_legend_size          = 'l'                           # m
           conf.default_caption_size         = 'xl'                          # m
           conf.default_radio_divider_text   = 'how about'                   # or

--- a/guide/content/introduction/labels-captions-hints-and-legends.slim
+++ b/guide/content/introduction/labels-captions-hints-and-legends.slim
@@ -188,7 +188,7 @@ section
   == render('/partials/example-fig.*',
     caption: "Radio buttons with a fully-customised legend",
     code: radios_with_legend,
-    hide_html_output: true)
+    hide_html_output: false)
 
   == render('/partials/example-fig.*',
     caption: "Fully customising legends with procs",

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -21,7 +21,7 @@ module GOVUKDesignSystemFormBuilder
   #   Can be either +xl+, +l+, +m+ or +s+.
   #
   # * +:default_legend_tag+ controls the default tag that legends are
-  #   wrapped in. Defaults to +h1+.
+  #   wrapped in. Defaults to +nil+.
   #
   # * +:default_submit_button_text+ sets the value assigned to +govuk_submit+,
   #   defaults to 'Continue'.
@@ -47,7 +47,7 @@ module GOVUKDesignSystemFormBuilder
     brand: 'govuk',
 
     default_legend_size: 'm',
-    default_legend_tag: 'h1',
+    default_legend_tag: nil,
     default_caption_size: 'm',
     default_submit_button_text: 'Continue',
     default_radio_divider_text: 'or',

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -459,7 +459,7 @@ module GOVUKDesignSystemFormBuilder
     # @param classes [Array,String] Classes to add to the radio button container.
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
-    # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
+    # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+. If +tag+ is unset no caption will be rendered.
     # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
     # @option legend kwargs [Hash] additional arguments are applied as attributes on the +legend+ element
     # @param caption [Hash] configures or sets the caption content which is inserted above the legend
@@ -538,7 +538,7 @@ module GOVUKDesignSystemFormBuilder
     # @param small [Boolean] controls whether small radio buttons are used instead of regular-sized ones
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
-    # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
+    # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+. If +tag+ is unset no caption will be rendered.
     # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
     # @option legend kwargs [Hash] additional arguments are applied as attributes on the +legend+ element
     # @param caption [Hash] configures or sets the caption content which is inserted above the legend
@@ -635,7 +635,7 @@ module GOVUKDesignSystemFormBuilder
     # @param legend [NilClass,Hash,Proc] options for configuring the legend. Legend will be omitted if +nil+.
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
-    # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
+    # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+. If +tag+ is unset no caption will be rendered.
     # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
     # @param caption [Hash] configures or sets the caption content which is inserted above the legend
     # @option caption text [String] the caption text
@@ -713,7 +713,7 @@ module GOVUKDesignSystemFormBuilder
     # @param legend [NilClass,Hash,Proc] options for configuring the legend. Legend will be omitted if +nil+.
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
-    # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
+    # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+. If +tag+ is unset no caption will be rendered.
     # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
     # @option legend kwargs [Hash] additional arguments are applied as attributes on the +legend+ element
     # @param caption [Hash] configures or sets the caption content which is inserted above the legend
@@ -840,7 +840,7 @@ module GOVUKDesignSystemFormBuilder
     # @param legend [NilClass,Hash,Proc] options for configuring the legend. Legend will be omitted if +nil+.
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
-    # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
+    # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+. If +tag+ is unset no caption will be rendered.
     # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
     # @option legend kwargs [Hash] additional arguments are applied as attributes on the +legend+ element
     # @param caption [Hash] configures or sets the caption content which is inserted above the legend
@@ -893,7 +893,7 @@ module GOVUKDesignSystemFormBuilder
     # @param described_by [Array<String>] the ids of the elements that describe this fieldset, usually hints and errors
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
-    # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+
+    # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+. If +tag+ is unset no caption will be rendered.
     # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
     # @option legend kwargs [Hash] additional arguments are applied as attributes on the +legend+ element
     # @param caption [Hash] configures or sets the caption content which is inserted above the label

--- a/lib/govuk_design_system_formbuilder/elements/legend.rb
+++ b/lib/govuk_design_system_formbuilder/elements/legend.rb
@@ -38,12 +38,18 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def content
-        return nil unless active?
+        return unless active?
 
-        tag.legend(class: classes, **@html_attributes) do
-          content_tag(@tag, class: heading_classes) do
-            safe_join([caption_element, @text])
-          end
+        tag.legend(legend_text, class: classes, **@html_attributes)
+      end
+
+      def legend_text
+        caption_and_text = safe_join([caption_element, @text])
+
+        if @tag.present?
+          content_tag(@tag, class: heading_classes) { caption_and_text }
+        else
+          caption_and_text
         end
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/legend.rb
+++ b/lib/govuk_design_system_formbuilder/elements/legend.rb
@@ -11,7 +11,7 @@ module GOVUKDesignSystemFormBuilder
 
         case legend
         when NilClass
-          @active = false
+          # do nothing
         when Proc
           @raw = capture { legend.call }
         when Hash
@@ -23,7 +23,7 @@ module GOVUKDesignSystemFormBuilder
             @caption = caption
           end
         else
-          fail(ArgumentError, %(legend must be a Proc or Hash))
+          fail(ArgumentError, %(legend must be a NilClass, Proc or Hash))
         end
       end
 

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
@@ -65,7 +65,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         let(:legend_text) { 'Favourite colour?' }
         let(:legend) { { text: legend_text } }
 
-        specify 'output should contain a correclty-positioned caption with the right content' do
+        specify 'output should contain a correctly-positioned caption with the right content' do
           expect(subject).to have_tag('fieldset', with: { class: %w(govuk-fieldset) }) do
             with_tag('span', text: caption_text, with: { class: caption_class })
           end

--- a/spec/govuk_design_system_formbuilder/builder/configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration_spec.rb
@@ -15,8 +15,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       subject { builder.send(*args, legend: { text: legend_text }) }
 
       describe 'legend tag' do
-        specify 'the default tag should be h1' do
-          expect(GOVUKDesignSystemFormBuilder.config.default_legend_tag).to eql('h1')
+        specify 'the default tag should be nil' do
+          expect(GOVUKDesignSystemFormBuilder.config.default_legend_tag).to be_nil
         end
 
         context 'overriding with h6' do

--- a/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
@@ -101,7 +101,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         let(:legend_text) { 'Favourite colour?' }
         let(:legend) { { text: legend_text } }
 
-        specify 'output should contain a correclty-positioned caption with the right content' do
+        specify 'output should contain a correctly-positioned caption with the right content' do
           expect(subject).to have_tag('fieldset', with: { class: %w(govuk-fieldset) }) do
             with_tag('span', text: caption_text, with: { class: caption_class })
           end

--- a/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
@@ -62,7 +62,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         let(:legend_text) { 'Favourite colour?' }
         let(:legend) { { text: legend_text } }
 
-        specify 'output should contain a correclty-positioned caption with the right content' do
+        specify 'output should contain a correctly-positioned caption with the right content' do
           expect(subject).to have_tag('fieldset', with: { class: %w(govuk-fieldset) }) do
             with_tag('span', text: caption_text, with: { class: caption_class })
           end

--- a/spec/support/shared/shared_legend_examples.rb
+++ b/spec/support/shared/shared_legend_examples.rb
@@ -11,7 +11,7 @@ shared_examples 'a field that supports a fieldset with legend' do
     context 'when something other than a Proc or Hash is supplied' do
       subject { builder.send(*args, legend: "This should fail") }
 
-      specify { expect { subject }.to raise_error(ArgumentError, 'legend must be a Proc or Hash') }
+      specify { expect { subject }.to raise_error(ArgumentError, 'legend must be a NilClass, Proc or Hash') }
     end
 
     context 'when no text is supplied' do

--- a/spec/support/shared/shared_legend_examples.rb
+++ b/spec/support/shared/shared_legend_examples.rb
@@ -19,9 +19,7 @@ shared_examples 'a field that supports a fieldset with legend' do
 
       specify 'output should contain a header set to the attribute name' do
         expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-          expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
-            expect(fs).to have_tag('h1', class: 'govuk-fieldset__legend', text: attribute.capitalize)
-          end
+          expect(fg).to have_tag('fieldset', text: attribute.capitalize, with: { class: 'govuk-fieldset' })
         end
       end
     end
@@ -49,7 +47,7 @@ shared_examples 'a field that supports a fieldset with legend' do
             specify %(the legend size should be #{size}) do
               expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
                 expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
-                  expect(fs).to have_tag('h1', text: legend_text, class: "govuk-fieldset__legend--#{size}")
+                  expect(fs).to have_tag('legend', text: legend_text, class: "govuk-fieldset__legend--#{size}")
                 end
               end
             end
@@ -73,7 +71,7 @@ shared_examples 'a field that supports a fieldset with legend' do
         specify %(the legend size should be 'm') do
           expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
             with_tag('fieldset', with: { class: 'govuk-fieldset' }) do
-              with_tag('h1', text: legend_text, class: "govuk-fieldset__legend--#{expected_size}")
+              with_tag('legend', text: legend_text, class: "govuk-fieldset__legend--#{expected_size}")
             end
           end
         end

--- a/spec/support/shared/shared_localisation_examples.rb
+++ b/spec/support/shared/shared_localisation_examples.rb
@@ -144,9 +144,7 @@ shared_examples 'a field that supports setting the legend via localisation' do
     specify 'should set the legend from the locales' do
       with_localisations(localisations) do
         expect(subject).to have_tag('fieldset') do
-          with_tag('legend', with: { class: 'govuk-fieldset__legend' }) do
-            with_tag('h1', text: Regexp.new(expected_legend), with: { class: 'govuk-fieldset__heading' })
-          end
+          with_tag('legend', text: Regexp.new(expected_legend), with: { class: 'govuk-fieldset__legend' })
         end
       end
     end
@@ -159,9 +157,7 @@ shared_examples 'a field that supports setting the legend via localisation' do
     specify 'should set the legend from the locales' do
       with_localisations(localisations) do
         expect(subject).to have_tag('fieldset') do
-          with_tag('legend', with: { class: 'govuk-fieldset__legend' }) do
-            with_tag('h1', text: Regexp.new(expected_legend), with: { class: 'govuk-fieldset__heading' })
-          end
+          with_tag('legend', text: Regexp.new(expected_legend), with: { class: 'govuk-fieldset__legend' })
         end
       end
     end


### PR DESCRIPTION
As per #201, legends shouldn't contain `<h1>` tags by default.

This change modifies the behaviour of legends so that when `tag: nil` the legend content isn't wrapped in any other tags. To override this behaviour, ie when the heading is also the page title, tag can be set to `tag: 'h1'`. to achieve the old behaviour.

The new value for `default_legend_tag` is `nil`.

This is somewhat related to https://github.com/alphagov/govuk-design-system/issues/1364

### Example output:

```slim
= f.govuk_date_field :date_of_birth,
  date_of_birth: true,
  legend: { text: 'Enter your date of birth' },
  hint: { text: 'For example, 31 3 1980' }
```

```html
<div class="govuk-form-group">
  <fieldset class="govuk-fieldset" aria-describedby="person-date-of-birth-hint">
    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
      Enter your date of birth
    </legend>
    <span class="govuk-hint" id="person-date-of-birth-hint">
      For example, 31 3 1980
    </span>
...
```