### PR TITLE
Upgrade to GOV.UK Rubocop version 4.0.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,9 +25,15 @@ Style/PercentLiteralDelimiters:
   Enabled: false
 Layout/HashAlignment:
   Enabled: false
+Style/StringConcatenation:
+  Enabled: false
 Style/SignalException:
   Enabled: false
 Style/AsciiComments:
+  Enabled: false
+Style/OptionalBooleanParameter:
+  Enabled: false
+Style/CommentAnnotation:
   Enabled: false
 Style/FormatString:
   EnforcedStyle: format

--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
     s.add_dependency(*VersionFormatter.new(lib, rails_version, exact_rails_version).to_a)
   end
 
-  s.add_development_dependency("rubocop-govuk", "= 3.17.2")
+  s.add_development_dependency("rubocop-govuk", "= 4.0.0.pre.1")
   s.add_development_dependency("pry", "~> 0.13.0")
   s.add_development_dependency("pry-byebug", "~> 3.9", ">= 3.9.0")
   s.add_development_dependency("rspec-html-matchers", "~> 0")
@@ -45,4 +45,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("sassc", "~> 2.4.0")
   s.add_development_dependency("sass")
   s.add_development_dependency("slim", "~> 4.1.0")
+  s.add_development_dependency("puma", "~> 5.2")
 end

--- a/guide/lib/helpers/formatters.rb
+++ b/guide/lib/helpers/formatters.rb
@@ -28,11 +28,11 @@ module Helpers
           generator: Temple::Generators::RailsOutputBuffer
         )
           .call(raw)
-          .gsub(/ _slim_controls[\d] =/, "=")        # remove _slim_controlsX assignment (where X is an integer)
-          .gsub(/do\n\s+%>/, "do %>")                # close blocks on the same line
-          .gsub(/%><%/, "%>\n<%")                    # ensure ERB tags are on separate lines
-          .gsub(/<%= _slim_controls[\d] %>/, '')     # remove _slim_controlsX var display, we've handled it above
-          .gsub(/,\n/, ', ')                         # don't leave newlines between args, it breaks indentation
+          .gsub(/ _slim_controls\d =/, "=")    # remove _slim_controlsX assignment (where X is an integer)
+          .gsub(/do\n\s+%>/, "do %>")          # close blocks on the same line
+          .gsub(/%><%/, "%>\n<%")              # ensure ERB tags are on separate lines
+          .gsub(/<%= _slim_controls\d %>/, '') # remove _slim_controlsX var display, we've handled it above
+          .gsub(/,\n/, ', ')                   # don't leave newlines between args, it breaks indentation
       )
     end
 
@@ -47,7 +47,7 @@ module Helpers
           html
             .gsub(">", ">\n")
             .gsub("\<\/", "\n\<\/")
-            .gsub(/\>\s+\<\/textarea\>/, "></textarea>")
+            .gsub(/>\s+<\/textarea>/, "></textarea>")
             .strip
         )
     end

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection_radio_button.rb
@@ -9,7 +9,7 @@ module GOVUKDesignSystemFormBuilder
         #   error summary requires that the id of the first radio is linked-to from the corresponding
         #   error message. As when the summary is built what happens later in the form is unknown, we
         #   need to control this to ensure the link is generated correctly
-        def initialize(builder, object_name, attribute_name, item, value_method:, text_method:, hint_method:, link_errors: false, bold_labels:)
+        def initialize(builder, object_name, attribute_name, item, value_method:, text_method:, hint_method:, bold_labels:, link_errors: false)
           super(builder, object_name, attribute_name)
 
           @item        = item

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -48,7 +48,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports setting the hint via localisation'
 
     it_behaves_like 'a field that accepts a plain ruby object' do
-      let(:described_element) { ['input', with: { type: 'file' }] }
+      let(:described_element) { ['input', { with: { type: 'file' } }] }
     end
 
     describe 'additional attributes' do

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -13,7 +13,7 @@ class Being
     :name,
     :born_on,
     :gender,
-    :over_18,
+    :over18,
     :favourite_colour,
     :favourite_colour_reason,
     :projects,
@@ -24,6 +24,10 @@ class Being
     :stationery,
     :stationery_choice
   )
+
+  def initialize(_args = nil)
+    # do nothing
+  end
 end
 
 class Person < Being
@@ -76,6 +80,8 @@ class Guest < Being
     self.projects         = projects
     self.cv               = cv
     self.born_on          = born_on
+
+    super
   end
 
   def self.example


### PR DESCRIPTION
Since adding Ruby 3.0.0 support (#232), rubocop has failed to run for me locally:

```
Error: RuboCop found unknown Ruby version 3.0 in `.ruby-version`.
Supported versions: 2.4, 2.5, 2.6, 2.7, 2.8
```

As v4.0.0 of govuk-rubocop is on its way out (alphagov/rubocop-govuk/issues/129) we may as well take the opportunity to upgrade.