### PR TITLE
Add hyperlink directly to single checkbox example

### DIFF
--- a/guide/content/form-elements/checkboxes.slim
+++ b/guide/content/form-elements/checkboxes.slim
@@ -12,7 +12,7 @@ p.govuk-body
 
   ul.govuk-list.govuk-list--bullet
     li select multiple options from a list
-    li toggle a single option on or off
+    li == link_to("toggle a single option on or off", "#generating-a-single-checkbox")
 
 section
 


### PR DESCRIPTION
This is a really common use case for checkboxes and it's not immediately obvious that `1` and `0` should be used instead of `true` and `false`. Hopefully the link will make the example easier to find. If not it might be worth separating it out into a separate page.