### PR TITLE
Allow novalidate to be enabled by default on forms

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -24,6 +24,12 @@ module GOVUKDesignSystemFormBuilder
 
     private
 
+      def form_no_validate?
+        return false if config.default_form_novalidate
+
+        !@validate
+      end
+
       def buttons
         safe_join([submit, @block_content])
       end
@@ -46,7 +52,7 @@ module GOVUKDesignSystemFormBuilder
 
       def options
         {
-          formnovalidate: !@validate,
+          formnovalidate: form_no_validate?,
           disabled: @disabled,
           data: {
             module: %(#{brand}-button),

--- a/spec/govuk_design_system_formbuilder/builder/configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration_spec.rb
@@ -5,6 +5,31 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   describe 'configuration' do
     after { GOVUKDesignSystemFormBuilder.reset! }
 
+    describe 'form validation' do
+      let(:method) { :govuk_submit }
+      let(:args) { Array.wrap(method) }
+      subject { builder.send(*args) }
+
+      context 'when default_form_novalidate is unset' do
+        specify "submit input should have a formnovalidate attribute" do
+          expect(subject).to have_tag('input', with: { type: 'submit', formnovalidate: 'formnovalidate' })
+        end
+      end
+
+      context 'when default_form_novalidate is set to true' do
+        before do
+          GOVUKDesignSystemFormBuilder.configure do |conf|
+            conf.default_form_novalidate = true
+          end
+        end
+
+        specify "submit input should have no formnovalidate attribute" do
+          expect(subject).to have_tag('input', with: { type: 'submit' })
+          expect(parsed_subject.at_css('input').attributes.keys).not_to include("formnovalidate")
+        end
+      end
+    end
+
     describe 'legend config' do
       include_context 'setup radios'
       let(:method) { :govuk_collection_radio_buttons }


### PR DESCRIPTION
This is a rehash of a _really old_ feature (28ffa91071046) whereby the behaviour of `#form_for` and `#form_with` could be altered to default `novalidate: true`. It improves on the previous attempt by wrapping the functionality in conditional logic which requires the `default_form_novalidate` configuration option to be set.

It defaults to `false`.

When it is set to `true` the `formnovalidate` attribute will be omitted from the submit button.