### PR TITLE
Allow HTML attributes to be set via keyword args across all helpers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 # .rubocop.yml
+---
 inherit_gem:
   rubocop-govuk:
     - config/default.yml
@@ -34,6 +35,8 @@ Style/AsciiComments:
 Style/OptionalBooleanParameter:
   Enabled: false
 Style/CommentAnnotation:
+  Enabled: false
+Style/EmptyCaseCondition:
   Enabled: false
 Style/FormatString:
   EnforcedStyle: format

--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |s|
   exact_rails_version = ENV.has_key?("RAILS_VERSION")
   rails_version = ENV.fetch("RAILS_VERSION") { "5.2.3" }
 
+  s.add_dependency("deep_merge", "~> 1.2.1")
+
   %w(actionview activemodel activesupport).each do |lib|
     s.add_dependency(*VersionFormatter.new(lib, rails_version, exact_rails_version).to_a)
   end

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -1,3 +1,4 @@
+require 'deep_merge/rails_compat'
 require 'active_support/configurable'
 
 [%w(traits *.rb), %w(*.rb), %w(elements ** *.rb), %w(containers ** *.rb)]

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -598,6 +598,7 @@ module GOVUKDesignSystemFormBuilder
     #   container and only revealed when the radio button is picked
     # @param link_errors [Boolean] controls whether this radio button should be linked to from {#govuk_error_summary}
     #   from the error summary. <b>Should only be set to +true+ for the first radio button in a fieldset</b>
+    # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
     # @example A single radio button for our new favourite colour
@@ -605,8 +606,8 @@ module GOVUKDesignSystemFormBuilder
     #  = f.govuk_radio_buttons_fieldset :favourite_colour do
     #    = f.govuk_radio_button :favourite_colour, :red, label: { text: 'Red' }
     #
-    def govuk_radio_button(attribute_name, value, hint: {}, label: {}, link_errors: false, &block)
-      Elements::Radios::FieldsetRadioButton.new(self, object_name, attribute_name, value, hint: hint, label: label, link_errors: link_errors, &block).html
+    def govuk_radio_button(attribute_name, value, hint: {}, label: {}, link_errors: false, **kwargs, &block)
+      Elements::Radios::FieldsetRadioButton.new(self, object_name, attribute_name, value, hint: hint, label: label, link_errors: link_errors, **kwargs, &block).html
     end
 
     # Inserts a text divider into a list of radio buttons
@@ -776,6 +777,7 @@ module GOVUKDesignSystemFormBuilder
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @option label kwargs [Hash] additional arguments are applied as attributes on the +label+ element
     # @param multiple [Boolean] controls whether the check box is part of a collection or represents a single attribute
+    # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     # @param block [Block] any HTML passed in will form the contents of the fieldset
     # @return [ActiveSupport::SafeBuffer] HTML output
     #
@@ -787,7 +789,7 @@ module GOVUKDesignSystemFormBuilder
     #     label: { text: 'Do you agree with our terms and conditions?' },
     #     hint: { text: 'You will not be able to proceed unless you do' }
     #
-    def govuk_check_box(attribute_name, value, unchecked_value = false, hint: {}, label: {}, link_errors: false, multiple: true, &block)
+    def govuk_check_box(attribute_name, value, unchecked_value = false, hint: {}, label: {}, link_errors: false, multiple: true, **kwargs, &block)
       Elements::CheckBoxes::FieldsetCheckBox.new(
         self,
         object_name,
@@ -798,6 +800,7 @@ module GOVUKDesignSystemFormBuilder
         label: label,
         link_errors: link_errors,
         multiple: multiple,
+        **kwargs,
         &block
       ).html
     end

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -829,8 +829,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_submit "Proceed", prevent_double_click: true do
     #     = link_to 'Cancel', some_other_path, class: 'govuk-button__secondary'
     #
-    def govuk_submit(text = config.default_submit_button_text, warning: false, secondary: false, classes: nil, prevent_double_click: true, validate: config.default_submit_validate, disabled: false, &block)
-      Elements::Submit.new(self, text, warning: warning, secondary: secondary, classes: classes, prevent_double_click: prevent_double_click, validate: validate, disabled: disabled, &block).html
+    def govuk_submit(text = config.default_submit_button_text, warning: false, secondary: false, classes: nil, prevent_double_click: true, validate: config.default_submit_validate, disabled: false, **kwargs, &block)
+      Elements::Submit.new(self, text, warning: warning, secondary: secondary, classes: classes, prevent_double_click: prevent_double_click, validate: validate, disabled: disabled, **kwargs, &block).html
     end
 
     # Generates three inputs for the +day+, +month+ and +year+ components of a date

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -813,6 +813,7 @@ module GOVUKDesignSystemFormBuilder
     #   client-side validation provided by the browser. This is to provide a more consistent and accessible user
     #   experience
     # @param disabled [Boolean] makes the button disabled when true
+    # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     # @param block [Block] When content is passed in via a block the submit element and the block content will
     #   be wrapped in a +<div class="govuk-button-group">+ which will space the buttons and links within
     #   evenly.
@@ -858,6 +859,7 @@ module GOVUKDesignSystemFormBuilder
     # @param form_group [Hash] configures the form group
     # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
+    # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input group
     # @param date_of_birth [Boolean] if +true+ {https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Values birth date auto completion attributes}
     #   will be added to the inputs
@@ -877,8 +879,8 @@ module GOVUKDesignSystemFormBuilder
     # @example A date input with legend supplied as a proc
     #  = f.govuk_date_field :finishes_on,
     #    legend: -> { tag.h3('Which category do you belong to?') }
