### PR TITLE
Switch to vanilla rubocop

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.5.8', '2.6.6', '2.7.2']
+        ruby: ['2.6.6', '2.7.2', '3.0.0']
         rails: ['5.2.4', '6.0.3', '6.1.0']
     runs-on: ubuntu-20.04
     name: Testing with Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.2'
+          ruby-version: '3.0.0'
 
       - name: Install gems
         env:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,8 @@ Style/TrailingCommaInArrayLiteral:
   Enabled: false
 Naming/MethodParameterName:
   Enabled: false
+Naming/VariableNumber:
+  Enabled: false
 Style/PercentLiteralDelimiters:
   Enabled: false
 Layout/HashAlignment:
@@ -31,3 +33,11 @@ Style/AsciiComments:
   Enabled: false
 Style/FormatString:
   EnforcedStyle: format
+Style/StringConcatenation:
+  Enabled: false
+Lint/MissingSuper:
+  Exclude:
+    - spec/**/*
+Style/OptionalBooleanParameter:
+  Exclude:
+    - lib/govuk_design_system_formbuilder/builder.rb

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=DFE-Digital/govuk_design_system_formbuilder)](https://dependabot.com)
 [![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk_design_system_formbuilder)](https://github.com/DFE-Digital/govuk_design_system_formbuilder/blob/master/LICENSE)
 [![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.10.2-brightgreen)](https://design-system.service.gov.uk)
-[![Rails](https://img.shields.io/badge/Ruby-2.5.8%20%E2%95%B1%202.6.6%20%E2%95%B1%202.7.2-E16D6D)](https://weblog.rubyonrails.org/releases/)
-[![Ruby](https://img.shields.io/badge/Rails-5.2.4%20%E2%95%B1%206.0.3%20%E2%95%B1%206.1.0-E16D6D)](https://www.ruby-lang.org/en/downloads/)
+[![Rails](https://img.shields.io/badge/Ruby-2.6.6%20%E2%95%B1%202.7.2%20%E2%95%B1%203.0.0-E16D6D)](https://www.ruby-lang.org/en/downloads/)
+[![Ruby](https://img.shields.io/badge/Rails-5.2.4%20%E2%95%B1%206.0.3%20%E2%95%B1%206.1.0-E16D6D)](https://weblog.rubyonrails.org/releases/)
 
 This library provides an easy-to-use form builder for the [GOV.UK Design System](https://design-system.service.gov.uk/).
 

--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -30,7 +30,10 @@ Gem::Specification.new do |s|
     s.add_dependency(*VersionFormatter.new(lib, rails_version, exact_rails_version).to_a)
   end
 
-  s.add_development_dependency("rubocop-govuk", "= 3.17.2")
+  s.add_development_dependency("rubocop", "~> 1.7")
+  s.add_development_dependency("rubocop-rake", "~> 0.5.1")
+  s.add_development_dependency("rubocop-rails", "~> 2.9.1")
+  s.add_development_dependency("rubocop-rspec", "~> 2.1.0")
   s.add_development_dependency("pry", "~> 0.13.0")
   s.add_development_dependency("pry-byebug", "~> 3.9", ">= 3.9.0")
   s.add_development_dependency("rspec-html-matchers", "~> 0")
@@ -40,6 +43,7 @@ Gem::Specification.new do |s|
   # Required for the guide
   s.add_development_dependency("htmlbeautifier", "~> 1.3.1")
   s.add_development_dependency("nanoc", "~> 4.11")
+  s.add_development_dependency("puma", "~> 5.1.1")
   s.add_development_dependency("rouge", "~> 3.26.0")
   s.add_development_dependency("rubypants", "~> 0.7.0")
   s.add_development_dependency("sassc", "~> 2.4.0")

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -25,13 +25,13 @@ dl.govuk-summary-list
       ul.govuk-list
         li
           span.govuk-tag.govuk-tag-red
+            | 3.0.0
+        li
+          span.govuk-tag.govuk-tag-red
             | 2.7.1
         li
           span.govuk-tag.govuk-tag-red
             | 2.6.6
-        li
-          span.govuk-tag.govuk-tag-red
-            | 2.5.8
 
   .govuk-summary-list__row
     dt.govuk-summary-list__key

--- a/guide/layouts/partials/example-fig.slim
+++ b/guide/layouts/partials/example-fig.slim
@@ -74,7 +74,7 @@ figure.full-sample
 
     h4.govuk-heading-s.example-subheading.output Rendered output
     div.example-output
-      == format_slim(code, f: builder(display_errors), **form_data)
+      == format_slim(code, f: builder(errors: display_errors), **form_data)
 
   - unless defined?(hide_html_output) && hide_html_output
     section
@@ -83,7 +83,7 @@ figure.full-sample
         code.highlight.language-html
           - if defined?(sample_data)
             - eval(sample_data)
-          = format_slim(code, f: builder(display_errors), **form_data)
+          = format_slim(code, f: builder(errors: display_errors), **form_data)
 
 
 - if defined?(custom_config)

--- a/guide/lib/helpers/formatters.rb
+++ b/guide/lib/helpers/formatters.rb
@@ -28,11 +28,11 @@ module Helpers
           generator: Temple::Generators::RailsOutputBuffer
         )
           .call(raw)
-          .gsub(/ _slim_controls[\d] =/, "=")        # remove _slim_controlsX assignment (where X is an integer)
-          .gsub(/do\n\s+%>/, "do %>")                # close blocks on the same line
-          .gsub(/%><%/, "%>\n<%")                    # ensure ERB tags are on separate lines
-          .gsub(/<%= _slim_controls[\d] %>/, '')     # remove _slim_controlsX var display, we've handled it above
-          .gsub(/,\n/, ', ')                         # don't leave newlines between args, it breaks indentation
+          .gsub(/ _slim_controls\d =/, "=")     # remove _slim_controlsX assignment (where X is an integer)
+          .gsub(/do\n\s+%>/, "do %>")           # close blocks on the same line
+          .gsub(/%><%/, "%>\n<%")               # ensure ERB tags are on separate lines
+          .gsub(/<%= _slim_controls\d %>/, '')  # remove _slim_controlsX var display, we've handled it above
+          .gsub(/,\n/, ', ')                    # don't leave newlines between args, it breaks indentation
       )
     end
 
@@ -47,7 +47,7 @@ module Helpers
           html
             .gsub(">", ">\n")
             .gsub("\<\/", "\n\<\/")
-            .gsub(/\>\s+\<\/textarea\>/, "></textarea>")
+            .gsub(/>\s+<\/textarea>/, "></textarea>")
             .strip
         )
     end

--- a/guide/lib/setup/form_builder_objects.rb
+++ b/guide/lib/setup/form_builder_objects.rb
@@ -1,6 +1,6 @@
 module Setup
   module FormBuilderObjects
-    def builder(errors = false)
+    def builder(errors: false)
       case errors
       when :fields
         builder_with_field_errors

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -53,7 +53,7 @@ module GOVUKDesignSystemFormBuilder
     def has_errors?
       @builder.object.respond_to?(:errors) &&
         @builder.object.errors.any? &&
-        @builder.object.errors.messages.dig(@attribute_name).present?
+        @builder.object.errors.messages[@attribute_name].present?
     end
 
     def described_by(*ids)

--- a/lib/govuk_design_system_formbuilder/containers/character_count.rb
+++ b/lib/govuk_design_system_formbuilder/containers/character_count.rb
@@ -2,7 +2,7 @@ module GOVUKDesignSystemFormBuilder
   module Containers
     class CharacterCount < Base
       def initialize(builder, max_words:, max_chars:, threshold:)
-        @builder = builder
+        super(builder, nil, nil)
 
         fail ArgumentError, 'limit can be words or chars' if max_words && max_chars
 
@@ -11,10 +11,10 @@ module GOVUKDesignSystemFormBuilder
         @threshold = threshold
       end
 
-      def html
+      def html(&block)
         return yield unless limit?
 
-        tag.div(**options) { yield }
+        tag.div(**options, &block)
       end
 
     private

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
@@ -2,13 +2,14 @@ module GOVUKDesignSystemFormBuilder
   module Containers
     class CheckBoxes < Base
       def initialize(builder, small:, classes: nil)
-        @builder = builder
+        super(builder, nil, nil)
+
         @small   = small
         @classes = classes
       end
 
-      def html
-        tag.div(**options) { yield }
+      def html(&block)
+        tag.div(**options, &block)
       end
 
     private

--- a/lib/govuk_design_system_formbuilder/containers/form_group.rb
+++ b/lib/govuk_design_system_formbuilder/containers/form_group.rb
@@ -8,8 +8,8 @@ module GOVUKDesignSystemFormBuilder
         @html_attributes = kwargs
       end
 
-      def html
-        tag.div(class: classes, **@html_attributes) { yield }
+      def html(&block)
+        tag.div(class: classes, **@html_attributes, &block)
       end
 
     private

--- a/lib/govuk_design_system_formbuilder/containers/radios.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radios.rb
@@ -4,14 +4,16 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Hint
 
       def initialize(builder, inline:, small:, classes:)
+        super(builder, nil, nil)
+
         @builder = builder
         @inline  = inline
         @small   = small
         @classes = classes
       end
 
-      def html
-        tag.div(**options) { yield }
+      def html(&block)
+        tag.div(**options, &block)
       end
 
     private

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -6,7 +6,7 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Supplemental
 
-        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method: nil, hint:, legend:, caption:, small:, classes:, form_group:, &block)
+        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint:, legend:, caption:, small:, classes:, form_group:, hint_method: nil, &block)
           super(builder, object_name, attribute_name, &block)
 
           @collection   = collection

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -9,7 +9,7 @@ module GOVUKDesignSystemFormBuilder
 
       SEGMENTS = { day: '3i', month: '2i', year: '1i' }.freeze
 
-      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, date_of_birth: false, omit_day:, form_group:, wildcards:, &block)
+      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, omit_day:, form_group:, wildcards:, date_of_birth: false, &block)
         super(builder, object_name, attribute_name, &block)
 
         @legend        = legend

--- a/lib/govuk_design_system_formbuilder/elements/error_message.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_message.rb
@@ -5,10 +5,6 @@ module GOVUKDesignSystemFormBuilder
 
       include Traits::Error
 
-      def initialize(builder, object_name, attribute_name)
-        super(builder, object_name, attribute_name)
-      end
-
       def html
         return nil unless has_errors?
 

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -4,8 +4,8 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Error
 
       def initialize(builder, object_name, title, link_base_errors_to:)
-        @builder             = builder
-        @object_name         = object_name
+        super(builder, object_name, nil)
+
         @title               = title
         @link_base_errors_to = link_base_errors_to
       end

--- a/lib/govuk_design_system_formbuilder/elements/null.rb
+++ b/lib/govuk_design_system_formbuilder/elements/null.rb
@@ -1,6 +1,6 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
-    class Null < Base
+    class Null
       def initialize; end
 
       def html

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
@@ -9,7 +9,7 @@ module GOVUKDesignSystemFormBuilder
         #   error summary requires that the id of the first radio is linked-to from the corresponding
         #   error message. As when the summary is built what happens later in the form is unknown, we
         #   need to control this to ensure the link is generated correctly
-        def initialize(builder, object_name, attribute_name, item, value_method:, text_method:, hint_method:, link_errors: false, bold_labels:)
+        def initialize(builder, object_name, attribute_name, item, value_method:, text_method:, hint_method:, bold_labels:, link_errors: false)
           super(builder, object_name, attribute_name)
 
           @item        = item

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -6,7 +6,7 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Hint
       include Traits::Supplemental
 
-      def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, options: {}, html_options: {}, hint:, label:, caption:, form_group:, &block)
+      def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint:, label:, caption:, form_group:, options: {}, html_options: {}, &block)
         super(builder, object_name, attribute_name, &block)
 
         @collection   = collection
@@ -49,7 +49,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def custom_classes
-        @html_options.dig(:class)
+        @html_options[:class]
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -6,7 +6,8 @@ module GOVUKDesignSystemFormBuilder
       def initialize(builder, text, warning:, secondary:, classes:, prevent_double_click:, validate:, disabled:, &block)
         fail ArgumentError, 'buttons can be warning or secondary' if warning && secondary
 
-        @builder              = builder
+        super(builder, nil, nil)
+
         @text                 = text
         @prevent_double_click = prevent_double_click
         @warning              = warning

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -48,7 +48,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports setting the hint via localisation'
 
     it_behaves_like 'a field that accepts a plain ruby object' do
-      let(:described_element) { ['input', with: { type: 'file' }] }
+      let(:described_element) { ['input', { with: { type: 'file' } }] }
     end
 
     describe 'additional attributes' do


### PR DESCRIPTION
**This is just an experiment - it follows on from #232**

Switch from the GOV.UK rubocop config to the vanilla one as part of the Ruby 3.0.0 upgrade. Seeing as many of the
less-useful cops are already ignored and this has pointed out some improvements to the codebase it feels like a reasonable step.

Leaving here for discussion closer to the time when we're ready to make the jump to supporting 3.0.0.