### PR TITLE
Support Rails 6.1.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['2.5.8', '2.6.6', '2.7.2']
-        rails: ['5.2.4', '6.0.3']
+        rails: ['5.2.4', '6.0.3', '6.1.0']
     runs-on: ubuntu-20.04
     name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}
     steps:
@@ -32,7 +32,7 @@ jobs:
         run: make ruby-lint
 
       - name: Download CodeClimate reporter
-        if: ${{ matrix.ruby == '2.7.2' && matrix.rails == '6.0.3' }}
+        if: ${{ matrix.ruby == '2.7.2' && matrix.rails == '6.1.0' }}
         run: |
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
@@ -42,7 +42,7 @@ jobs:
         run: make rspec
 
       - name: Report coverage to CodeClimate
-        if: ${{ matrix.ruby == '2.7.2' && matrix.rails == '6.0.3' }}
+        if: ${{ matrix.ruby == '2.7.2' && matrix.rails == '6.1.0' }}
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
           GIT_BRANCH: ${{ steps.extract_branch.outputs.branch }}
@@ -50,5 +50,5 @@ jobs:
         run: ./cc-test-reporter after-build -t simplecov
 
       - name: Run Nanoc Check
-        if: ${{ matrix.ruby == '2.7.2' && matrix.rails == '6.0.3' }}
+        if: ${{ matrix.ruby == '2.7.2' && matrix.rails == '6.1.0' }}
         run: make nanoc-check-all

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .ruby-version
+.envrc
 Gemfile.lock
 doc/*
 *.gem

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -40,6 +40,9 @@ dl.govuk-summary-list
       ul.govuk-list
         li
           span.govuk-tag.govuk-tag-red
+            | 6.1.0
+        li
+          span.govuk-tag.govuk-tag-red
             | 6.0.3
         li
           span.govuk-tag.govuk-tag-red

--- a/guide/lib/setup/form_builder_objects.rb
+++ b/guide/lib/setup/form_builder_objects.rb
@@ -36,7 +36,7 @@ module Setup
     end
 
     def helper
-      ActionView::Base.new(action_view_context)
+      ActionView::Base.new(action_view_context, {}, nil)
     end
 
   private

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'rspec-html-matchers'
+require 'action_controller'
 require 'action_view'
 require 'active_model'
 require 'active_support'

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -48,8 +48,14 @@ class Person < Being
     )
   end
 
-  def self.with_errors_on_base
-    new.tap { |p| p.errors[:base].push("This person is always invalid") }
+  def self.with_errors_on_base(msg = "This person is always invalid")
+    new.tap do |person|
+      if rails_version_later_than_6_1_0?
+        person.errors.add(:base, msg)
+      else
+        person.errors[:base].push(msg)
+      end
+    end
   end
 
 private

--- a/spec/support/shared/setup_builder.rb
+++ b/spec/support/shared/setup_builder.rb
@@ -1,6 +1,8 @@
 shared_context 'setup builder' do
-  let(:action_view_context) { ActionView::LookupContext.new(nil) }
-  let(:helper) { ActionView::Base.new(action_view_context) }
+  let(:assigns) { {} }
+  let(:controller) { ActionController::Base.new }
+  let(:lookup_context) { ActionView::LookupContext.new(nil) }
+  let(:helper) { ActionView::Base.new(lookup_context, assigns, controller) }
   let(:object) { Person.new(name: 'Joey') }
   let(:object_name) { :person }
   let(:builder) { described_class.new(object_name, object, helper, {}) }

--- a/spec/support/shared/shared_error_examples.rb
+++ b/spec/support/shared/shared_error_examples.rb
@@ -30,9 +30,14 @@ shared_examples 'a field that supports errors' do
       let(:error_messages) { [first_error, second_error] }
 
       before do
-        allow(object.errors.messages).to(
-          receive(:[]).and_return(error_messages)
-        )
+        if rails_version_later_than_6_1_0?
+          object.errors.clear
+          error_messages.each { |m| object.errors.add(attribute, m) }
+        else
+          allow(object.errors.messages).to(
+            receive(:[]).and_return(error_messages)
+          )
+        end
       end
 
       specify 'the first error should be included' do

--- a/spec/support/utility.rb
+++ b/spec/support/utility.rb
@@ -13,3 +13,11 @@ end
 def underscores_to_dashes(val)
   val.to_s.tr('_', '-')
 end
+
+def rails_version
+  ENV.fetch('RAILS_VERSION') { '6.1.0' }
+end
+
+def rails_version_later_than_6_1_0?
+  rails_version >= '6.1.0'
+end


### PR DESCRIPTION
Rails 6.1.0 [introduced a new structure for error messages](https://github.com/rails/rails/pull/32313) that [substantially changed the ways errors are accessed and manipulated](https://code.lulalala.com/2020/0531-1013.html).

The library only retrieves errors via `object.errors.messages` which didn't change, but the specs access the errors hash directly.

As we'll need to support both older (5.2.x) versions of Rails for the foreseeable future, multiple ways of adding and removing messages need to be implemented. This is governed by the utility method `rails_version_later_than_6_1_0?` which checks the regular `RAILS_VERSION` environment variable approach but should default to the latest version.

* [x] Make sure the tests pass with Rails 6.1.0
* [x] Add Rails 6.1.0 to the GitHub Actions build matrix
* [x] Update the guide
* [x] Make sure the guide builds properly
