### PR TITLE
Pass through additional attributes where not already supported

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -813,6 +813,7 @@ module GOVUKDesignSystemFormBuilder
     #   client-side validation provided by the browser. This is to provide a more consistent and accessible user
     #   experience
     # @param disabled [Boolean] makes the button disabled when true
+    # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     # @param block [Block] When content is passed in via a block the submit element and the block content will
     #   be wrapped in a +<div class="govuk-button-group">+ which will space the buttons and links within
     #   evenly.
@@ -829,8 +830,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_submit "Proceed", prevent_double_click: true do
     #     = link_to 'Cancel', some_other_path, class: 'govuk-button__secondary'
     #
-    def govuk_submit(text = config.default_submit_button_text, warning: false, secondary: false, classes: nil, prevent_double_click: true, validate: config.default_submit_validate, disabled: false, &block)
-      Elements::Submit.new(self, text, warning: warning, secondary: secondary, classes: classes, prevent_double_click: prevent_double_click, validate: validate, disabled: disabled, &block).html
+    def govuk_submit(text = config.default_submit_button_text, warning: false, secondary: false, classes: nil, prevent_double_click: true, validate: config.default_submit_validate, disabled: false, **kwargs, &block)
+      Elements::Submit.new(self, text, warning: warning, secondary: secondary, classes: classes, prevent_double_click: prevent_double_click, validate: validate, disabled: disabled, **kwargs, &block).html
     end
 
     # Generates three inputs for the +day+, +month+ and +year+ components of a date
@@ -858,6 +859,7 @@ module GOVUKDesignSystemFormBuilder
     # @param form_group [Hash] configures the form group
     # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
+    # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input group
     # @param date_of_birth [Boolean] if +true+ {https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Values birth date auto completion attributes}
     #   will be added to the inputs
@@ -877,8 +879,8 @@ module GOVUKDesignSystemFormBuilder
     # @example A date input with legend supplied as a proc
     #  = f.govuk_date_field :finishes_on,
     #    legend: -> { tag.h3('Which category do you belong to?') }
-    def govuk_date_field(attribute_name, hint: {}, legend: {}, caption: {}, date_of_birth: false, omit_day: false, form_group: {}, wildcards: false, &block)
-      Elements::Date.new(self, object_name, attribute_name, hint: hint, legend: legend, caption: caption, date_of_birth: date_of_birth, omit_day: omit_day, form_group: form_group, wildcards: wildcards, &block).html
+    def govuk_date_field(attribute_name, hint: {}, legend: {}, caption: {}, date_of_birth: false, omit_day: false, form_group: {}, wildcards: false, **kwargs, &block)
+      Elements::Date.new(self, object_name, attribute_name, hint: hint, legend: legend, caption: caption, date_of_birth: date_of_birth, omit_day: omit_day, form_group: form_group, wildcards: wildcards, **kwargs, &block).html
     end
 
     # Generates a summary of errors in the form, each linking to the corresponding
@@ -912,6 +914,7 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option caption kwargs [Hash] additional arguments are applied as attributes on the caption +span+ element
+    # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     #
     # @example A fieldset containing address fields
     #   = f.govuk_fieldset legend: { text: 'Address' } do
@@ -927,8 +930,8 @@ module GOVUKDesignSystemFormBuilder
     # @see https://design-system.service.gov.uk/components/fieldset/ GOV.UK fieldset
     # @see https://design-system.service.gov.uk/styles/typography/#headings-with-captions Headings with captions
     # @return [ActiveSupport::SafeBuffer] HTML output
-    def govuk_fieldset(legend: { text: 'Fieldset heading' }, caption: {}, described_by: nil, &block)
-      Containers::Fieldset.new(self, legend: legend, caption: caption, described_by: described_by, &block).html
+    def govuk_fieldset(legend: { text: 'Fieldset heading' }, caption: {}, described_by: nil, **kwargs, &block)
+      Containers::Fieldset.new(self, legend: legend, caption: caption, described_by: described_by, **kwargs, &block).html
     end
 
     # Generates an input of type +file+

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -1,17 +1,18 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
     class Fieldset < Base
-      def initialize(builder, object_name = nil, attribute_name = nil, legend: {}, caption: {}, described_by: nil, &block)
+      def initialize(builder, object_name = nil, attribute_name = nil, legend: {}, caption: {}, described_by: nil, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @legend         = legend
-        @caption        = caption
-        @described_by   = described_by(described_by)
-        @attribute_name = attribute_name
+        @legend          = legend
+        @caption         = caption
+        @described_by    = described_by(described_by)
+        @attribute_name  = attribute_name
+        @html_attributes = kwargs
       end
 
       def html
-        tag.fieldset(**options) do
+        tag.fieldset(**options, **@html_attributes) do
           safe_join([legend_element, (@block_content || yield)])
         end
       end

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -9,20 +9,21 @@ module GOVUKDesignSystemFormBuilder
 
       SEGMENTS = { day: '3i', month: '2i', year: '1i' }.freeze
 
-      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, omit_day:, form_group:, wildcards:, date_of_birth: false, &block)
+      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, omit_day:, form_group:, wildcards:, date_of_birth: false, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @legend        = legend
-        @caption       = caption
-        @hint          = hint
-        @date_of_birth = date_of_birth
-        @omit_day      = omit_day
-        @form_group    = form_group
-        @wildcards     = wildcards
+        @legend          = legend
+        @caption         = caption
+        @hint            = hint
+        @date_of_birth   = date_of_birth
+        @omit_day        = omit_day
+        @form_group      = form_group
+        @wildcards       = wildcards
+        @html_attributes = kwargs
       end
 
       def html
