### PR TITLE
Add guide section on permitting date params

### DIFF
--- a/guide/content/form-elements/date-field.slim
+++ b/guide/content/form-elements/date-field.slim
@@ -9,6 +9,20 @@ p.govuk-body
     of an event.
 
 p.govuk-body
+  | The date field's parameters match those used by Rails' <code>date_select</code> 
+    helper. To access the parameters in your controller you should just need to permit
+    the attribute, for example:
+
+.code-sample
+  pre
+    code.highlight.language-ruby
+      | # in UsersController
+
+        def user_params
+          params.require(:user).permit(:date_of_birth, ...)
+        end
+
+p.govuk-body
   | Three inputs for day, month and year respectively are used to
     capture the dates rather than a date picker. This is because:
 


### PR DESCRIPTION
I think this has confused a few people in the past. It's not clear _why_ this library opts to use Rails-style [multi-parameter assignment](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/attribute_assignment.rb#L34), which results in date params that look like `date_of_birth(1i)`.