### PR TITLE
Allow base errors to link to supplied fields 

### DIFF
--- a/guide/content/introduction/error-handling.slim
+++ b/guide/content/introduction/error-handling.slim
@@ -23,10 +23,25 @@ p.govuk-body
     extra configuration.
 
 == render('/partials/example-fig.*',
-  caption: "A text field with an error",
-  code: text_field_with_errors,
+  caption: "A form with multiple errors",
+  code: form_with_multiple_errors,
   sample_data: departments_data_raw,
-  show_errors: true,
-  hide_data: true)
+  show_errors: :fields,
+  hide_data: true,
+  hide_html_output: true)
+
+== render('/partials/example-fig.*',
+  caption: "Linking errors on the base object to specific fields",
+  code: form_with_errors_on_object_base,
+  sample_data: departments_data_raw,
+  show_errors: :base,
+  hide_data: true,
+  hide_html_output: false) do
+
+  p.govuk-body
+    | Some errors don't apply to a specific field but the object as a whole.
+      The GOV.UK Design System guidelines suggest that in this case, the error
+      summary link should take the user to the first field. As the form builder
+      doesn't know the order in which fields will be rendered, it must be specified.
 
 == render('/partials/related-info.*', links: error_handling_info)

--- a/guide/lib/examples/error_handling.rb
+++ b/guide/lib/examples/error_handling.rb
@@ -1,8 +1,6 @@
 module Examples
   module ErrorHandling
-    def text_field_with_errors
-      object.valid?
-
+    def form_with_multiple_errors
       <<~SNIPPET
         = f.govuk_error_summary
 
@@ -28,6 +26,15 @@ module Examples
           :name,
           :description,
           legend: { text: 'What would you like for lunch on your first day?', size: 's' }
+      SNIPPET
+    end
+
+    def form_with_errors_on_object_base
+      <<~SNIPPET
+        = f.govuk_error_summary link_base_errors_to: :email_address
+
+        = f.govuk_email_field :email_address, label: { text: "Email address" }
+        = f.govuk_phone_field :telephone_number, label: { text: "Phone number" }
       SNIPPET
     end
   end

--- a/guide/lib/helpers/person.rb
+++ b/guide/lib/helpers/person.rb
@@ -79,13 +79,23 @@ class Person
   attr_accessor(
     :welcome_pack_reference_number,
     :welcome_pack_received_on,
-    :welcome_lunch_choice
+    :welcome_lunch_choice,
+    :email_address,
+    :telephone_number
   )
 