-        Containers::FormGroup.new(@builder, @object_name, @attribute_name, **@form_group).html do
+        Containers::FormGroup.new(@builder, @object_name, @attribute_name, **@form_group, **@html_attributes).html do
           Containers::Fieldset.new(@builder, @object_name, @attribute_name, **fieldset_options).html do
             safe_join([supplemental_content, hint_element, error_element, date])
           end

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -3,7 +3,7 @@ module GOVUKDesignSystemFormBuilder
     class Submit < Base
       using PrefixableArray
 
-      def initialize(builder, text, warning:, secondary:, classes:, prevent_double_click:, validate:, disabled:, &block)
+      def initialize(builder, text, warning:, secondary:, classes:, prevent_double_click:, validate:, disabled:, **kwargs, &block)
         super(builder, nil, nil)
 
         fail ArgumentError, 'buttons can be warning or secondary' if warning && secondary
@@ -15,6 +15,7 @@ module GOVUKDesignSystemFormBuilder
         @classes              = classes
         @validate             = validate
         @disabled             = disabled
+        @html_attributes      = kwargs
         @block_content        = capture { block.call } if block_given?
       end
 
@@ -33,7 +34,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def submit
-        @builder.submit(@text, class: classes, **options)
+        @builder.submit(@text, class: classes, **options, **@html_attributes)
       end
 
       def classes

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -224,5 +224,13 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         expect(subject).to have_tag('input', with: { id: year_identifier, pattern: "[0-9]*" })
       end
     end
+
+    describe "additional attributes" do
+      subject { builder.send(*args, data: { test: "abc" }) }
+
+      specify "should have additional attributes" do
+        expect(subject).to have_tag('div', with: { 'data-test': 'abc' })
+      end
+    end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
@@ -116,5 +116,17 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
     end
+
+    context 'additional attributes' do
+      subject do
+        builder.send(method, data: { test: 'abc' }) do
+          builder.govuk_text_field(:name)
+        end
+      end
+
+      specify 'field should have additional attributes' do
+        expect(subject).to have_tag('fieldset', with: { 'data-test': 'abc' })
+      end
+    end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -52,12 +52,13 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     describe 'additional attributes' do
-      subject { builder.send(method, attribute, accept: 'image/*', multiple: true) }
+      subject { builder.send(method, attribute, accept: 'image/*', multiple: true, data: { test: 'abc' }) }
 
       specify 'input should have additional attributes' do
         expect(subject).to have_tag('input', with: {
           accept: 'image/*',
-          multiple: 'multiple'
+          multiple: 'multiple',
+          'data-test': 'abc'
         })
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -61,7 +61,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:extra_args) do
         {
           required: { provided: true, output: 'required' },
-          autofocus: { provided: true, output: 'autofocus' }
+          autofocus: { provided: true, output: 'autofocus' },
+          data: { test: 'abc' }
         }
       end
 
@@ -70,7 +71,13 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       specify 'select tag should have the extra attributes' do
         select_tag = parsed_subject.at_css('select')
         extract_args(extra_args, :output).each do |key, val|
-          expect(select_tag[key]).to eql(val)
+          if key == 'data' && val.respond_to?('each')
+            val.each do |dataKey, dataVal|
+              expect(select_tag[%(data-#{key})]).to eql(dataVal)
+            end
+          else
+            expect(select_tag[key]).to eql(val)
+          end
         end
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -157,5 +157,18 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
     end
+
+    describe 'extra arguments' do
+      subject { builder.send(*args.push('Create'), data: { test: 'abc' }) }
+
+      specify 'should add the extra attributes to the submit' do
+        expect(subject).to have_tag(
+          'input',
+          with: {
+            'data-test': 'abc'
+          }
+        )
+      end
+    end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -193,14 +193,15 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
   describe 'extra arguments' do
     let(:placeholder) { 'Once upon a time…' }
-    subject { builder.send(*args, placeholder: placeholder, required: true) }
+    subject { builder.send(*args, placeholder: placeholder, required: true, data: { test: 'abc' }) }
 
     specify 'should add the extra attributes to the textarea' do
       expect(subject).to have_tag(
         'textarea',
         with: {
           placeholder: placeholder,
-          required: 'required'
+          required: 'required',
+          'data-test': 'abc'
         }
       )
     end


### PR DESCRIPTION
Resolves https://github.com/DFE-Digital/govuk_design_system_formbuilder/issues/249 cc @ethanmills 

This adds support for passing through additional attributes where it wasn't already supported, and improves the tests in a couple places where it was already supported but not tested.

Some places already supported basically the same thing but with `html_attributes` instead - I left that alone.