### PR TITLE
Upgrade to SimpleCov from 0.17.1 to 0.20.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,8 @@ jobs:
         run: make ruby-lint
 
       - name: Download CodeClimate reporter
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         run: |
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
@@ -62,6 +64,7 @@ jobs:
 
       - name: Run RSpec
         env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
           SIMPLECOV: '1'
         run: make rspec
 

--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("pry-byebug", "~> 3.9", ">= 3.9.0")
   s.add_development_dependency("rspec-html-matchers", "~> 0")
   s.add_development_dependency("rspec-rails", "~> 4.0")
-  s.add_development_dependency("simplecov", "~> 0.17.1")
+  s.add_development_dependency("simplecov", "~> 0.20")
 
   # Required for the guide
   s.add_development_dependency("htmlbeautifier", "~> 1.3.1")


### PR DESCRIPTION
This was a non-trivial upgrade because versions 0.18 and 0.19 of SimpleCov aren't compatible with CodeClimate, but `<= 0.17.1`, and `>= 0.20.0` are.

To make SimpleCov output a 'JSON Coverage report' (in coverage/coverage.json) the `CC_TEST_REPORTER_ID` needs to be present in the RSpec workflow step.

I'm not 100% sure whether it's required for before-build, but added it anyway for good measure.