### PR TITLE
Remove incorrect quote and reword the single checkbox instructions

### DIFF
--- a/guide/content/css/guide.sass
+++ b/guide/content/css/guide.sass
@@ -179,6 +179,7 @@ p, li, dt, dd, td, th
 
   code
     background-color: govuk-tint(govuk_colour('yellow'), 40%)
+    padding: 0 .2em
 
 .ugly-gradient
   display: inline-block
@@ -198,7 +199,8 @@ p, li, dt, dd, td, th
 
 blockquote
   background: govuk-tint(govuk-colour('light-grey'), 35%)
-  padding: 1em
+  padding: 2em
+  margin: 1em 0
 
   > p
     font-style: italic

--- a/guide/content/form-elements/checkboxes.slim
+++ b/guide/content/form-elements/checkboxes.slim
@@ -5,15 +5,18 @@ title: Check boxes
 h1.govuk-heading-xl Checkboxes
 
 p.govuk-body-l
-  | The checkboxes component allows users to select one or more options.
+p.govuk-body
+  | The checkboxes component allows users to:
+
+ul.govuk-list.govuk-list--bullet
+  li #{link_to("select multiple options from a list", "#generating-a-collection-of-checkboxes").html_safe}
+  li #{link_to("toggle a single option on or off", "#generating-a-single-checkbox").html_safe}
 
 p.govuk-body
