### PR TITLE
Provide the ability to suppress hidden fields in checkbox collections

### DIFF
--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -34,6 +34,12 @@ module GOVUKDesignSystemFormBuilder
   #   blocks. As per the GOV.UK Design System spec, it defaults to
   #   'There is a problem'.
   #
+  # * +:default_collection_check_boxes_include_hidden+ controls whether or not
+  #   a hidden field is added when rendering a collection of check boxes
+  #
+  # * +:default_collection_radio_buttons_include_hidden+ controls whether or not
+  #   a hidden field is added when rendering a collection of radio buttons
+  #
   # * +:localisation_schema_fallback+ sets the prefix elements for the array
   #   used to build the localisation string. The final two elements are always
   #   are the object name and attribute name. The _special_ value +__context__+,
@@ -52,6 +58,8 @@ module GOVUKDesignSystemFormBuilder
     default_submit_button_text: 'Continue',
     default_radio_divider_text: 'or',
     default_error_summary_title: 'There is a problem',
+    default_collection_check_boxes_include_hidden: true,
+    default_collection_radio_buttons_include_hidden: true,
 
     localisation_schema_fallback: %i(helpers __context__),
     localisation_schema_label: nil,

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -501,7 +501,7 @@ module GOVUKDesignSystemFormBuilder
     #    :name,
     #    legend: -> { tag.h3('Which category do you belong to?') }
     #
-    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method = nil, hint_method = nil, hint: {}, legend: {}, caption: {}, inline: false, small: false, bold_labels: false, classes: nil, include_hidden: false, form_group: {}, &block)
+    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method = nil, hint_method = nil, hint: {}, legend: {}, caption: {}, inline: false, small: false, bold_labels: false, classes: nil, include_hidden: config.default_collection_radio_buttons_include_hidden, form_group: {}, &block)
       Elements::Radios::Collection.new(
         self,
         object_name,
@@ -683,7 +683,7 @@ module GOVUKDesignSystemFormBuilder
     #    :name,
     #    legend: -> { tag.h3('What kind of sandwich do you want?') }
     #
-    def govuk_collection_check_boxes(attribute_name, collection, value_method, text_method, hint_method = nil, hint: {}, legend: {}, caption: {}, small: false, classes: nil, form_group: {}, include_hidden: true, &block)
+    def govuk_collection_check_boxes(attribute_name, collection, value_method, text_method, hint_method = nil, hint: {}, legend: {}, caption: {}, small: false, classes: nil, form_group: {}, include_hidden: config.default_collection_check_boxes_include_hidden, &block)
       Elements::CheckBoxes::Collection.new(
         self,
         object_name,

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -646,6 +646,7 @@ module GOVUKDesignSystemFormBuilder
     # @param form_group [Hash] configures the form group
     # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
+    # @param include_hidden [Boolean] controls whether a hidden field is inserted to allow for empty submissions
     # @param block [Block] any HTML passed in will be injected into the fieldset, after the hint and before the checkboxes
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
@@ -682,7 +683,7 @@ module GOVUKDesignSystemFormBuilder
     #    :name,
     #    legend: -> { tag.h3('What kind of sandwich do you want?') }
     #
-    def govuk_collection_check_boxes(attribute_name, collection, value_method, text_method, hint_method = nil, hint: {}, legend: {}, caption: {}, small: false, classes: nil, form_group: {}, &block)
+    def govuk_collection_check_boxes(attribute_name, collection, value_method, text_method, hint_method = nil, hint: {}, legend: {}, caption: {}, small: false, classes: nil, form_group: {}, include_hidden: true, &block)
       Elements::CheckBoxes::Collection.new(
         self,
         object_name,
@@ -697,6 +698,7 @@ module GOVUKDesignSystemFormBuilder
         small: small,
         classes: classes,
         form_group: form_group,
+        include_hidden: include_hidden,
         &block
       ).html
     end

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -6,19 +6,20 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Supplemental
 
-        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint:, legend:, caption:, small:, classes:, form_group:, hint_method: nil, &block)
+        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint:, legend:, caption:, small:, classes:, form_group:, include_hidden:, hint_method: nil, &block)
           super(builder, object_name, attribute_name, &block)
 
