### PR TITLE
Add support for wildcards in day and month inputs

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -850,6 +850,7 @@ module GOVUKDesignSystemFormBuilder
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option caption kwargs [Hash] additional arguments are applied as attributes on the caption +span+ element
     # @param omit_day [Boolean] do not render a day input, only capture month and year
+    # @param wildcards [Boolean] add an 'X' to the date wildcards so users can add approximate dates
     # @param form_group [Hash] configures the form group
     # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
@@ -872,8 +873,8 @@ module GOVUKDesignSystemFormBuilder
     # @example A date input with legend supplied as a proc
     #  = f.govuk_date_field :finishes_on,
     #    legend: -> { tag.h3('Which category do you belong to?') }
-    def govuk_date_field(attribute_name, hint: {}, legend: {}, caption: {}, date_of_birth: false, omit_day: false, form_group: {}, &block)
-      Elements::Date.new(self, object_name, attribute_name, hint: hint, legend: legend, caption: caption, date_of_birth: date_of_birth, omit_day: omit_day, form_group: form_group, &block).html
+    def govuk_date_field(attribute_name, hint: {}, legend: {}, caption: {}, date_of_birth: false, omit_day: false, form_group: {}, wildcards: false, &block)
+      Elements::Date.new(self, object_name, attribute_name, hint: hint, legend: legend, caption: caption, date_of_birth: date_of_birth, omit_day: omit_day, form_group: form_group, wildcards: wildcards, &block).html
     end
 
     # Generates a summary of errors in the form, each linking to the corresponding

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -9,7 +9,7 @@ module GOVUKDesignSystemFormBuilder
 
       SEGMENTS = { day: '3i', month: '2i', year: '1i' }.freeze
 
-      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, date_of_birth: false, omit_day:, form_group:, &block)
+      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, date_of_birth: false, omit_day:, form_group:, wildcards:, &block)
         super(builder, object_name, attribute_name, &block)
 
         @legend        = legend
@@ -18,6 +18,7 @@ module GOVUKDesignSystemFormBuilder
         @date_of_birth = date_of_birth
         @omit_day      = omit_day
         @form_group    = form_group
+        @wildcards     = wildcards
       end
 
       def html
@@ -82,11 +83,17 @@ module GOVUKDesignSystemFormBuilder
           class: classes(width),
           name: name(segment),
           type: 'text',
-          pattern: '[0-9]*',
+          pattern: pattern(segment),
           inputmode: 'numeric',
           value: value,
           autocomplete: date_of_birth_autocomplete_value(segment)
         )
+      end
+
+      def pattern(segment)
+        return '[0-9X]*' if @wildcards && segment.in?(%i(day month))
+
+        '[0-9]*'
       end
 
       def classes(width)

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -211,5 +211,18 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
     end
+
+    describe "wildcards" do
+      subject { builder.send(*args, wildcards: true) }
+
+      specify %(the date and month input patterns contain an X) do
+        expect(subject).to have_tag('input', with: { id: day_identifier, pattern: "[0-9X]*" })
+        expect(subject).to have_tag('input', with: { id: month_identifier, pattern: "[0-9X]*" })
+      end
+
+      specify %(the year pattern doesn't contain an X) do
+        expect(subject).to have_tag('input', with: { id: year_identifier, pattern: "[0-9]*" })
+      end
+    end
   end
 end


### PR DESCRIPTION
The [latest version of the design system](https://github.com/alphagov/govuk-frontend/releases/tag/v3.10.0), introduces support for date inputs that [allow an 'X' to be used in place of an exact date](https://github.com/alphagov/govuk-frontend/pull/1975).

This change implements that functionality but does so in a more-restrictive way; users won't have free reign over the pattern but
can optionally have 'X' added to it by supplying `wildcards: true` as an argument.

Should this be more flexible? Is it even necessary? These special 'dates' will need to be intercepted before Rails tries to parse them anyway, perhaps this should be left as an exercise for the developer 🤔