### PR TITLE
Ensure keyword args applied as attribtues to legends

### DIFF
--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -38,7 +38,14 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def legend_options
-        { legend: @legend, caption: @caption }
+        case @legend
+        when Hash
+          @legend.merge(caption: @caption)
+        when Proc
+          { content: @legend }
+        else
+          fail(ArgumentError, %(legend must be a Proc or Hash))
+        end
       end
     end
   end

--- a/spec/support/shared/shared_legend_examples.rb
+++ b/spec/support/shared/shared_legend_examples.rb
@@ -11,7 +11,7 @@ shared_examples 'a field that supports a fieldset with legend' do
     context 'when something other than a Proc or Hash is supplied' do
       subject { builder.send(*args, legend: "This should fail") }
 
-      specify { expect { subject }.to raise_error(ArgumentError, 'legend must be a NilClass, Proc or Hash') }
+      specify { expect { subject }.to raise_error(ArgumentError, 'legend must be a Proc or Hash') }
     end
 
     context 'when no text is supplied' do

--- a/spec/support/shared/shared_legend_examples.rb
+++ b/spec/support/shared/shared_legend_examples.rb
@@ -76,6 +76,15 @@ shared_examples 'a field that supports a fieldset with legend' do
           end
         end
       end
+
+      context 'when additional HTML attributes are provided' do
+        let(:html_attributes) { { focusable: 'false', lang: 'fr' } }
+        subject { builder.send(*args, legend: { text: legend_text }.merge(html_attributes)) }
+
+        specify 'the legend should have the custom HTML attributes' do
+          expect(subject).to have_tag('.govuk-fieldset__legend', with: html_attributes, text: legend_text)
+        end
+      end
     end
 
     context 'when a proc is supplied' do


### PR DESCRIPTION
This fixes a bug #216 that was caused by an oversight when it came to the arguments passed into the legend - for historical reasons, legends were structured differently to Labels, Hints and Captions so the `kwargs` weren't where I expected them to be :man_facepalming: 

This PR brings them all more-or-less inline which fixes the bug automatically.