### PR TITLE
Fix radio button procs example in guide

### DIFF
--- a/guide/lib/examples/radios.rb
+++ b/guide/lib/examples/radios.rb
@@ -87,8 +87,8 @@ module Examples
         = f.govuk_collection_radio_buttons :laptop,
           laptops,
           ->(option) { option },
-          ->(option) { I18n.t('laptops.names.' + option.to_s) },
-          ->(option) { I18n.t('laptops.descriptions.' + option.to_s) },
+          ->(option) { I18n.t('laptops.names.' + option) },
+          ->(option) { I18n.t('laptops.descriptions.' + option) },
           legend: { text: "Which laptop would you like to use?" }
       SNIPPET
     end

--- a/guide/lib/setup/example_data.rb
+++ b/guide/lib/setup/example_data.rb
@@ -72,7 +72,7 @@ module Setup
 
     def laptops_data_raw
       <<~DATA
-        laptops = %i(thinkpad xps macbook_pro zenbook)
+        laptops = %w(thinkpad xps macbook_pro zenbook)
       DATA
     end
 

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/label.rb
@@ -16,7 +16,7 @@ module GOVUKDesignSystemFormBuilder
 
         def html
           @checkbox.label(for: field_id(link_errors: @link_errors), class: label_classes) do
-            [localised_text(:label), @checkbox.text, @value].compact.first
+            [localised_text(:label), @checkbox.text, @value].compact.first.to_s
           end
         end
 

--- a/lib/govuk_design_system_formbuilder/traits/collection_item.rb
+++ b/lib/govuk_design_system_formbuilder/traits/collection_item.rb
@@ -8,7 +8,7 @@ module GOVUKDesignSystemFormBuilder
         when Symbol, String
           item.send(method)
         when Proc
-          capture { method.call(item) }
+          capture { method.call(item).to_s }
         end
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
@@ -152,6 +152,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         let(:hint_class) { 'govuk-checkboxes__hint' }
         let(:args) { [method, :department, departments, :code, :name] }
       end
+
+      it_behaves_like 'a collection field that supports setting the value via a proc' do
+        let(:attribute) { :favourite_colour }
+      end
     end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -125,6 +125,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         let(:args) { [method, attribute, colours, :id, i18n_proc] }
       end
 
+      it_behaves_like 'a collection field that supports setting the value via a proc'
+
       context 'radio button hints' do
         let(:colours_with_descriptions) { colours.select { |c| c.description.present? } }
         let(:colours_without_descriptions) { colours.reject { |c| c.description.present? } }

--- a/spec/support/shared/shared_value_examples.rb
+++ b/spec/support/shared/shared_value_examples.rb
@@ -1,0 +1,39 @@
+shared_examples 'a collection field that supports setting the value via a proc with symbols' do
+  let(:args) { [method, attribute, stationery, ->(item) { item }, ->(item) { item.capitalize }] }
+
+  context 'when the values are symbols' do
+    specify 'the values should be present' do
+      stationery.each { |item| expect(subject).to have_tag("input", with: { value: item.to_s }) }
+    end
+
+    specify 'the label should be present' do
+      stationery.each do |item|
+        expect(subject).to have_tag("label", text: item.to_s.capitalize, with: { for: %(person-favourite-colour-#{item}-field) })
+      end
+    end
+  end
+end
+
+shared_examples 'a collection field that supports setting the value via a proc with strings' do
+  context 'when the values are strings' do
+    let(:stationery) { %w(pencil pen eraser paperclip) }
+
+    specify 'the values should be present' do
+      stationery.each { |item| expect(subject).to have_tag("input", with: { value: item.to_s }) }
+    end
+
+    specify 'the label should be present' do
+      stationery.each do |item|
+        expect(subject).to have_tag("label", text: item.to_s.capitalize, with: { for: %(person-favourite-colour-#{item}-field) })
+      end
+    end
+  end
+end
+
+shared_examples 'a collection field that supports setting the value via a proc' do
+  prefix = 'a collection field that supports setting the value via a proc'
+  stationery = %w(pencil pen eraser paperclip)
+
+  include_examples(%(#{prefix} with strings)) { let(:stationery) { stationery } }
+  include_examples(%(#{prefix} with symbols)) { let(:stationery) { stationery.map(&:to_sym) } }
+end


### PR DESCRIPTION
There's a bug in the guide where clicking the radio button labels [in the last example](https://govuk-form-builder.netlify.app/form-elements/radios/#populating-values-labels-and-hints-with-procs) doesn't focus the right radio.

It's because the passed-in values are symbols rather than strings.

When a value is passed into the collection helper via a proc as a symbol, it wasn't applied properly when constructing the elements within. This could lead to inputs not having a value, labels not linking to the corresponding input and hints not describing their intended target.

This change ensures that any symbols are converted to strings and adds some tests ensuring that when symbols are supplied via procs the output is rendered properly.


* [x] Check it still works ok when HTML safe strings are passed in