-  | Use the checkboxes component when you need to help users:
-
-  ul.govuk-list.govuk-list--bullet
-    li select multiple options from a list
-    li == link_to("toggle a single option on or off", "#generating-a-single-checkbox")
-
+  | By default the form builder will automatically inject hidden inputs into
+    checkbox fieldsets. This ensures that a parameter is submitted with the form
+    even if no checkboxes have been checked.
+ 
 section
 
   == render('/partials/example-fig.*',
@@ -53,39 +56,28 @@ section
         the results. Using smaller checkboxes lets users see and change search
         filters without distracting them from the main content.
 
-    p.govuk-body
-      | To address the empty submission problem outlined above, Rails generates hidden fields with no
-        value to represent the unchecked state. This is taken care of by default when using <code>govuk_collection_check_boxes</code>
-        and <code>govuk_collection_check_boxes</code> for multiple values. When using <code>govuk_collection_check_boxes</code> for a single value,
-        usually a boolean toggle or confirmation, we need to take an exta step and pass in <code>multiple: false</code>.
-
   == render('/partials/example-fig.*',
     caption: "Generating a single checkbox",
     code: single_checkbox) do
 
     p.govuk-body
-      | Single checkboxes can be used to toggle boolean fields. This pattern
-        is most-commonly used for accepting terms and conditions or changing
-        settings.
+      | Single checkboxes are usually used for boolean fields like accepting
+        terms and conditions or toggling a setting.
 
     p.govuk-body
       | When asking users questions, favour the use of 'Yes' and 'No' radio
         buttons. This ensures the user has understood the question and is
         actively selecting the appropriate answer.
 
-    p.govuk-body
-      | Note that <code>multiple: false</code> is passed to both the
-        <code>#govuk_check_boxes_fieldset</code> and
-        <code>#govuk_check_box</code> helpers. They're required to
-        ensure only a single hidden field is rendered and its <code>name</code>
-        matches that of the single checkbox.
-
-    blockquote
+    div.important
       p.govuk-body
-        | When no corresponding hidden field is present, an unchecked check box
-          will result in no value being submitted to the server.
+        | Note that in this example <code>multiple: false</code> is passed to
+          both the <code>#govuk_check_boxes_fieldset</code> and
+          <code>#govuk_check_box</code> helpers. 
 
-      footer
-        == link_to("Mozilla Developer Network Documentation", mdn_checkbox_value_link)
+      p.govuk-body
+        | They're required to ensure the both checkbox's and hidden field's
+          <code>name</code> is generated in the format that Rails expects for a
+          single attribute.
 
 == render('/partials/related-info.*', links: checkbox_info)

--- a/guide/content/form-elements/checkboxes.slim
+++ b/guide/content/form-elements/checkboxes.slim
@@ -53,14 +53,6 @@ section
         the results. Using smaller checkboxes lets users see and change search
         filters without distracting them from the main content.
 
-    blockquote
-      p.govuk-body
-        | If a checkbox is unchecked when its form is submitted, there is no value
-          submitted to the server to represent its unchecked state
-
-      footer
-        == link_to('Mozilla Developer Network Documentation', 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#Value')
-
     p.govuk-body
       | To address the empty submission problem outlined above, Rails generates hidden fields with no
         value to represent the unchecked state. This is taken care of by default when using <code>govuk_collection_check_boxes</code>
@@ -81,10 +73,19 @@ section
         buttons. This ensures the user has understood the question and is
         actively selecting the appropriate answer.
 
-    p.govuk-body.important
-      | Note that the <code>multiple</code> keyword on
-        <code>govuk_check_boxes_fieldset</code> changes the hidden field's
-        <code>name</code> attribute to the Rails' single attribute syntax. It is
-        required to prevent unnecessary hidden fields from being generated.
+    p.govuk-body
+      | Note that <code>multiple: false</code> is passed to both the
+        <code>#govuk_check_boxes_fieldset</code> and
+        <code>#govuk_check_box</code> helpers. They're required to
+        ensure only a single hidden field is rendered and its <code>name</code>
+        matches that of the single checkbox.
+
+    blockquote
+      p.govuk-body
+        | When no corresponding hidden field is present, an unchecked check box
+          will result in no value being submitted to the server.
+
+      footer
+        == link_to("Mozilla Developer Network Documentation", mdn_checkbox_value_link)
 
 == render('/partials/related-info.*', links: checkbox_info)

--- a/guide/content/form-elements/checkboxes.slim
+++ b/guide/content/form-elements/checkboxes.slim
@@ -4,7 +4,6 @@ title: Check boxes
 
 h1.govuk-heading-xl Checkboxes
 
-p.govuk-body-l
 p.govuk-body
   | The checkboxes component allows users to:
 

--- a/guide/content/form-elements/checkboxes.slim
+++ b/guide/content/form-elements/checkboxes.slim
@@ -5,16 +5,17 @@ title: Check boxes
 h1.govuk-heading-xl Checkboxes
 
 p.govuk-body
-  | The checkboxes component allows users to:
+  | Checkboxes allow users to:
 
 ul.govuk-list.govuk-list--bullet
   li #{link_to("select multiple options from a list", "#generating-a-collection-of-checkboxes").html_safe}
   li #{link_to("toggle a single option on or off", "#generating-a-single-checkbox").html_safe}
 
 p.govuk-body
-  | By default the form builder will automatically inject hidden inputs into
-    checkbox fieldsets. This ensures that a parameter is submitted with the form
-    even if no checkboxes have been checked.
+  | By default the form builder's checkbox helpers will automatically inject a
+    hidden field. The hidden field ensures that a parameter is always submitted
+    with the form, even when no checkboxes have been checked, allowing options
+    #{link_to("to be deselected", rails_checkbox_gotcha_link).html_safe}.
  
 section
 
@@ -76,7 +77,7 @@ section
 
       p.govuk-body
         | They're required to ensure the both checkbox's and hidden field's
-          <code>name</code> is generated in the format that Rails expects for a
-          single attribute.
+          <code>name</code> attribute is generated in the format that Rails
+          expects for a single field.
 
 == render('/partials/related-info.*', links: checkbox_info)

--- a/guide/content/form-elements/date-field.slim
+++ b/guide/content/form-elements/date-field.slim
@@ -4,7 +4,7 @@ title: Date fields
 
 h1.govuk-heading-xl Date fields
 
-p.govuk-body-l
+p.govuk-body
   | Date fields allow the user to enter the day, month and year
     of an event.
 

--- a/guide/content/form-elements/file-field.slim
+++ b/guide/content/form-elements/file-field.slim
@@ -4,7 +4,7 @@ title: File field
 
 h1.govuk-heading-xl File field
 
-p.govuk-body-l
+p.govuk-body
   | The file upload field allows users to upload files.
 
 p.govuk-body

--- a/guide/content/form-elements/radios.slim
+++ b/guide/content/form-elements/radios.slim
@@ -4,7 +4,7 @@ title: Radio buttons
 
 h1.govuk-heading-xl Radio buttons
 
-p.govuk-body-l
+p.govuk-body
   | Radio buttons allow users to select a single option from a list.
 
 p.govuk-body

--- a/guide/content/form-elements/select.slim
+++ b/guide/content/form-elements/select.slim
@@ -4,7 +4,7 @@ title: Select boxes
 
 h1.govuk-heading-xl Select field
 
-p.govuk-body-l
+p.govuk-body
   | The select component allows users to choose an option from a long list.
 
 p.govuk-body

--- a/guide/content/form-elements/submit.slim
+++ b/guide/content/form-elements/submit.slim
@@ -4,7 +4,7 @@ title: Submit button
 
 h1.govuk-heading-xl Submit button
 
-p.govuk-body-l
+p.govuk-body
   | Submit buttons submit the contents of the form
 
 p.govuk-body

--- a/guide/content/form-elements/text-area.slim
+++ b/guide/content/form-elements/text-area.slim
@@ -4,7 +4,7 @@ title: Text area
 
 h1.govuk-heading-xl Text area
 
-p.govuk-body-l
+p.govuk-body
   | Text areas allow users to enter text that's longer than a single line.
 
 p.govuk-body

--- a/guide/content/form-elements/text-field.slim
+++ b/guide/content/form-elements/text-field.slim
@@ -4,7 +4,7 @@ title: Text fields
 
 h1.govuk-heading-xl Text fields
 
-p.govuk-body-l
+p.govuk-body
   | Text fields allow users to enter text that's no longer than a single line.
 
 p.govuk-body

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -89,9 +89,5 @@ module Helpers
     def nhs_design_system_link
       'https://service-manual.nhs.uk/design-system'
     end
-
-    def mdn_checkbox_value_link
-      'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#Value'
-    end
   end
 end

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -89,5 +89,9 @@ module Helpers
     def nhs_design_system_link
       'https://service-manual.nhs.uk/design-system'
     end
+
+    def mdn_checkbox_value_link
+      'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#Value'
+    end
   end
 end

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -89,5 +89,9 @@ module Helpers
     def nhs_design_system_link
       'https://service-manual.nhs.uk/design-system'
     end
+
+    def rails_checkbox_gotcha_link
+      'https://api.rubyonrails.org/v6.1/classes/ActionView/Helpers/FormHelper.html#method-i-check_box-label-Gotcha'
+    end
   end
 end


### PR DESCRIPTION
~~The quote in the 'small checkboxes' section should really have been in the 'generating a single checkbox' one. Also tried to improve the phrasing of the single checkbox documentation a little.~~

Ended up rewording most of the guidance on the checkboxes page. It definitely feels like it makes more sense now.

Fixes #243