### PR TITLE
Allow suppression of elements by passing in nil

### DIFF
--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -30,7 +30,11 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def legend_element
-        @legend_element ||= Elements::Legend.new(@builder, @object_name, @attribute_name, **legend_options)
+        @legend_element ||= if @legend.nil?
+                              Elements::Null.new
+                            else
+                              Elements::Legend.new(@builder, @object_name, @attribute_name, **legend_options)
+                            end
       end
 
       def legend_options

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -6,6 +6,7 @@ module GOVUKDesignSystemFormBuilder
 
         include Traits::Label
         include Traits::Hint
+        include Traits::FieldsetItem
         include Traits::Conditional
 
         def initialize(builder, object_name, attribute_name, value, unchecked_value, label:, hint:, link_errors:, multiple:, &block)
@@ -54,20 +55,8 @@ module GOVUKDesignSystemFormBuilder
           %w(checkboxes__input).prefix(brand)
         end
 
-        def label_element
-          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, **label_content, **label_options)
-        end
-
-        def label_options
-          { checkbox: true, value: @value, link_errors: @link_errors }
-        end
-
-        def hint_element
-          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_options, **hint_content)
-        end
-
-        def hint_options
-          { value: @value, checkbox: true }
+        def fieldset_options
+          { checkbox: true }
         end
 
         def conditional_classes

--- a/lib/govuk_design_system_formbuilder/elements/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/hint.rb
@@ -25,7 +25,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        return nil unless active?
+        return unless active?
 
         content_tag(hint_tag, **hint_options, **@html_attributes) { hint_body }
       end

--- a/lib/govuk_design_system_formbuilder/elements/null.rb
+++ b/lib/govuk_design_system_formbuilder/elements/null.rb
@@ -1,0 +1,19 @@
+module GOVUKDesignSystemFormBuilder
+  module Elements
+    class Null < Base
+      def initialize; end
+
+      def html
+        nil
+      end
+
+      def active?
+        false
+      end
+
+      def hint_id
+        nil
+      end
+    end
+  end
+end

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -6,6 +6,7 @@ module GOVUKDesignSystemFormBuilder
 
         include Traits::Label
         include Traits::Hint
+        include Traits::FieldsetItem
         include Traits::Conditional
 
         def initialize(builder, object_name, attribute_name, value, label:, hint:, link_errors:, &block)
@@ -34,24 +35,8 @@ module GOVUKDesignSystemFormBuilder
           end
         end
 
-        def radio_options
+        def fieldset_options
           { radio: true }
-        end
-
-        def label_element
-          @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, **label_content, **label_options)
-        end
-
-        def label_options
-          { value: @value, link_errors: @link_errors }.merge(radio_options)
-        end
-
-        def hint_element
-          @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_options, **hint_content)
-        end
-
-        def hint_options
-          { value: @value }.merge(radio_options)
         end
 
         def input

--- a/lib/govuk_design_system_formbuilder/traits/caption.rb
+++ b/lib/govuk_design_system_formbuilder/traits/caption.rb
@@ -4,11 +4,11 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def caption_element
-        @caption_element ||= Elements::Caption.new(@builder, @object_name, @attribute_name, **caption_options)
-      end
-
-      def caption_options
-        @caption
+        @caption_element ||= if @caption.nil?
+                               Elements::Null.new
+                             else
+                               Elements::Caption.new(@builder, @object_name, @attribute_name, **@caption)
+                             end
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/traits/fieldset_item.rb
+++ b/lib/govuk_design_system_formbuilder/traits/fieldset_item.rb
@@ -1,0 +1,27 @@
+module GOVUKDesignSystemFormBuilder
+  module Traits
+    module FieldsetItem
+    private
+
+      def label_element
+        @label_element ||= if @label.nil?
+                             Elements::Null.new
+                           else
+                             Elements::Label.new(@builder, @object_name, @attribute_name, **label_content, **label_options)
+                           end
+      end
+
+      def label_options
+        { value: @value, link_errors: @link_errors }.merge(fieldset_options)
+      end
+
+      def hint_element
+        @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_options, **hint_content)
+      end
+
+      def hint_options
+        { value: @value }.merge(fieldset_options)
+      end
+    end
+  end
+end

