### PR TITLE
Render button when HTML content provided to submit

### DIFF
--- a/guide/content/css/guide.sass
+++ b/guide/content/css/guide.sass
@@ -185,6 +185,15 @@ p, li, dt, dd, td, th
   padding: 0 0.2rem
   background: linear-gradient(90deg, rgba(184,255,255,1) 0%, rgba(255,152,255,1) 50%, rgba(255,255,108,1) 100%)
 
+.example-output > button
+  padding: 0.2em 1em 1em
+  font-size: 150%
+
+  div.large
+    font-weight: bold
+    padding: 0.5em 0.6em 0.2em
+    font-size: 200%
+
 .orange-underline
   text-decoration: underline orange solid 2px
   text-underline-offset: 4px

--- a/guide/content/form-elements/submit.slim
+++ b/guide/content/form-elements/submit.slim
@@ -48,4 +48,14 @@ section
         passed in as a block will be rendered in-line with the primary submit
         button.
 
+  == render('/partials/example-fig.*',
+    caption: "A submit button containing HTML",
+    code: button_containing_html) do
+
+    p.govuk-body
+      | To add HTML content to a button pass in a proc instead of a string.
+        This will render the proc content wrapped in <code>button</code> tags
+        instead of the usual <code>input</code> and offer some additional styling
+        options.
+
 == render('/partials/related-info.*', links: submit_info)

--- a/guide/lib/examples/submit.rb
+++ b/guide/lib/examples/submit.rb
@@ -31,5 +31,13 @@ module Examples
             ' Safe as draft
       SNIPPET
     end
+
+    def button_containing_html
+      <<~SNIPPET
+        = f.govuk_submit -> do
+          div.large Submit
+          ' your application
+      SNIPPET
+    end
   end
 end

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -799,7 +799,8 @@ module GOVUKDesignSystemFormBuilder
 
     # Generates a submit button, green by default
     #
-    # @param text [String] the button text
+    # @param content [String,Proc] the submit input or button text. When a Proc is provided the contents will be rendered inside a +<button>+ tag instead
+    #   of an +<input type='submit'>+
     # @param warning [Boolean] makes the button red ({https://design-system.service.gov.uk/components/button/#warning-buttons warning}) when true
     # @param secondary [Boolean] makes the button grey ({https://design-system.service.gov.uk/components/button/#secondary-buttons secondary}) when true
     # @param classes [Array,String] Classes to add to the submit button
@@ -823,8 +824,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_submit "Proceed", prevent_double_click: true do
     #     = link_to 'Cancel', some_other_path, class: 'govuk-button__secondary'
     #
-    def govuk_submit(text = config.default_submit_button_text, warning: false, secondary: false, classes: nil, prevent_double_click: true, validate: false, disabled: false, &block)
-      Elements::Submit.new(self, text, warning: warning, secondary: secondary, classes: classes, prevent_double_click: prevent_double_click, validate: validate, disabled: disabled, &block).html
+    def govuk_submit(content = config.default_submit_button_text, warning: false, secondary: false, classes: nil, prevent_double_click: true, validate: false, disabled: false, &block)
+      Elements::Submit.new(self, content, warning: warning, secondary: secondary, classes: classes, prevent_double_click: prevent_double_click, validate: validate, disabled: disabled, &block).html
     end
 
     # Generates three inputs for the +day+, +month+ and +year+ components of a date

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -3,11 +3,11 @@ module GOVUKDesignSystemFormBuilder
     class Submit < Base
       using PrefixableArray
 
-      def initialize(builder, text, warning:, secondary:, classes:, prevent_double_click:, validate:, disabled:, &block)
+      def initialize(builder, content, warning:, secondary:, classes:, prevent_double_click:, validate:, disabled:, &block)
         fail ArgumentError, 'buttons can be warning or secondary' if warning && secondary
 
         @builder              = builder
-        @text                 = text
+        @content              = content
         @prevent_double_click = prevent_double_click
         @warning              = warning
         @secondary            = secondary
@@ -18,13 +18,21 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        safe_join([submit, @block_content])
+        safe_join([element, @block_content])
       end
 
     private
 
-      def submit
-        @builder.submit(@text, class: classes, **options)
+      def element
+        @content.is_a?(Proc) ? button : input
+      end
+
+      def input
+        @builder.submit(@content, class: classes, **options)
+      end
+
+      def button
+        tag.button(class: classes, **options) { @content.call }
       end
 
       def classes

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -91,6 +91,21 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
+    describe 'when content is a proc containing HTML' do
+      context 'when the button param is true' do
+        let(:button_text) { 'Create the thing' }
+        let(:button_content) { -> { builder.tag.strong(button_text) } }
+
+        subject { builder.send(*args.push(button_content)) }
+
+        specify 'should generate a button tag that contains the supplied HTML' do
+          expect(subject).to have_tag('button', with: { class: 'govuk-button' }) do
+            with_tag('strong', button_text)
+          end
+        end
+      end
+    end
+
     describe 'extra buttons passed in via a block' do
       let(:target) { '#' }
       let(:classes) { %w(govuk-button govuk-button--secondary) }
@@ -135,7 +150,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
-    describe 'disabling button' do
+    describe 'disabling the input' do
       context 'when disabled is false' do
         subject { builder.send(*args.push('Create')) }
 


### PR DESCRIPTION
The `#govuk_submit` method usually renders an `<input type='submit'>`.

Sometimes it might be useful to allow HTML to be included inside a form submission button which would be supported by a `<button>` tag instead.

When the submit content is just text it seems that there's no advantage in using a button over an input, so we'll stick to using what Rails expects.

This change updates the behaviour so when `#govuk_submit` is supplied with HTML (via a proc), it render the contents inside a button tag.

This deviates slightly from Rails' form builder which always uses an input, and there *may* be issues with the way IE6 deals with buttons, but it shouldn't cause any major problems with modern browsers.

It's worth noting that the main reason for opting for a proc instead of a block here is that blocks are already used by `#govuk_submit` to position subsequent buttons and apply spacing between them.

## Examples

### With a string

```slim
= f.govuk_submit 'Do the thing'
```
This will render

```html
<input class="govuk-submit" value="Do the thing"/>
```

### With a proc

```slim
= f.govuk_submit -> { tag.strong('Do the thing') }
```

This will render.

```html
<button class="govuk-submit">
  <strong>Do the thing</strong>
</button>
```

Buttons placed inside forms will automatically submit them.

---------

Fixes #203
Refs #205