### PR TITLE
Propagate value to hint element in FieldsetCheckBox

### DIFF
--- a/guide/content/building-blocks/localisation.slim
+++ b/guide/content/building-blocks/localisation.slim
@@ -58,6 +58,12 @@ p.govuk-body
     sample_data: departments_value_data_raw)
 
   == render('/partials/example-fig.*',
+    caption: "A more comprehensive example of localised check boxes",
+    localisation: movie_genre_check_boxes_locale,
+    code: movie_genre_check_boxes) do
+    == render('/partials/fieldset-warning.*', input_type: 'check box')
+
+  == render('/partials/example-fig.*',
     caption: "Customising locale structure",
     localisation: custom_locale,
     code: role_name,

--- a/guide/lib/examples/localisation.rb
+++ b/guide/lib/examples/localisation.rb
@@ -83,6 +83,42 @@ module Examples
       LOCALE
     end
 
+    def movie_genre_check_boxes
+      <<~SNIPPET
+        = f.govuk_check_boxes_fieldset :movie_genres do
+          = f.govuk_check_box :movie_genres, :action, link_errors: true
+          = f.govuk_check_box :movie_genres, :comedy
+          = f.govuk_check_box :movie_genres, :horror
+          = f.govuk_check_box :movie_genres, :other do
+            = f.govuk_text_field :other_movie_genres
+      SNIPPET
+    end
+
+    def movie_genre_check_boxes_locale
+      <<~LOCALE
+        helpers:
+          legend:
+            person:
+              movie_genres: Which movie genres do you prefer?
+          hint:
+            person:
+              other_movie_genres: You can enter as many as you like
+              movie_genres: Select all that apply
+              movie_genres_options:
+                action: War, espionage, martial arts
+                comedy: Parody, dark comedy
+                horror: Zombies, slasher, found footage
+          label:
+            person:
+              other_movie_genres: Which additional movie genres do you like?
+              movie_genres_options:
+                action: Action
+                comedy: Comedy
+                horror: Horror
+                other: Other
+      LOCALE
+    end
+
     def role_name
       <<~SNIPPET
         = f.govuk_text_field :role, label: { size: 'm' }

--- a/guide/lib/helpers/person.rb
+++ b/guide/lib/helpers/person.rb
@@ -47,6 +47,8 @@ class Person
     :department_ids,
     :languages,
     :other_language,
+    :movie_genres,
+    :other_movie_genres,
     :terms_and_conditions_agreed
   )
 

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -67,7 +67,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def hint_options
-          { checkbox: true }
+          { value: @value, checkbox: true }
         end
 
         def conditional_classes

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
@@ -40,6 +40,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that contains a customisable form group'
 
     it_behaves_like 'a field that supports setting the hint via localisation'
+    it_behaves_like 'a field that supports localised fieldset hints' do
+      let(:localisation_key) { :projects_options }
+      let(:field_name_selector) { "projects" }
+    end
     it_behaves_like 'a field that supports setting the legend via localisation'
 
     it_behaves_like 'a field that accepts a plain ruby object' do

--- a/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
@@ -40,6 +40,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that contains a customisable form group'
 
     it_behaves_like 'a field that supports setting the hint via localisation'
+    it_behaves_like 'a field that supports localised fieldset hints' do
+      let(:localisation_key) { :favourite_colour_options }
+      let(:field_name_selector) { "favourite-colour" }
+    end
     it_behaves_like 'a field that supports setting the legend via localisation'
 
     it_behaves_like 'a field that accepts a plain ruby object' do

--- a/spec/support/locales/collection_hints.en.yaml
+++ b/spec/support/locales/collection_hints.en.yaml
@@ -1,0 +1,9 @@
+helpers:
+  hint:
+    person:
+      projects_options:
+        11: Xanthous
+        22: Yellow
+      favourite_colour_options:
+        red: Maroon
+        green: Pea

--- a/spec/support/shared/shared_localisation_examples.rb
+++ b/spec/support/shared/shared_localisation_examples.rb
@@ -251,3 +251,17 @@ shared_examples 'a field that supports localised collection hints' do
     end
   end
 end
+
+shared_examples 'a field that supports localised fieldset hints' do
+  let(:localisations) { { en: YAML.load_file('spec/support/locales/collection_hints.en.yaml').deep_symbolize_keys } }
+  let(:expected_hints) { localisations.dig(:en, :helpers, :hint, :person, localisation_key) }
+
+  specify 'the hints should be set by localisation' do
+    with_localisations(localisations) do
+      expected_hints.each do |id, hint|
+        expected_id = ["person", field_name_selector, id, "hint"].join("-")
+        expect(subject).to have_tag("span", with: { id: expected_id }, text: hint)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The value was missing from the `hint_options` hash, and the consequence was (because a `nil` value) the fallback to the hint text of the fieldset, when declaring individual checkboxes inside a `govuk_check_boxes_fieldset` (for example if one of the check boxes has to reveal a text area)

The code causing the issue was (it was entering in the second branching due to value being `nil`):

```ruby
def schema_path
  if @value.present?
    [@object_name, "#{@attribute_name}_options", @value]
  else
    [@object_name, @attribute_name]
  end
end
```

### Example before
<img width="630" alt="Screenshot 2020-10-26 at 10 59 52" src="https://user-images.githubusercontent.com/687910/97297261-ab446e80-1849-11eb-8c30-285d96e1f1c5.png">

### Example after
<img width="605" alt="Screenshot 2020-10-27 at 11 35 26" src="https://user-images.githubusercontent.com/687910/97297283-b5666d00-1849-11eb-87c0-54d43d031004.png">

If any of the individual check boxes had a hint text declared in the locales, it will show as expected:
<img width="604" alt="Screenshot 2020-10-27 at 11 36 15" src="https://user-images.githubusercontent.com/687910/97297378-dcbd3a00-1849-11eb-9502-68c1138bb671.png">