--- a/lib/govuk_design_system_formbuilder/traits/fieldset_item.rb
+++ b/lib/govuk_design_system_formbuilder/traits/fieldset_item.rb
@@ -16,7 +16,11 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def hint_element
-        @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_options, **hint_content)
+        @hint_element ||= if @hint.nil?
+                            Elements::Null.new
+                          else
+                            Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_options, **hint_content)
+                          end
       end
 
       def hint_options

--- a/lib/govuk_design_system_formbuilder/traits/hint.rb
+++ b/lib/govuk_design_system_formbuilder/traits/hint.rb
@@ -10,13 +10,15 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def hint_element
-        @hint_element ||= Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_content)
+        @hint_element ||= if @hint.nil?
+                            Elements::Null.new
+                          else
+                            Elements::Hint.new(@builder, @object_name, @attribute_name, **hint_content)
+                          end
       end
 
       def hint_content
         case @hint
-        when NilClass
-          {}
         when Hash
           @hint
         when Proc

--- a/lib/govuk_design_system_formbuilder/traits/label.rb
+++ b/lib/govuk_design_system_formbuilder/traits/label.rb
@@ -4,7 +4,11 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def label_element
-        @label_element ||= Elements::Label.new(@builder, @object_name, @attribute_name, caption: @caption, **label_content)
+        @label_element ||= if @label.nil?
+                             Elements::Null.new
+                           else
+                             Elements::Label.new(@builder, @object_name, @attribute_name, caption: @caption, **label_content)
+                           end
       end
 
       def label_content

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
@@ -4,16 +4,17 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
   describe '#govuk_check_box' do
     let(:method) { :govuk_check_box }
-    let(:attribute) { :projects }
-    let(:value) { project_x.id }
+    let(:attribute) { :stationery }
+    let(:value) { ballpoint_pen.id }
+    let(:value_with_dashes) { underscores_to_dashes(value) }
     let(:args) { [method, attribute, value] }
 
     subject { builder.send(*args) }
 
     specify 'output should contain a check box item group with a check box input' do
