### PR TITLE
Take a quick look at button tag generation

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -799,7 +799,8 @@ module GOVUKDesignSystemFormBuilder
 
     # Generates a submit button, green by default
     #
-    # @param text [String] the button text
+    # @param content [String,Proc] the submit input or button text. When a Proc is provided the contents will be rendered inside a +<button>+ tag instead
+    #   of an +<input type='submit'>+
     # @param warning [Boolean] makes the button red ({https://design-system.service.gov.uk/components/button/#warning-buttons warning}) when true
     # @param secondary [Boolean] makes the button grey ({https://design-system.service.gov.uk/components/button/#secondary-buttons secondary}) when true
     # @param classes [Array,String] Classes to add to the submit button
@@ -823,8 +824,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_submit "Proceed", prevent_double_click: true do
     #     = link_to 'Cancel', some_other_path, class: 'govuk-button__secondary'
     #
-    def govuk_submit(text = config.default_submit_button_text, warning: false, secondary: false, classes: nil, prevent_double_click: true, validate: false, disabled: false, &block)
-      Elements::Submit.new(self, text, warning: warning, secondary: secondary, classes: classes, prevent_double_click: prevent_double_click, validate: validate, disabled: disabled, &block).html
+    def govuk_submit(content = config.default_submit_button_text, warning: false, secondary: false, classes: nil, prevent_double_click: true, validate: false, disabled: false, &block)
+      Elements::Submit.new(self, content, warning: warning, secondary: secondary, classes: classes, prevent_double_click: prevent_double_click, validate: validate, disabled: disabled, &block).html
     end
 
     # Generates three inputs for the +day+, +month+ and +year+ components of a date

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -3,11 +3,11 @@ module GOVUKDesignSystemFormBuilder
     class Submit < Base
       using PrefixableArray
 
-      def initialize(builder, text, warning:, secondary:, classes:, prevent_double_click:, validate:, disabled:, &block)
+      def initialize(builder, content, warning:, secondary:, classes:, prevent_double_click:, validate:, disabled:, &block)
         fail ArgumentError, 'buttons can be warning or secondary' if warning && secondary
 
         @builder              = builder
-        @text                 = text
+        @content              = content
         @prevent_double_click = prevent_double_click
         @warning              = warning
         @secondary            = secondary
@@ -18,13 +18,21 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        safe_join([submit, @block_content])
+        safe_join([element, @block_content])
       end
 
     private
 
-      def submit
-        @builder.submit(@text, class: classes, **options)
+      def element
+        @content.is_a?(Proc) ? button : input
+      end
+
+      def input
+        @builder.submit(@content, class: classes, **options)
+      end
+
+      def button
+        tag.button(class: classes, **options) { @content.call }
       end
 
       def classes

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -91,6 +91,21 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
+    describe 'when content is a proc containing HTML' do
+      context 'when the button param is true' do
+        let(:button_text) { 'Create the thing' }
+        let(:button_content) { -> { builder.tag.strong(button_text) } }
+
+        subject { builder.send(*args.push(button_content)) }
+
+        specify 'should generate a button tag that contains the supplied HTML' do
+          expect(subject).to have_tag('button', with: { class: 'govuk-button' }) do
+            with_tag('strong', button_text)
+          end
+        end
+      end
+    end
+
     describe 'extra buttons passed in via a block' do
       let(:target) { '#' }
       let(:classes) { %w(govuk-button govuk-button--secondary) }
@@ -135,7 +150,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
-    describe 'disabling button' do
+    describe 'disabling the input' do
       context 'when disabled is false' do
         subject { builder.send(*args.push('Create')) }
 


### PR DESCRIPTION
I'm in two minds about whether or not the presence of a `button` param is a good idea. Unless there's HTML inside the button, is there any advantage of a `<button>` over an `<input type='submit'>`?

Leaning towards choosing the tag based on content (which avoids the problem of dealing with passing in a proc when `button: false`) and having a `config.submit_generate_buttons = (false|true)` to globally override for the sake of developer preference.

Refs #203