-    def govuk_date_field(attribute_name, hint: {}, legend: {}, caption: {}, date_of_birth: false, omit_day: false, form_group: {}, wildcards: false, &block)
-      Elements::Date.new(self, object_name, attribute_name, hint: hint, legend: legend, caption: caption, date_of_birth: date_of_birth, omit_day: omit_day, form_group: form_group, wildcards: wildcards, &block).html
+    def govuk_date_field(attribute_name, hint: {}, legend: {}, caption: {}, date_of_birth: false, omit_day: false, form_group: {}, wildcards: false, **kwargs, &block)
+      Elements::Date.new(self, object_name, attribute_name, hint: hint, legend: legend, caption: caption, date_of_birth: date_of_birth, omit_day: omit_day, form_group: form_group, wildcards: wildcards, **kwargs, &block).html
     end
 
     # Generates a summary of errors in the form, each linking to the corresponding
@@ -912,6 +914,7 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option caption kwargs [Hash] additional arguments are applied as attributes on the caption +span+ element
+    # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     #
     # @example A fieldset containing address fields
     #   = f.govuk_fieldset legend: { text: 'Address' } do
@@ -927,8 +930,8 @@ module GOVUKDesignSystemFormBuilder
     # @see https://design-system.service.gov.uk/components/fieldset/ GOV.UK fieldset
     # @see https://design-system.service.gov.uk/styles/typography/#headings-with-captions Headings with captions
     # @return [ActiveSupport::SafeBuffer] HTML output
-    def govuk_fieldset(legend: { text: 'Fieldset heading' }, caption: {}, described_by: nil, &block)
-      Containers::Fieldset.new(self, legend: legend, caption: caption, described_by: described_by, &block).html
+    def govuk_fieldset(legend: { text: 'Fieldset heading' }, caption: {}, described_by: nil, **kwargs, &block)
+      Containers::Fieldset.new(self, legend: legend, caption: caption, described_by: described_by, **kwargs, &block).html
     end
 
     # Generates an input of type +file+

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -341,6 +341,7 @@ module GOVUKDesignSystemFormBuilder
     # @param form_group [Hash] configures the form group
     # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
+    # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +textarea+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/textarea/ GOV.UK text area component

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -412,7 +412,7 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_collection_select(:team, @teams, :id, :name) do
     #     label: -> { tag.h3("Which team did you represent?") }
     #
-    def govuk_collection_select(attribute_name, collection, value_method, text_method, options: {}, html_options: {}, hint: {}, label: {}, caption: {}, form_group: {}, &block)
+    def govuk_collection_select(attribute_name, collection, value_method, text_method, options: {}, hint: {}, label: {}, caption: {}, form_group: {}, **kwargs, &block)
       Elements::Select.new(
         self,
         object_name,
@@ -424,8 +424,8 @@ module GOVUKDesignSystemFormBuilder
         label: label,
         caption: caption,
         options: options,
-        html_options: html_options,
         form_group: form_group,
+        **kwargs,
         &block
       ).html
     end

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -890,6 +890,7 @@ module GOVUKDesignSystemFormBuilder
     # @param title [String] the error summary heading
     # @param link_base_errors_to [Symbol,String] set the field that errors on +:base+ are linked
     #   to, as there won't be a field representing the object base.
+    # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the error summary +div+ element
     #
     # @note Only the first error in the +#errors+ array for each attribute will
     #   be included.
@@ -898,8 +899,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_error_summary 'Uh-oh, spaghettios'
     #
     # @see https://design-system.service.gov.uk/components/error-summary/ GOV.UK error summary
-    def govuk_error_summary(title = config.default_error_summary_title, link_base_errors_to: nil)
-      Elements::ErrorSummary.new(self, object_name, title, link_base_errors_to: link_base_errors_to).html
+    def govuk_error_summary(title = config.default_error_summary_title, link_base_errors_to: nil, **kwargs)
+      Elements::ErrorSummary.new(self, object_name, title, link_base_errors_to: link_base_errors_to, **kwargs).html
     end
 
     # Generates a fieldset containing the contents of the block

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -1,6 +1,8 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
     class Fieldset < Base