-      expect(subject).to have_tag('div', with: { class: 'govuk-checkboxes__item' }) do |ci|
-        expect(ci).to have_tag('input', with: {
-          id: "person-projects-#{value}-field",
+      expect(subject).to have_tag('div', with: { class: 'govuk-checkboxes__item' }) do
+        with_tag('input', with: {
+          id: "person-stationery-#{value_with_dashes}-field",
           type: 'checkbox',
           value: value
         })
@@ -25,7 +26,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports custom branding'
 
     it_behaves_like 'a field that supports labels' do
-      let(:label_text) { 'Project X' }
+      let(:label_text) { 'Writing implement' }
       let(:field_type) { "input[type='checkbox']" }
 
       specify 'the label should have a check box label class' do
@@ -34,6 +35,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that supports setting the label via localisation'
+    it_behaves_like 'a field that supports setting the hint via localisation'
 
     context 'labels set via procs' do
       let(:label_text) { 'Project Y' }
@@ -53,7 +55,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     context 'check box hints' do
-      let(:hint_text) { project_x.description }
+      let(:hint_text) { ballpoint_pen.description }
 
       subject do
         builder.send(*args, hint: { text: hint_text })
@@ -159,7 +161,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         specify 'conditional_id contains the object, attribute and value name' do
           expect(
             parsed_subject.at_css("input[type='checkbox']")['data-aria-controls']
-          ).to eql("#{object_name}-#{attribute}-#{value}-conditional")
+          ).to eql("#{object_name}-#{attribute}-#{value_with_dashes}-conditional")
         end
       end
 

--- a/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
@@ -5,8 +5,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
   describe '#govuk_radio_button' do
     let(:method) { :govuk_radio_button }
-    let(:value) { 'red' }
-    let(:attribute) { :favourite_colour }
+    let(:value) { :ballpoint_pen }
+    let(:value_with_dashes) { underscores_to_dashes(value) }
+    let(:attribute) { :stationery }
     let(:args) { [method, attribute, value] }
 
     subject { builder.send(*args) }
@@ -31,6 +32,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that supports setting the label via localisation'
+    it_behaves_like 'a field that supports setting the hint via localisation'
 
     context 'labels set via procs' do
       let(:label_text) { 'Orange' }
@@ -79,7 +81,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       context 'when a block is given' do
         subject do
           builder.govuk_radio_button(attribute, value) do
-            builder.govuk_text_field(:favourite_colour_reason)
+            builder.govuk_text_field(:stationery_choice)
           end
         end
 
@@ -89,7 +91,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
         specify 'should include content provided in the block in a conditional div' do
           expect(subject).to have_tag('div', with: { class: 'govuk-radios__conditional govuk-radios__conditional--hidden' }) do |cd|
-            expect(cd).to have_tag('label', with: { class: 'govuk-label' }, text: 'Favourite_colour_reason')
+            expect(cd).to have_tag('label', with: { class: 'govuk-label' }, text: 'Stationery_choice')
             expect(cd).to have_tag('input', with: { type: 'text' })
           end
         end
@@ -103,7 +105,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         specify 'conditional_id contains the object, attribute and value name' do
           expect(
             parsed_subject.at_css("input[type='radio']")['data-aria-controls']
-          ).to eql(%(person-favourite-colour-#{value}-conditional))
+          ).to eql(%(person-stationery-#{value_with_dashes}-conditional))
         end
       end
 

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -3,6 +3,11 @@ class Project
   attr_accessor(:id, :name, :description)
 end
 
+class Stationery
+  include ActiveModel::Model
+  attr_accessor(:id, :name, :description)
+end
+
 class Being
   attr_accessor(
     :name,
@@ -15,7 +20,9 @@ class Being
     :project_responsibilities,
     :cv,
     :photo,
-    :department
+    :department,
+    :stationery,
+    :stationery_choice
   )
 end
 

--- a/spec/support/locales/sample.en.yaml
+++ b/spec/support/locales/sample.en.yaml
@@ -15,6 +15,8 @@ helpers:
         marketing: Marketing
         finance: Finance
         sales: Sales
+      stationery_options:
+        ballpoint_pen: An ink-dispensing writing implement
 
   caption:
     person:
@@ -43,3 +45,7 @@ helpers:
         marketing: Flyers, posters, etc
         finance: What's worth doing is worth doing for money
         # sales is intentionally missing
+      stationery_options:
+        ballpoint_pen: |-
+          A ballpoint pen, also known as a biro or ball pen, is a pen that
+          dispenses ink (usually in paste form) over a metal ball at its point.

--- a/spec/support/shared/setup_examples.rb
+++ b/spec/support/shared/setup_examples.rb
@@ -22,4 +22,10 @@ shared_context 'setup examples' do
   let(:department_marketing) { Department.new(code: :marketing, name: "Flyer distribution") }
   let(:department_sales) { Department.new(code: :sales, name: "Selling stuff") }
   let(:departments) { [department_it, department_finance, department_marketing, department_sales] }
+
+  let(:pencil) { Stationery.new(id: :pencil, name: "Pencil") }
+  let(:ballpoint_pen) { Stationery.new(id: :ballpoint_pen, name: "Ballpoint pen", description: "A ballpoint pen dispenses ink over a metal ball at its point") }
+  let(:ruler) { Stationery.new(id: :ruler, name: "Ruler") }
+  let(:stapler) { Stationery.new(id: :stapler, name: "Stapler") }
+  let(:stationery_items) { [pencil, ballpoint_pen, ruler, stapler] }
 end

--- a/spec/support/shared/shared_localisation_examples.rb
+++ b/spec/support/shared/shared_localisation_examples.rb
@@ -145,7 +145,13 @@ shared_examples 'a field that supports setting the hint via localisation' do
   let(:localisations) { LOCALISATIONS }
 
   context 'localising when no text is supplied' do
-    let(:expected_hint) { I18n.translate("helpers.hint.person.#{attribute}") }
+    let(:expected_hint) do
+      if defined?(value) && value.present?
+        I18n.translate("helpers.hint.person.#{attribute}_options.#{value}")
+      else
+        I18n.translate("helpers.hint.person.#{attribute}")
+      end
+    end
 
     subject { builder.send(*args) { arbitrary_html_content } }
 

--- a/spec/support/shared/shared_localisation_examples.rb
+++ b/spec/support/shared/shared_localisation_examples.rb
@@ -36,6 +36,18 @@ shared_examples 'a field that supports setting the label via localisation' do
       end
     end
   end
+
+  context 'allowing localised text to be suppressed' do
+    subject do
+      builder.send(*args, label: nil)
+    end
+
+    specify 'no label should be rendered' do
+      with_localisations(localisations) do
+        expect(subject).not_to have_tag('label')
+      end
+    end
+  end
 end
 
 shared_examples 'a field that supports setting the label caption via localisation' do
@@ -64,7 +76,21 @@ shared_examples 'a field that supports setting the label caption via localisatio
 
     specify 'should use the supplied caption text' do
       with_localisations(localisations) do
-        expect(subject).to have_tag('span', text: expected_caption)
+        expect(subject).to have_tag('span', text: expected_caption, with: { class: "govuk-caption-m" })
+      end
+    end
+  end
+
+  context 'allowing localised text to be suppressed' do
+    let(:expected_caption) { "Private data" }
+
+    subject do
+      builder.send(*args, caption: nil)
+    end
+
+    specify 'no caption should be rendered' do
+      with_localisations(localisations) do
+        expect(subject).not_to have_tag('span', with: { class: "govuk-caption-m" })
       end
     end
   end
@@ -100,6 +126,18 @@ shared_examples 'a field that supports setting the legend caption via localisati
       end
     end
   end
+
+  context 'allowing localised text to be suppressed via the legend' do
+    subject do
+      builder.send(*args, legend: nil)
+    end
+
+    specify 'no caption should be rendered' do
+      with_localisations(localisations) do
+        expect(subject).not_to have_tag('span', with: { class: "govuk-caption-m" })
+      end
+    end
+  end
 end
 
 shared_examples 'a field that supports setting the hint via localisation' do
@@ -131,6 +169,18 @@ shared_examples 'a field that supports setting the hint via localisation' do
       end
     end
   end
+
+  context 'allowing localised text to be suppressed' do
+    subject do
+      builder.send(*args, hint: nil) { arbitrary_html_content }
+    end
+
+    specify 'no hint should be rendered' do
+      with_localisations(localisations) do
+        expect(subject).not_to have_tag('span', with: { class: 'govuk-hint' })
+      end
+    end
+  end
 end
 
 shared_examples 'a field that supports setting the legend via localisation' do
@@ -159,6 +209,16 @@ shared_examples 'a field that supports setting the legend via localisation' do
         expect(subject).to have_tag('fieldset') do
           with_tag('legend', text: Regexp.new(expected_legend), with: { class: 'govuk-fieldset__legend' })
         end
+      end
+    end
+  end
+
+  context 'allowing localised text to be suppressed' do
+    subject { builder.send(*args, legend: nil) { arbitrary_html_content } }
+
+    specify 'no legend should be rendered' do
+      with_localisations(localisations) do
+        expect(subject).not_to have_tag('legend')
       end
     end
   end


### PR DESCRIPTION
This addresses a problem where elements are always rendered if there's a matching localisation key, even if `nil` is supplied to the helper.

Introducing a `Elements::Null` class simplifies the logic - an alternative solution was to introduce an `:enabled` flag but as we already have :active it was noisy and confusing.

When the relevant argument (`:caption`, `:hint`, `:label` or `:legend`) is nil a `Elements::Null` is built instead of the usual 'active' element. It will never render any HTML and allows the suppression of elements.

The default argument for captions, hints, labels and legends is always an empty hash, so simply not providing any arguments will allow the localisation mechanism to kick in and populate the element.

Fixes #212