### PR TITLE
Upgrade to GOV.UK Frontend version 3.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/fde73b5dc9476197281b/test_coverage)](https://codeclimate.com/github/DFE-Digital/govuk_design_system_formbuilder/test_coverage)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=DFE-Digital/govuk_design_system_formbuilder)](https://dependabot.com)
 [![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk_design_system_formbuilder)](https://github.com/DFE-Digital/govuk_design_system_formbuilder/blob/master/LICENSE)
-[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.10.2-brightgreen)](https://design-system.service.gov.uk)
+[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.11.0-brightgreen)](https://design-system.service.gov.uk)
 [![Rails](https://img.shields.io/badge/Ruby-2.5.8%20%E2%95%B1%202.6.6%20%E2%95%B1%202.7.2-E16D6D)](https://weblog.rubyonrails.org/releases/)
 [![Ruby](https://img.shields.io/badge/Rails-5.2.4%20%E2%95%B1%206.0.3%20%E2%95%B1%206.1.0-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 

--- a/guide/content/form-elements/submit.slim
+++ b/guide/content/form-elements/submit.slim
@@ -40,7 +40,7 @@ section
     code: submit_button_disabled)
 
   == render('/partials/example-fig.*',
-    caption: "A submit button with an accompanying call to action",
+    caption: "A group of buttons",
     code: multiple_buttons) do
 
     p.govuk-body

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -16,7 +16,7 @@ dl.govuk-summary-list
       ul.govuk-list
         li
           span.govuk-tag.govuk-tag-govuk
-            | Version 3.10.2
+            | Version 3.11.0
 
   .govuk-summary-list__row
     dt.govuk-summary-list__key

--- a/guide/lib/examples/submit.rb
+++ b/guide/lib/examples/submit.rb
@@ -29,6 +29,9 @@ module Examples
         = f.govuk_submit 'Save and continue' do
           a.govuk-button.govuk-button--secondary href='/#'
             ' Safe as draft
+          button.govuk-button.govuk-button--warning Delete and start again
+          a.govuk-link href="#"
+            ' View recent changes
       SNIPPET
     end
   end

--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "govuk-frontend": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.10.2.tgz",
-      "integrity": "sha512-MpMymgLsKoMw40MggZ0XLCAj1FY5N2s8Pf3aQR+k0cZOsegjLsnejxNfEB9qEl9jcma2fiiVcvsEZ+Ipo+Oo2g=="
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.11.0.tgz",
+      "integrity": "sha512-1hW/3etYBtKPM+PNdWVOijvWVI3mpYL8eb7WLTtlh/Qxf2mCp6LkCsZk9I034n4EJBYQ5jlUWsUlTOOIypftpg=="
     }
   }
 }

--- a/guide/package.json
+++ b/guide/package.json
@@ -12,6 +12,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "govuk-frontend": "^3.10.2"
+    "govuk-frontend": "^3.11.0"
   }
 }

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -811,9 +811,9 @@ module GOVUKDesignSystemFormBuilder
     #   client-side validation provided by the browser. This is to provide a more consistent and accessible user
     #   experience
     # @param disabled [Boolean] makes the button disabled when true
-    # @param block [Block] Any supplied HTML will be inserted immediately after
-    #   the submit button. It is intended for other buttons directly related to
-    #   the form's operation, such as 'Cancel' or 'Safe draft'
+    # @param block [Block] When content is passed in via a block the submit element and the block content will
+    #   be wrapped in a +<div class="govuk-button-group">+ which will space the buttons and links within
+    #   evenly.
     # @raise [ArgumentError] raised if both +warning+ and +secondary+ are true
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @note Only the first additional button or link (passed in via a block) will be given the

--- a/lib/govuk_design_system_formbuilder/containers/button_group.rb
+++ b/lib/govuk_design_system_formbuilder/containers/button_group.rb
@@ -1,0 +1,15 @@
+module GOVUKDesignSystemFormBuilder
+  module Containers
+    class ButtonGroup < Base
+      def initialize(builder, buttons)
+        super(builder, nil, nil)
+
+        @buttons = buttons
+      end
+
+      def html
+        tag.div(@buttons, class: %(#{brand}-button-group))
+      end
+    end
+  end
+end

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -19,10 +19,18 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        safe_join([submit, @block_content])
+        @block_content.present? ? button_group : buttons
       end
 
     private
+
+      def buttons
+        safe_join([submit, @block_content])
+      end
+
+      def button_group
+        Containers::ButtonGroup.new(@builder, buttons).html
+      end
 
       def submit
         @builder.submit(@text, class: classes, **options)
@@ -31,7 +39,7 @@ module GOVUKDesignSystemFormBuilder
       def classes
         %w(button)
           .prefix(brand)
-          .push(warning_class, secondary_class, disabled_class, padding_class, custom_classes)
+          .push(warning_class, secondary_class, disabled_class, custom_classes)
           .flatten
           .compact
       end
@@ -53,10 +61,6 @@ module GOVUKDesignSystemFormBuilder
 
       def secondary_class
         %(#{brand}-button--secondary) if @secondary
-      end
-
-      def padding_class
-        %(#{brand}-!-margin-right-1) if @block_content
       end
 
       def disabled_class

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -92,11 +92,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     describe 'extra buttons passed in via a block' do
-      let(:target) { '#' }
+      let(:text) { 'Cancel' }
+      let(:target) { '/some-amazing-page' }
       let(:classes) { %w(govuk-button govuk-button--secondary) }
       subject do
         builder.send(method) do
-          builder.link_to('Cancel', target, class: classes)
+          builder.link_to(text, target, class: classes)
         end
       end
 
@@ -104,8 +105,11 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         expect(subject).to have_tag('a', with: { href: target, class: classes })
       end
 
-      specify 'should add an extra margin class to the submit' do
-        expect(subject).to have_tag('input', with: { class: 'govuk-\!-margin-right-1' })
+      specify 'should wrap the buttons and extra content in a button group' do
+        expect(subject).to have_tag('div', with: { class: 'govuk-button-group' }) do
+          with_tag('input', value: text)
+          with_tag('a', with: { href: target })
+        end
       end
     end
 


### PR DESCRIPTION
The latest revision to the design system brings one change that affects this library, [button groups](https://github.com/alphagov/govuk-frontend/pull/2114).

Previously the behaviour was to automatically apply a right margin to the submit input when additional content was passed into `govuk_submit` via a block.

The new behaviour is to wrap the submit input and the block contents in a `div.govuk-button-group`; this will allow the buttons and links within to be nicely arranged.

![Screenshot from 2021-02-10 15-48-10](https://user-images.githubusercontent.com/128088/107534014-6c97b180-6bb7-11eb-972f-c9eb8d6de830.png)
