### PR TITLE
Add example of hard-coding a radio option hint text

### DIFF
--- a/guide/lib/examples/radios.rb
+++ b/guide/lib/examples/radios.rb
@@ -49,7 +49,7 @@ module Examples
       <<~SNIPPET
         = f.govuk_radio_buttons_fieldset(:old_department_id, legend: { size: 'm', text: 'Which department do you work in?' }) do
           = f.govuk_radio_button :old_department_id, 'it', label: { text: 'Information Technology' }, link_errors: true
-          = f.govuk_radio_button :old_department_id, 'marketing', label: { text: 'Marketing' }
+          = f.govuk_radio_button :old_department_id, 'marketing', label: { text: 'Marketing' }, hint: { text: 'Includes Sales and Digital Marketing' }
           = f.govuk_radio_divider
           = f.govuk_radio_button :old_department_id, 'other', label: { text: 'Other' } do
             = f.govuk_text_field :old_department_description,


### PR DESCRIPTION
This alters: https://govuk-form-builder.netlify.app/form-elements/radios/#radio-buttons-fieldset-with-conditional-content-and-a-divider

When adding a text-divider, the list of options has to be hard-coded. It was unclear how to add hint-text to the option in a hard-coded way, since the mentions of hint text for radio options on this page were about doing so programmatically. This change adds an example of how to do this.