-  validates :welcome_pack_reference_number, presence: { message: 'Enter the reference number you received in your welcome pack' }
-  validates :welcome_pack_received_on, presence: { message: 'Enter the date you received your welcome pack' }
-  validates :department_id, presence: { message: %(Select the department to which you've been assigned) }
-  validates :welcome_lunch_choice, presence: { message: 'Select a lunch choice for your first day' }
+  validates :welcome_pack_reference_number, presence: { message: 'Enter the reference number you received in your welcome pack' }, on: :fields
+  validates :welcome_pack_received_on, presence: { message: 'Enter the date you received your welcome pack' }, on: :fields
+  validates :department_id, presence: { message: %(Select the department to which you've been assigned) }, on: :fields
+  validates :welcome_lunch_choice, presence: { message: 'Select a lunch choice for your first day' }, on: :fields
+
+  validate :telephone_number_or_email_address_exists, on: :base_errors
+
+  def telephone_number_or_email_address_exists
+    if telephone_number.blank? && email_address.blank?
+      errors[:base] << "Enter a telephone number or email address"
+    end
+  end
 
   # fieldset
   attr_accessor(

--- a/guide/lib/setup/form_builder_objects.rb
+++ b/guide/lib/setup/form_builder_objects.rb
@@ -1,23 +1,38 @@
 module Setup
   module FormBuilderObjects
     def builder(errors = false)
-      errors ? builder_with_errors : builder_without_errors
+      case errors
+      when :fields
+        builder_with_field_errors
+      when :base
+        builder_with_base_errors
+      else
+        builder_without_errors
+      end
     end
 
     def builder_without_errors
       GOVUKDesignSystemFormBuilder::FormBuilder.new(:person, object, helper, {})
     end
 
-    def builder_with_errors
-      GOVUKDesignSystemFormBuilder::FormBuilder.new(:person, object_with_errors, helper, {})
+    def builder_with_field_errors
+      GOVUKDesignSystemFormBuilder::FormBuilder.new(:person, object_with_field_errors, helper, {})
+    end
+
+    def builder_with_base_errors
+      GOVUKDesignSystemFormBuilder::FormBuilder.new(:person, object_with_base_errors, helper, {})
     end
 
     def object
       Person.new
     end
 
-    def object_with_errors
-      Person.new.tap(&:valid?)
+    def object_with_field_errors
+      Person.new.tap { |p| p.valid?(:fields) }
+    end
+
+    def object_with_base_errors
+      Person.new.tap { |p| p.valid?(:base_errors) }
     end
 
     def helper

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -880,6 +880,8 @@ module GOVUKDesignSystemFormBuilder
     # part of the form that contains the error
     #
     # @param title [String] the error summary heading
+    # @param link_base_errors_to [Symbol,String] set the field that errors on +:base+ are linked
+    #   to, as there won't be a field representing the object base.
     #
     # @note Only the first error in the +#errors+ array for each attribute will
     #   be included.
@@ -888,8 +890,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_error_summary 'Uh-oh, spaghettios'
     #
     # @see https://design-system.service.gov.uk/components/error-summary/ GOV.UK error summary
-    def govuk_error_summary(title = config.default_error_summary_title)
-      Elements::ErrorSummary.new(self, object_name, title).html
+    def govuk_error_summary(title = config.default_error_summary_title, link_base_errors_to: nil)
+      Elements::ErrorSummary.new(self, object_name, title, link_base_errors_to: link_base_errors_to).html
     end
 
     # Generates a fieldset containing the contents of the block

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -3,10 +3,11 @@ module GOVUKDesignSystemFormBuilder
     class ErrorSummary < Base
       include Traits::Error
 
-      def initialize(builder, object_name, title)
-        @builder = builder
-        @object_name = object_name
-        @title = title
+      def initialize(builder, object_name, title, link_base_errors_to:)
+        @builder             = builder
+        @object_name         = object_name
+        @title               = title
+        @link_base_errors_to = link_base_errors_to
       end
 
       def html
@@ -54,7 +55,11 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def field_id(attribute)
-        build_id('field-error', attribute_name: attribute)
+        if attribute.eql?(:base) && @link_base_errors_to.present?
+          build_id('field', attribute_name: @link_base_errors_to)
+        else
+          build_id('field-error', attribute_name: attribute)
+        end
       end
 
       def summary_title_id

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -289,5 +289,27 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         expect { subject }.to raise_error(NoMethodError, /errors/)
       end
     end
+
+    describe 'when there are errors on the base object' do
+      let(:object) { Person.with_errors_on_base }
+      let(:error) { object.errors[:base].first }
+
+      context 'when an override is specified' do
+        let(:link_base_errors_to) { :name }
+        subject { builder.send(method, link_base_errors_to: link_base_errors_to) }
+
+        specify 'the override field should be linked to' do
+          expect(subject).to have_tag("a", text: error, with: { href: %(#person-#{link_base_errors_to}-field) })
+        end
+      end
+
+      context 'when no override is specified' do
+        subject { builder.send(method) }
+
+        specify 'the base field should be linked to' do
+          expect(subject).to have_tag("a", text: error, with: { href: %(#person-base-field-error) })
+        end
+      end
+    end
   end
 end

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -41,6 +41,10 @@ class Person < Being
     )
   end
 
+  def self.with_errors_on_base
+    new.tap { |p| p.errors[:base].push("This person is always invalid") }
+  end
+
 private
 
   def born_on_must_be_in_the_past


### PR DESCRIPTION
In the case where errors are added to the object's `:base`, linking items in the error summary list to a field is impossible. The GOV.UK Design System guidance states that [such errors should link to the first field](https://design-system.service.gov.uk/components/error-summary#linking-from-the-error-summary-to-each-answer).

This change adds a `link_base_errors_to` argument to the error_summary helper that will override the link when errors on the object base are detected.

There's a [new section on the guide](https://deploy-preview-209--govuk-form-builder.netlify.app/introduction/error-handling/#linking-errors-on-the-base-object-to-specific-fields) covering the behaviour in more detail.

Refs #208 