### PR TITLE
Add Ruby 3.0.0 to supported versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.5.8', '2.6.6', '2.7.2']
-        rails: ['5.2.4', '6.0.3', '6.1.1']
+        ruby: ['2.6.6', '2.7.2', '3.0.0']
+        rails: ['5.2.4', '6.0.3', '6.1.0']
     runs-on: ubuntu-20.04
     name: Testing with Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
     steps:
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.2'
+          ruby-version: '3.0.0'
 
       - name: Install gems
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['2.6.6', '2.7.2', '3.0.0']
-        rails: ['5.2.4', '6.0.3', '6.1.0']
+        rails: ['6.0.3', '6.1.3']
     runs-on: ubuntu-20.04
     name: Testing with Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
     steps:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk_design_system_formbuilder)](https://github.com/DFE-Digital/govuk_design_system_formbuilder/blob/master/LICENSE)
 [![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.11.0-brightgreen)](https://design-system.service.gov.uk)
 [![Rails](https://img.shields.io/badge/Ruby-2.6.6%20%E2%95%B1%202.7.2%20%E2%95%B1%203.0.0-E16D6D)](https://www.ruby-lang.org/en/downloads/)
-[![Ruby](https://img.shields.io/badge/Rails-5.2.4%20%E2%95%B1%206.0.3%20%E2%95%B1%206.1.0-E16D6D)](https://weblog.rubyonrails.org/releases/)
+[![Ruby](https://img.shields.io/badge/Rails-6.0.3%20%E2%95%B1%206.1.0-E16D6D)](https://weblog.rubyonrails.org/releases/)
 
 This library provides an easy-to-use form builder for the [GOV.UK Design System](https://design-system.service.gov.uk/).
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=DFE-Digital/govuk_design_system_formbuilder)](https://dependabot.com)
 [![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk_design_system_formbuilder)](https://github.com/DFE-Digital/govuk_design_system_formbuilder/blob/master/LICENSE)
 [![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.11.0-brightgreen)](https://design-system.service.gov.uk)
-[![Rails](https://img.shields.io/badge/Ruby-2.5.8%20%E2%95%B1%202.6.6%20%E2%95%B1%202.7.2-E16D6D)](https://weblog.rubyonrails.org/releases/)
-[![Ruby](https://img.shields.io/badge/Rails-5.2.4%20%E2%95%B1%206.0.3%20%E2%95%B1%206.1.0-E16D6D)](https://www.ruby-lang.org/en/downloads/)
+[![Rails](https://img.shields.io/badge/Ruby-2.6.6%20%E2%95%B1%202.7.2%20%E2%95%B1%203.0.0-E16D6D)](https://www.ruby-lang.org/en/downloads/)
+[![Ruby](https://img.shields.io/badge/Rails-5.2.4%20%E2%95%B1%206.0.3%20%E2%95%B1%206.1.0-E16D6D)](https://weblog.rubyonrails.org/releases/)
 
 This library provides an easy-to-use form builder for the [GOV.UK Design System](https://design-system.service.gov.uk/).
 

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -25,13 +25,13 @@ dl.govuk-summary-list
       ul.govuk-list
         li
           span.govuk-tag.govuk-tag-red
+            | 3.0.0
+        li
+          span.govuk-tag.govuk-tag-red
             | 2.7.1
         li
           span.govuk-tag.govuk-tag-red
             | 2.6.6
-        li
-          span.govuk-tag.govuk-tag-red
-            | 2.5.8
 
   .govuk-summary-list__row
     dt.govuk-summary-list__key

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -28,7 +28,7 @@ dl.govuk-summary-list
             | 3.0.0
         li
           span.govuk-tag.govuk-tag-red
-            | 2.7.1
+            | 2.7.2
         li
           span.govuk-tag.govuk-tag-red
             | 2.6.6
@@ -40,10 +40,7 @@ dl.govuk-summary-list
       ul.govuk-list
         li
           span.govuk-tag.govuk-tag-red
-            | 6.1.1
+            | 6.1.3
         li
           span.govuk-tag.govuk-tag-red
             | 6.0.3
-        li
-          span.govuk-tag.govuk-tag-red
-            | 5.2.4


### PR DESCRIPTION
This upgrade drops support for:
 
* Rails 5.2.4
* Ruby 2.5.8

The gem will probably run just fine on them for the foreseeable future but they will no longer for part of the testing matrix and won't be officially supported.

------

### ~~There are two things holding this back:~~

#### Rubocop

It appears that `govuk-rubocop` [hasn't caught up yet](https://github.com/alphagov/rubocop-govuk/releases).

```
$ make ruby-lint
bundle exec rubocop lib spec guide/lib util
Error: RuboCop found unknown Ruby version 3.0 in `.ruby-version`.
Supported versions: 2.4, 2.5, 2.6, 2.7, 2.8
make: *** [Makefile:11: ruby-lint] Error 2
```

We'll wait for this for a time but can switch to vanilla Rubocop if it becomes a blocker.

#### Rails 5.2.4

It appears that [Rails 5.2.4 isn't compatible with Ruby 3.0.0](https://github.com/DFE-Digital/govuk_design_system_formbuilder/pull/232/checks?check_run_id=1655420946). This is probably due to the [separation of positional and keyword arguments](https://www.ruby-lang.org/https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) due to seeing this a lot in the build log:

```
ArgumentError:
  wrong number of arguments (given 3, expected 1..2)
```

It may be the case that it's also dropped to unofficially supported status.

 Feedback welcome.