+      include Traits::HTMLAttributes
+
       def initialize(builder, object_name = nil, attribute_name = nil, legend: {}, caption: {}, described_by: nil, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
@@ -12,7 +14,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        tag.fieldset(**options, **@html_attributes) do
+        tag.fieldset(attributes(@html_attributes)) do
           safe_join([legend_element, (@block_content || yield)])
         end
       end

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -14,7 +14,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        tag.fieldset(attributes(@html_attributes)) do
+        tag.fieldset(**attributes(@html_attributes)) do
           safe_join([legend_element, (@block_content || yield)])
         end
       end
@@ -29,7 +29,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def classes
-        %(#{brand}-fieldset)
+        [%(#{brand}-fieldset)]
       end
 
       def legend_element

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -1,17 +1,18 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
     class Fieldset < Base
-      def initialize(builder, object_name = nil, attribute_name = nil, legend: {}, caption: {}, described_by: nil, &block)
+      def initialize(builder, object_name = nil, attribute_name = nil, legend: {}, caption: {}, described_by: nil, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @legend         = legend
-        @caption        = caption
-        @described_by   = described_by(described_by)
-        @attribute_name = attribute_name
+        @legend          = legend
+        @caption         = caption
+        @described_by    = described_by(described_by)
+        @attribute_name  = attribute_name
+        @html_attributes = kwargs
       end
 
       def html
-        tag.fieldset(**options) do
+        tag.fieldset(**options, **@html_attributes) do
           safe_join([legend_element, (@block_content || yield)])
         end
       end

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -8,8 +8,9 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::FieldsetItem
         include Traits::Conditional
+        include Traits::HTMLAttributes
 
-        def initialize(builder, object_name, attribute_name, value, unchecked_value, label:, hint:, link_errors:, multiple:, &block)
+        def initialize(builder, object_name, attribute_name, value, unchecked_value, label:, hint:, link_errors:, multiple:, **kwargs, &block)
           super(builder, object_name, attribute_name)
 
           @value           = value
@@ -18,6 +19,7 @@ module GOVUKDesignSystemFormBuilder
           @hint            = hint
           @multiple        = multiple
           @link_errors     = link_errors
+          @html_attributes = kwargs
 
           if block_given?
             @conditional_content = wrap_conditional(block)
@@ -38,7 +40,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def check_box
-          @builder.check_box(@attribute_name, options, @value, @unchecked_value)
+          @builder.check_box(@attribute_name, attributes(@html_attributes), @value, @unchecked_value)
         end
 
         def options

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -9,20 +9,21 @@ module GOVUKDesignSystemFormBuilder
 
       SEGMENTS = { day: '3i', month: '2i', year: '1i' }.freeze
 
-      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, omit_day:, form_group:, wildcards:, date_of_birth: false, &block)
+      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, omit_day:, form_group:, wildcards:, date_of_birth: false, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @legend        = legend
-        @caption       = caption
-        @hint          = hint
-        @date_of_birth = date_of_birth
-        @omit_day      = omit_day
-        @form_group    = form_group
-        @wildcards     = wildcards
+        @legend          = legend
+        @caption         = caption
+        @hint            = hint
+        @date_of_birth   = date_of_birth
+        @omit_day        = omit_day
+        @form_group      = form_group
+        @wildcards       = wildcards
+        @html_attributes = kwargs
       end
 
       def html
-        Containers::FormGroup.new(@builder, @object_name, @attribute_name, **@form_group).html do
+        Containers::FormGroup.new(@builder, @object_name, @attribute_name, **@form_group, **@html_attributes).html do
           Containers::Fieldset.new(@builder, @object_name, @attribute_name, **fieldset_options).html do
             safe_join([supplemental_content, hint_element, error_element, date])
           end

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -2,18 +2,20 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     class ErrorSummary < Base
       include Traits::Error
+      include Traits::HTMLAttributes
 
-      def initialize(builder, object_name, title, link_base_errors_to:)
+      def initialize(builder, object_name, title, link_base_errors_to:, **kwargs)
         super(builder, object_name, nil)
 
         @title               = title
         @link_base_errors_to = link_base_errors_to
+        @html_attributes     = kwargs
       end
 
       def html
         return nil unless object_has_errors?
 
-        tag.div(class: summary_class, **summary_options) do
+        tag.div(class: summary_class, **attributes(@html_attributes)) do
           safe_join([title, summary])
         end
       end
@@ -70,7 +72,7 @@ module GOVUKDesignSystemFormBuilder
         @builder.object.errors.any?
       end
 
-      def summary_options
+      def options
         {
           tabindex: -1,
           role: 'alert',

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -15,7 +15,7 @@ module GOVUKDesignSystemFormBuilder
       def html
         return nil unless object_has_errors?
 
-        tag.div(class: summary_class, **attributes(@html_attributes)) do
+        tag.div(**attributes(@html_attributes)) do
           safe_join([title, summary])
         end
       end
@@ -48,6 +48,10 @@ module GOVUKDesignSystemFormBuilder
         '#'.concat(target)
       end
 
+      def classes
+        Array.wrap(summary_class)
+      end
+
       def summary_class(part = nil)
         if part
           %(#{brand}-error-summary).concat('__', part)
@@ -74,6 +78,7 @@ module GOVUKDesignSystemFormBuilder
 
       def options
         {
+          class: classes,
           tabindex: -1,
           role: 'alert',
           data: {

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -7,6 +7,7 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Hint
       include Traits::Label
       include Traits::Supplemental
+      include Traits::HTMLAttributes
 
       def initialize(builder, object_name, attribute_name, hint:, label:, caption:, form_group:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
@@ -27,7 +28,7 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def file
-        @builder.file_field(@attribute_name, **options, **@html_attributes)
+        @builder.file_field(@attribute_name, attributes(@html_attributes))
       end
 
       def options

--- a/lib/govuk_design_system_formbuilder/elements/inputs/email.rb
+++ b/lib/govuk_design_system_formbuilder/elements/inputs/email.rb
@@ -7,6 +7,7 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Label
         include Traits::Supplemental
+        include Traits::HTMLAttributes
 
       private
 

--- a/lib/govuk_design_system_formbuilder/elements/inputs/number.rb
+++ b/lib/govuk_design_system_formbuilder/elements/inputs/number.rb
@@ -7,6 +7,7 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Label
         include Traits::Supplemental
+        include Traits::HTMLAttributes
 
         def builder_method
           :number_field

--- a/lib/govuk_design_system_formbuilder/elements/inputs/password.rb
+++ b/lib/govuk_design_system_formbuilder/elements/inputs/password.rb
@@ -7,6 +7,7 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Label
         include Traits::Supplemental
+        include Traits::HTMLAttributes
 
         def builder_method
           :password_field

--- a/lib/govuk_design_system_formbuilder/elements/inputs/phone.rb
+++ b/lib/govuk_design_system_formbuilder/elements/inputs/phone.rb
@@ -7,6 +7,7 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Label
         include Traits::Supplemental
+        include Traits::HTMLAttributes
 
         def builder_method
           :phone_field

--- a/lib/govuk_design_system_formbuilder/elements/inputs/text.rb
+++ b/lib/govuk_design_system_formbuilder/elements/inputs/text.rb
@@ -7,6 +7,7 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Label
         include Traits::Supplemental
+        include Traits::HTMLAttributes
 
         def builder_method
           :text_field

--- a/lib/govuk_design_system_formbuilder/elements/inputs/url.rb
+++ b/lib/govuk_design_system_formbuilder/elements/inputs/url.rb
@@ -7,6 +7,7 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Label
         include Traits::Supplemental
+        include Traits::HTMLAttributes
 
         def builder_method
           :url_field

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -8,14 +8,16 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::FieldsetItem
         include Traits::Conditional
+        include Traits::HTMLAttributes
 
-        def initialize(builder, object_name, attribute_name, value, label:, hint:, link_errors:, &block)
+        def initialize(builder, object_name, attribute_name, value, label:, hint:, link_errors:, **kwargs, &block)
           super(builder, object_name, attribute_name)
 
-          @value       = value
-          @label       = label
-          @hint        = hint
-          @link_errors = has_errors? && link_errors
+          @value           = value
+          @label           = label
+          @hint            = hint
+          @link_errors     = has_errors? && link_errors
+          @html_attributes = kwargs
 
           if block_given?
             @conditional_content = wrap_conditional(block)
@@ -40,7 +42,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def input
-          @builder.radio_button(@attribute_name, @value, **options)
+          @builder.radio_button(@attribute_name, @value, **attributes(@html_attributes))
         end
 
         def options

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -19,6 +19,12 @@ module GOVUKDesignSystemFormBuilder
         @hint            = hint
         @form_group      = form_group
         @html_attributes = kwargs
+
+        # FIXME remove this soon, worth informing people who miss the release notes that the
+        #       args have changed though.
+        if :html_options.in?(kwargs.keys)
+          Rails.logger.warn("GOVUKDesignSystemFormBuilder: html_options has been deprecated, use keyword arguments instead")
+        end
       end
 
       def html

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -5,19 +5,20 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Label
       include Traits::Hint
       include Traits::Supplemental
+      include Traits::HTMLAttributes
 
-      def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint:, label:, caption:, form_group:, options: {}, html_options: {}, &block)
+      def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint:, label:, caption:, form_group:, options: {}, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @collection   = collection
-        @value_method = value_method
-        @text_method  = text_method
-        @options      = options
-        @html_options = html_options
-        @label        = label
-        @caption      = caption
-        @hint         = hint
-        @form_group   = form_group
+        @collection      = collection
+        @value_method    = value_method
+        @text_method     = text_method
+        @options         = options
+        @label           = label
+        @caption         = caption
+        @hint            = hint
+        @form_group      = form_group
+        @html_attributes = kwargs
       end
 
       def html
@@ -29,27 +30,23 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def select
-        @builder.collection_select(@attribute_name, @collection, @value_method, @text_method, @options, **options)
+        @builder.collection_select(@attribute_name, @collection, @value_method, @text_method, @options, **attributes(@html_attributes))
       end
 
       def options
-        @html_options.deep_merge(
+        {
           id: field_id(link_errors: true),
           class: classes,
           aria: { describedby: described_by(hint_id, error_id, supplemental_id) }
-        )
+        }
       end
 
       def classes
-        [%(#{brand}-select), error_class, custom_classes].flatten.compact
+        [%(#{brand}-select), error_class].flatten.compact
       end
 
       def error_class
         %(#{brand}-select--error) if has_errors?
-      end
-
-      def custom_classes
-        @html_options[:class]
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -2,8 +2,9 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     class Submit < Base
       using PrefixableArray
+      include Traits::HTMLAttributes
 
-      def initialize(builder, text, warning:, secondary:, classes:, prevent_double_click:, validate:, disabled:, &block)
+      def initialize(builder, text, warning:, secondary:, classes:, prevent_double_click:, validate:, disabled:, **kwargs, &block)
         super(builder, nil, nil)
 
         fail ArgumentError, 'buttons can be warning or secondary' if warning && secondary
@@ -15,6 +16,7 @@ module GOVUKDesignSystemFormBuilder
         @classes              = classes
         @validate             = validate
         @disabled             = disabled
+        @html_attributes      = kwargs
         @block_content        = capture { block.call } if block_given?
       end
 
@@ -33,7 +35,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def submit
-        @builder.submit(@text, class: classes, **options)
+        @builder.submit(@text, class: classes, **attributes(@html_attributes))
       end
 
       def classes

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -35,7 +35,19 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def submit
-        @builder.submit(@text, class: classes, **attributes(@html_attributes))
+        @builder.submit(@text, **attributes(@html_attributes))
+      end
+
+      def options
+        {
+          formnovalidate: !@validate,
+          disabled: @disabled,
+          class: classes,
+          data: {
+            module: %(#{brand}-button),
+            'prevent-double-click': @prevent_double_click
+          }.select { |_k, v| v.present? }
+        }
       end
 
       def classes
@@ -44,17 +56,6 @@ module GOVUKDesignSystemFormBuilder
           .push(warning_class, secondary_class, disabled_class, custom_classes)
           .flatten
           .compact
-      end
-
-      def options
-        {
-          formnovalidate: !@validate,
-          disabled: @disabled,
-          data: {
-            module: %(#{brand}-button),
-            'prevent-double-click': @prevent_double_click
-          }.select { |_k, v| v.present? }
-        }
       end
 
       def warning_class

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -7,6 +7,7 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Hint
       include Traits::Label
       include Traits::Supplemental
+      include Traits::HTMLAttributes
 
       def initialize(builder, object_name, attribute_name, hint:, label:, caption:, rows:, max_words:, max_chars:, threshold:, form_group:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
@@ -37,7 +38,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def text_area
-        @builder.text_area(@attribute_name, **options, **@html_attributes)
+        @builder.text_area(@attribute_name, **attributes(@html_attributes))
       end
 
       def classes

--- a/lib/govuk_design_system_formbuilder/traits/html_attributes.rb
+++ b/lib/govuk_design_system_formbuilder/traits/html_attributes.rb
@@ -2,7 +2,7 @@ module GOVUKDesignSystemFormBuilder
   module Traits
     module HTMLAttributes
       def attributes(html_attributes = {})
-        options.deep_merge(html_attributes)
+        options.deeper_merge(html_attributes)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/traits/html_attributes.rb
+++ b/lib/govuk_design_system_formbuilder/traits/html_attributes.rb
@@ -1,0 +1,9 @@
+module GOVUKDesignSystemFormBuilder
+  module Traits
+    module HTMLAttributes
+      def attributes(html_attributes = {})
+        options.deep_merge(html_attributes)
+      end
+    end
+  end
+end

--- a/lib/govuk_design_system_formbuilder/traits/input.rb
+++ b/lib/govuk_design_system_formbuilder/traits/input.rb
@@ -37,7 +37,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def input
-        @builder.send(builder_method, @attribute_name, **options, **@html_attributes)
+        @builder.send(builder_method, @attribute_name, **attributes(@html_attributes))
       end
 
       def affixed?

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
@@ -34,6 +34,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
+    it_behaves_like 'a field that allows extra HTML attributes to be set' do
+      let(:element) { 'input' }
+    end
+
     it_behaves_like 'a field that supports setting the label via localisation'
     it_behaves_like 'a field that supports setting the hint via localisation'
 

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
@@ -35,7 +35,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that allows extra HTML attributes to be set' do
-      let(:element) { 'input' }
+      let(:described_element) { 'input' }
+      let(:expected_class) { 'govuk-checkboxes__input' }
     end
 
     it_behaves_like 'a field that supports setting the label via localisation'

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -224,5 +224,13 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         expect(subject).to have_tag('input', with: { id: year_identifier, pattern: "[0-9]*" })
       end
     end
+
+    describe "additional attributes" do
+      subject { builder.send(*args, data: { test: "abc" }) }
+
+      specify "should have additional attributes" do
+        expect(subject).to have_tag('div', with: { 'data-test': 'abc' })
+      end
+    end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -5,7 +5,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   let(:method) { :govuk_error_summary }
 
   describe '#govuk_error_summary' do
-    subject { builder.send(method) }
+    let(:args) { [method] }
+    subject { builder.send(*args) }
 
     context 'when the object has errors' do
       before { object.valid? }
@@ -319,6 +320,14 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         specify 'the base field should be linked to' do
           expect(subject).to have_tag("a", text: error, with: { href: %(#person-base-field-error) })
         end
+      end
+    end
+
+    context 'extra attributes' do
+      before { object.valid? }
+
+      it_behaves_like 'a field that allows extra HTML attributes to be set' do
+        let(:element) { 'div' }
       end
     end
   end

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -327,7 +327,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       before { object.valid? }
 
       it_behaves_like 'a field that allows extra HTML attributes to be set' do
-        let(:element) { 'div' }
+        let(:described_element) { 'div' }
+        let(:expected_class) { 'govuk-error-summary' }
       end
     end
   end

--- a/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
@@ -10,11 +10,18 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     let(:example_block) { proc { builder.tag.span(inner_text) } }
 
+    let(:args) { [method] }
+    let(:kwargs) { { legend: legend_options } }
+
     subject do
-      builder.send(method, legend: legend_options, &example_block)
+      builder.send(*args, **kwargs, &example_block)
     end
 
     include_examples 'HTML formatting checks'
+
+    it_behaves_like 'a field that allows extra HTML attributes to be set' do
+      let(:element) { 'fieldset' }
+    end
 
     specify 'output should be a fieldset containing the block contents' do
       expect(subject).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
@@ -114,18 +121,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         specify 'output should contain no caption at all' do
           expect(subject).not_to have_tag('span', with: { class: caption_class })
         end
-      end
-    end
-
-    context 'additional attributes' do
-      subject do
-        builder.send(method, data: { test: 'abc' }) do
-          builder.govuk_text_field(:name)
-        end
-      end
-
-      specify 'field should have additional attributes' do
-        expect(subject).to have_tag('fieldset', with: { 'data-test': 'abc' })
       end
     end
   end

--- a/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
@@ -116,5 +116,17 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
     end
+
+    context 'additional attributes' do
+      subject do
+        builder.send(method, data: { test: 'abc' }) do
+          builder.govuk_text_field(:name)
+        end
+      end
+
+      specify 'field should have additional attributes' do
+        expect(subject).to have_tag('fieldset', with: { 'data-test': 'abc' })
+      end
+    end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
@@ -20,7 +20,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     include_examples 'HTML formatting checks'
 
     it_behaves_like 'a field that allows extra HTML attributes to be set' do
-      let(:element) { 'fieldset' }
+      let(:described_element) { 'fieldset' }
+      let(:expected_class) { 'govuk-fieldset' }
     end
 
     specify 'output should be a fieldset containing the block contents' do

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -47,20 +47,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports setting the label caption via localisation'
     it_behaves_like 'a field that supports setting the hint via localisation'
 
-    it_behaves_like 'a field that accepts a plain ruby object' do
-      let(:described_element) { ['input', { with: { type: 'file' } }] }
+    it_behaves_like 'a field that allows extra HTML attributes to be set' do
+      let(:element) { 'input' }
     end
 
-    describe 'additional attributes' do
-      subject { builder.send(method, attribute, accept: 'image/*', multiple: true, data: { test: 'abc' }) }
-
-      specify 'input should have additional attributes' do
-        expect(subject).to have_tag('input', with: {
-          accept: 'image/*',
-          multiple: 'multiple',
-          'data-test': 'abc'
-        })
-      end
+    it_behaves_like 'a field that accepts a plain ruby object' do
+      let(:described_element) { ['input', { with: { type: 'file' } }] }
     end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -48,7 +48,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports setting the hint via localisation'
 
     it_behaves_like 'a field that allows extra HTML attributes to be set' do
-      let(:element) { 'input' }
+      let(:described_element) { 'input' }
+      let(:expected_class) { 'govuk-file-upload' }
     end
 
     it_behaves_like 'a field that accepts a plain ruby object' do

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -52,12 +52,13 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     describe 'additional attributes' do
-      subject { builder.send(method, attribute, accept: 'image/*', multiple: true) }
+      subject { builder.send(method, attribute, accept: 'image/*', multiple: true, data: { test: 'abc' }) }
 
       specify 'input should have additional attributes' do
         expect(subject).to have_tag('input', with: {
           accept: 'image/*',
-          multiple: 'multiple'
+          multiple: 'multiple',
+          'data-test': 'abc'
         })
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
@@ -32,7 +32,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that allows extra HTML attributes to be set' do
-      let(:element) { 'input' }
+      let(:described_element) { 'input' }
+      let(:expected_class) { 'govuk-radios__input' }
     end
 
     it_behaves_like 'a field that supports setting the label via localisation'

--- a/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
@@ -31,6 +31,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
+    it_behaves_like 'a field that allows extra HTML attributes to be set' do
+      let(:element) { 'input' }
+    end
+
     it_behaves_like 'a field that supports setting the label via localisation'
     it_behaves_like 'a field that supports setting the hint via localisation'
 

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -33,6 +33,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:described_element) { 'select' }
     end
 
+    it_behaves_like 'a field that allows extra HTML attributes to be set' do
+      let(:element) { 'select' }
+    end
+
     it_behaves_like 'a field that supports setting the label via localisation'
     it_behaves_like 'a field that supports setting the label caption via localisation'
     it_behaves_like 'a field that supports setting the hint via localisation'
@@ -54,31 +58,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     specify 'select box should contain the correct values and entries' do
       colours.each do |colour|
         expect(subject).to have_tag('select > option', text: colour.name, with: { value: colour.id })
-      end
-    end
-
-    context 'extra attributes' do
-      let(:extra_args) do
-        {
-          required: { provided: true, output: 'required' },
-          autofocus: { provided: true, output: 'autofocus' },
-          data: { test: 'abc' }
-        }
-      end
-
-      subject { builder.send(*args, html_options: extract_args(extra_args, :provided)) }
-
-      specify 'select tag should have the extra attributes' do
-        select_tag = parsed_subject.at_css('select')
-        extract_args(extra_args, :output).each do |key, val|
-          if key == 'data' && val.respond_to?('each')
-            val.each do |dataKey, dataVal|
-              expect(select_tag[%(data-#{key})]).to eql(dataVal)
-            end
-          else
-            expect(select_tag[key]).to eql(val)
-          end
-        end
       end
     end
 

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -34,7 +34,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that allows extra HTML attributes to be set' do
-      let(:element) { 'select' }
+      let(:described_element) { 'select' }
+      let(:expected_class) { 'govuk-select' }
     end
 
     it_behaves_like 'a field that supports setting the label via localisation'
@@ -58,16 +59,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     specify 'select box should contain the correct values and entries' do
       colours.each do |colour|
         expect(subject).to have_tag('select > option', text: colour.name, with: { value: colour.id })
-      end
-    end
-
-    context 'when custom classes are supplied via html_options' do
-      let(:custom_classes) { %w(fancy-select purple) }
-
-      subject { builder.send(*args, html_options: { class: custom_classes }) }
-
-      specify %(the select element should have the provided classes) do
-        expect(subject).to have_tag('select', with: { class: custom_classes.push('govuk-select') })
       end
     end
 

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -71,5 +71,18 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         expect(subject).to have_tag('option', text: selected_colour.name, with: { selected: 'selected', value: selected_colour.id })
       end
     end
+
+    # FIXME temporary only, ensure deprecation message is properly logged
+    context 'when legacy html_options argument is provided' do
+      subject { builder.send(*args, html_options: { data: { magic: true } }) }
+      let(:logger) { Logger.new($stdout) }
+
+      before { allow(Rails).to receive_message_chain(:logger, :warn) }
+      before { subject }
+
+      specify do
+        expect(Rails.logger).to have_received(:warn).with(/html_options has been deprecated/)
+      end
+    end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -61,7 +61,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:extra_args) do
         {
           required: { provided: true, output: 'required' },
-          autofocus: { provided: true, output: 'autofocus' }
+          autofocus: { provided: true, output: 'autofocus' },
+          data: { test: 'abc' }
         }
       end
 
@@ -70,7 +71,13 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       specify 'select tag should have the extra attributes' do
         select_tag = parsed_subject.at_css('select')
         extract_args(extra_args, :output).each do |key, val|
-          expect(select_tag[key]).to eql(val)
+          if key == 'data' && val.respond_to?('each')
+            val.each do |dataKey, dataVal|
+              expect(select_tag[%(data-#{key})]).to eql(dataVal)
+            end
+          else
+            expect(select_tag[key]).to eql(val)
+          end
         end
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -161,5 +161,18 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
     end
+
+    describe 'extra arguments' do
+      subject { builder.send(*args.push('Create'), data: { test: 'abc' }) }
+
+      specify 'should add the extra attributes to the submit' do
+        expect(subject).to have_tag(
+          'input',
+          with: {
+            'data-test': 'abc'
+          }
+        )
+      end
+    end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -18,7 +18,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     it_behaves_like 'a field that allows extra HTML attributes to be set' do
-      let(:element) { 'input' }
+      let(:described_element) { 'input' }
+      let(:expected_class) { 'govuk-button' }
     end
 
     specify 'output should be a submit input' do

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -17,6 +17,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:block_content) { -> { %(Example) } }
     end
 
+    it_behaves_like 'a field that allows extra HTML attributes to be set' do
+      let(:element) { 'input' }
+    end
+
     specify 'output should be a submit input' do
       expect(subject).to have_tag('input', with: { type: 'submit' })
     end

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -161,18 +161,5 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
     end
-
-    describe 'extra arguments' do
-      subject { builder.send(*args.push('Create'), data: { test: 'abc' }) }
-
-      specify 'should add the extra attributes to the submit' do
-        expect(subject).to have_tag(
-          'input',
-          with: {
-            'data-test': 'abc'
-          }
-        )
-      end
-    end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -193,14 +193,15 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
   describe 'extra arguments' do
     let(:placeholder) { 'Once upon a time…' }
-    subject { builder.send(*args, placeholder: placeholder, required: true) }
+    subject { builder.send(*args, placeholder: placeholder, required: true, data: { test: 'abc' }) }
 
     specify 'should add the extra attributes to the textarea' do
       expect(subject).to have_tag(
         'textarea',
         with: {
           placeholder: placeholder,
-          required: 'required'
+          required: 'required',
+          'data-test': 'abc'
         }
       )
     end

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -67,7 +67,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   it_behaves_like 'a field that supports setting the hint via localisation'
 
   it_behaves_like 'a field that allows extra HTML attributes to be set' do
-    let(:element) { 'textarea' }
+    let(:described_element) { 'textarea' }
+    let(:expected_class) { 'govuk-textarea' }
   end
 
   it_behaves_like 'a field that accepts a plain ruby object' do

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -66,6 +66,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   it_behaves_like 'a field that supports setting the label caption via localisation'
   it_behaves_like 'a field that supports setting the hint via localisation'
 
+  it_behaves_like 'a field that allows extra HTML attributes to be set' do
+    let(:element) { 'textarea' }
+  end
+
   it_behaves_like 'a field that accepts a plain ruby object' do
     let(:described_element) { 'textarea' }
   end
@@ -188,22 +192,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       specify 'should have the overriden number of rows' do
         expect(subject).to have_tag('textarea', with: { rows: rows })
       end
-    end
-  end
-
-  describe 'extra arguments' do
-    let(:placeholder) { 'Once upon a time…' }
-    subject { builder.send(*args, placeholder: placeholder, required: true, data: { test: 'abc' }) }
-
-    specify 'should add the extra attributes to the textarea' do
-      expect(subject).to have_tag(
-        'textarea',
-        with: {
-          placeholder: placeholder,
-          required: 'required',
-          'data-test': 'abc'
-        }
-      )
     end
   end
 end

--- a/spec/support/logger.rb
+++ b/spec/support/logger.rb
@@ -1,0 +1,5 @@
+module Rails
+  def self.logger
+    Logger.new($stdout)
+  end
+end

--- a/spec/support/shared/shared_html_attribute_examples.rb
+++ b/spec/support/shared/shared_html_attribute_examples.rb
@@ -4,7 +4,8 @@ shared_examples 'a field that allows extra HTML attributes to be set' do
     autocomplete: { provided: false,             expected: 'false' },
     placeholder:  { provided: 'Seymour Skinner', expected: 'Seymour Skinner' },
     data:         { provided: { a: 'b' },        expected: { 'data-a' => 'b' } },
-    aria:         { provided: { c: 'd' },        expected: { 'aria-c' => 'd' } }
+    aria:         { provided: { c: 'd' },        expected: { 'aria-c' => 'd' } },
+    class:        { provided: %w(red spots),     expected: %w(red spots) }
   }
 
   let(:custom_attributes) { custom_attributes }
@@ -18,19 +19,31 @@ shared_examples 'a field that allows extra HTML attributes to be set' do
 
   describe 'input tag should have the extra attributes:' do
     extract_args(custom_attributes, :expected).each do |key, val|
+      case
+
+      # class is dealt with as a special case because we want to ensure that whatever
+      # extra classes we provide are *added* to the pre-existing one (expected_class)
+      # instead of replacing it
+      when key == :class
+        specify "#{key} has classes #{val}" do
+          expect(subject).to have_tag(described_element, with: { class: val.concat(Array.wrap(expected_class)) })
+        end
+
       # we need to deal with the _special keys_, data and aria, separately
       # because Rails accepts them via a nested hash and automatically expands
       # them out; e.g,
       # tag.element(data: { a: 'b' }) will result in <element data-a="b" ...>
-      if key.in?(special_keys)
+      when key.in?(special_keys)
         specify "#{val} is set" do
           val.each do |data_attribute_name, data_attribute_value|
-            expect(subject).to have_tag(element, with: { data_attribute_name => data_attribute_value })
+            expect(subject).to have_tag(described_element, with: { data_attribute_name => data_attribute_value })
           end
         end
+
+      # all others, just check that the attribute has been set properly
       else
         specify "#{key} is #{val}" do
-          expect(subject).to have_tag(element, with: { key => val })
+          expect(subject).to have_tag(described_element, with: { key => val })
         end
       end
     end

--- a/spec/support/shared/shared_html_attribute_examples.rb
+++ b/spec/support/shared/shared_html_attribute_examples.rb
@@ -1,0 +1,36 @@
+shared_examples 'a field that allows extra HTML attributes to be set' do
+  custom_attributes = {
+    required:     { provided: true,              expected: 'required' },
+    autocomplete: { provided: false,             expected: 'false' },
+    placeholder:  { provided: 'Seymour Skinner', expected: 'Seymour Skinner' },
+    data:         { provided: { a: 'b' },        expected: { 'data-a' => 'b' } },
+    aria:         { provided: { c: 'd' },        expected: { 'aria-c' => 'd' } }
+  }
+
+  let(:custom_attributes) { custom_attributes }
+  special_keys = %i(data aria)
+
+  subject do
+    builder.send(*args, **extract_args(custom_attributes, :provided))
+  end
+
+  describe 'input tag should have the extra attributes:' do
+    extract_args(custom_attributes, :expected).each do |key, val|
+      # we need to deal with the _special keys_, data and aria, separately
+      # because Rails accepts them via a nested hash and automatically expands
+      # them out; e.g,
+      # tag.element(data: { a: 'b' }) will result in <element data-a="b" ...>
+      if key.in?(special_keys)
+        specify "#{val} is set" do
+          val.each do |data_attribute_name, data_attribute_value|
+            expect(subject).to have_tag(element, with: { data_attribute_name => data_attribute_value })
+          end
+        end
+      else
+        specify "#{key} is #{val}" do
+          expect(subject).to have_tag(element, with: { key => val })
+        end
+      end
+    end
+  end
+end

--- a/spec/support/shared/shared_html_attribute_examples.rb
+++ b/spec/support/shared/shared_html_attribute_examples.rb
@@ -8,10 +8,12 @@ shared_examples 'a field that allows extra HTML attributes to be set' do
   }
 
   let(:custom_attributes) { custom_attributes }
+
+  let(:example_block) { proc { builder.tag.span('block text') } }
   special_keys = %i(data aria)
 
   subject do
-    builder.send(*args, **extract_args(custom_attributes, :provided))
+    builder.send(*args, **extract_args(custom_attributes, :provided), &example_block)
   end
 
   describe 'input tag should have the extra attributes:' do

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -50,27 +50,8 @@ shared_examples 'a regular input' do |method_identifier, field_type|
     let(:described_element) { 'input' }
   end
 
-  context 'extra attributes' do
-    let(:regular_args) { { label: { text: 'What should we call you?' } } }
-
-    let(:extra_args) do
-      {
-        required: { provided: true, output: 'required' },
-        autocomplete: { provided: false, output: 'false' },
-        placeholder: { provided: 'Seymour Skinner', output: 'Seymour Skinner' }
-      }
-    end
-
-    subject do
-      builder.send(*args, **regular_args.merge(extract_args(extra_args, :provided)))
-    end
-
-    specify 'input tag should have the extra attributes' do
-      input_tag = parsed_subject.at_css('input')
-      extract_args(extra_args, :output).each do |key, val|
-        expect(input_tag[key]).to eql(val)
-      end
-    end
+  it_behaves_like 'a field that allows extra HTML attributes to be set' do
+    let(:element) { 'input' }
   end
 
   describe 'width' do

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -51,7 +51,8 @@ shared_examples 'a regular input' do |method_identifier, field_type|
   end
 
   it_behaves_like 'a field that allows extra HTML attributes to be set' do
-    let(:element) { 'input' }
+    let(:described_element) { 'input' }
+    let(:expected_class) { 'govuk-input' }
   end
 
   describe 'width' do


### PR DESCRIPTION
This is quite a big change but adds plenty of flexibility and standardises the way we assign HTML attributes.

Previously some helpers automatically applied any unrecognised keyword arguments as HTML attributes on the input element, but `#govuk_select` worked differently and they were assigned using `html_options` (like Rails).

Now, all the helpers that output a single input element (ie, everything except the radio button and check box collections and the date field which is comprised of 3 inputs) can have their attributes set using keyword args:

```
= govuk_file_field :photo, accept: ".jpg,.jpeg,.tiff,.heif"
```

This is inkeeping with the behaviour of `label`, `hint`, `legend`, `caption` and `form_group` hashes that already have this functionality.

Fixes #249, #250, #252