### PR TITLE
Add include_hidden argument to radios collection

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -456,6 +456,7 @@ module GOVUKDesignSystemFormBuilder
     # @param inline [Boolean] controls whether the radio buttons are displayed inline or not
     # @param small [Boolean] controls whether small radio buttons are used instead of regular-sized ones
     # @param bold_labels [Boolean] controls whether the radio button labels are bold
+    # @param include_hidden [Boolean] controls whether a hidden field is inserted to allow for empty submissions
     # @param classes [Array,String] Classes to add to the radio button container.
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
@@ -500,7 +501,7 @@ module GOVUKDesignSystemFormBuilder
     #    :name,
     #    legend: -> { tag.h3('Which category do you belong to?') }
     #
-    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method = nil, hint_method = nil, hint: {}, legend: {}, caption: {}, inline: false, small: false, bold_labels: false, classes: nil, form_group: {}, &block)
+    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method = nil, hint_method = nil, hint: {}, legend: {}, caption: {}, inline: false, small: false, bold_labels: false, classes: nil, include_hidden: false, form_group: {}, &block)
       Elements::Radios::Collection.new(
         self,
         object_name,
@@ -517,6 +518,7 @@ module GOVUKDesignSystemFormBuilder
         bold_labels: bold_labels,
         classes: classes,
         form_group: form_group,
+        include_hidden: include_hidden,
         &block
       ).html
     end

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -6,27 +6,28 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Supplemental
 
-        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method:, hint:, legend:, caption:, inline:, small:, bold_labels:, classes:, form_group:, &block)
+        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method:, hint:, legend:, caption:, inline:, small:, bold_labels:, classes:, form_group:, include_hidden:, &block)
           super(builder, object_name, attribute_name, &block)
 
-          @collection   = collection
-          @value_method = value_method
-          @text_method  = text_method
-          @hint_method  = hint_method
-          @inline       = inline
-          @small        = small
-          @legend       = legend
-          @caption      = caption
-          @hint         = hint
-          @classes      = classes
-          @form_group   = form_group
-          @bold_labels  = hint_method.present? || bold_labels
+          @collection     = collection
+          @value_method   = value_method
+          @text_method    = text_method
+          @hint_method    = hint_method
+          @inline         = inline
+          @small          = small
+          @legend         = legend
+          @caption        = caption
+          @hint           = hint
+          @classes        = classes
+          @form_group     = form_group
+          @include_hidden = include_hidden
+          @bold_labels    = hint_method.present? || bold_labels
         end
 
         def html
           Containers::FormGroup.new(@builder, @object_name, @attribute_name, **@form_group).html do
             Containers::Fieldset.new(@builder, @object_name, @attribute_name, **fieldset_options).html do
-              safe_join([supplemental_content, hint_element, error_element, radios])
+              safe_join([hidden_field, supplemental_content, hint_element, error_element, radios])
             end
           end
         end
@@ -45,6 +46,12 @@ module GOVUKDesignSystemFormBuilder
           Containers::Radios.new(@builder, inline: @inline, small: @small, classes: @classes).html do
             safe_join(collection)
           end
+        end
+
+        def hidden_field
+          return unless @include_hidden
+
+          @builder.hidden_field(@attribute_name, value: "")
         end
 
         def collection

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -73,9 +73,13 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:described_element) { ['input', { with: { type: 'radio' }, count: colours.size }] }
     end
 
-    context 'radio buttons' do
+    describe 'radio buttons' do
       specify 'each radio button should have the correct classes' do
         expect(subject).to have_tag('input', with: { class: %w(govuk-radios__input) }, count: colours.size)
+      end
+
+      specify %(shouldn't have a hidden field by default) do
+        expect(subject).not_to have_tag('input', with: { type: 'hidden' })
       end
 
       specify 'each label should have the correct classes' do
@@ -218,6 +222,16 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         context 'when bold labels are not specified in the options' do
           specify 'no labels should be bold when hints are enabled' do
             expect(subject).not_to have_tag('label', with: { class: bold_label_class })
+          end
+        end
+      end
+
+      context 'generating a hidden field' do
+        subject { builder.send(*args, include_hidden: true) }
+
+        specify "the hidden field should be present within the fieldset" do
+          expect(subject).to have_tag('fieldset') do
+            with_tag('input', with: { type: 'hidden', name: "#{object_name}[#{attribute}]" })
           end
         end
       end


### PR DESCRIPTION
Rails has had this functionality [since version 5](https://github.com/rails/rails/pull/18303) so it makes sense for it to be supported here. This change uses the same keyword, `include_hidden`, as Rails so should feel familiar to users. It's intended to [allow forms to be submitted without any of the radios being selected](https://bigbinary.com/blog/rails-5-add-a-hidden-field-on-collection-radio-buttons).