-          @collection   = collection
-          @value_method = value_method
-          @text_method  = text_method
-          @hint_method  = hint_method
-          @small        = small
-          @legend       = legend
-          @caption      = caption
-          @hint         = hint
-          @classes      = classes
-          @form_group   = form_group
+          @collection     = collection
+          @value_method   = value_method
+          @text_method    = text_method
+          @hint_method    = hint_method
+          @small          = small
+          @legend         = legend
+          @caption        = caption
+          @hint           = hint
+          @classes        = classes
+          @form_group     = form_group
+          @include_hidden = include_hidden
         end
 
         def html
@@ -56,7 +57,7 @@ module GOVUKDesignSystemFormBuilder
         def collection
           link_errors = has_errors?
 
-          @builder.collection_check_boxes(@attribute_name, @collection, @value_method, @text_method) do |check_box|
+          @builder.collection_check_boxes(@attribute_name, @collection, @value_method, @text_method, include_hidden: @include_hidden) do |check_box|
             Elements::CheckBoxes::CollectionCheckBox.new(
               @builder,
               @object_name,

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
@@ -66,6 +66,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
 
+      specify 'a hidden field is present by default' do
+        expect(subject).to have_tag('input', with: { type: 'hidden', name: "#{object_name}[#{attribute}][]" })
+      end
+
       context 'check box size' do
         context 'when small is specified in the options' do
           subject { builder.send(*args, small: true) }
@@ -155,6 +159,14 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
       it_behaves_like 'a collection field that supports setting the value via a proc' do
         let(:attribute) { :favourite_colour }
+      end
+
+      context 'suppressing the hidden field' do
+        subject { builder.send(*args, include_hidden: false) }
+
+        specify "the hidden field should be present within the fieldset" do
+          expect(subject).not_to have_tag('input', with: { type: 'hidden' })
+        end
       end
     end
   end

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -124,7 +124,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             end
 
             specify 'the radio button linked to should be first' do
-              expect(parsed_subject.css('input').first['id']).to eql(identifier)
+              expect(parsed_subject.css('input[type="radio"]').first['id']).to eql(identifier)
               expect(parsed_subject.css('label').first['for']).to eql(identifier)
             end
 

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -79,7 +79,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       specify %(shouldn't have a hidden field by default) do
-        expect(subject).not_to have_tag('input', with: { type: 'hidden' })
+        expect(subject).to have_tag('fieldset') do
+          with_tag('input', with: { type: 'hidden', name: "#{object_name}[#{attribute}]" })
+        end
       end
 
       specify 'each label should have the correct classes' do
@@ -229,12 +231,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       context 'generating a hidden field' do
-        subject { builder.send(*args, include_hidden: true) }
+        subject { builder.send(*args, include_hidden: false) }
 
         specify "the hidden field should be present within the fieldset" do
-          expect(subject).to have_tag('fieldset') do
-            with_tag('input', with: { type: 'hidden', name: "#{object_name}[#{attribute}]" })
-          end
+          expect(subject).not_to have_tag('input', with: { type: 'hidden' })
         end
       end
     end


### PR DESCRIPTION
The form builder didn't expose any way to set the `#collection_check_boxes` method's `include_hidden` param (which is wrapped by `#govuk_collection_check_boxes`). This was inconsistent with the corresponding radio buttons method `#govuk_collection_radio_buttons` which did.

This PR allows the hidden field to be suppressed by passing `include_hidden: false`.

For consistency, both with each other and with Rails, it changes the default value of the param in the `#govuk_collection_radio_buttons` method to `true`.

As this could affect users so there's also a way of configuring the inclusion of hidden fields on collection fields by setting the options:     `default_collection_check_boxes_include_hidden` and `default_collection_radio_buttons_include_hidden`.

Fixes #238 