### PR TITLE
Allow date inputs to set default values for multi-parameter attributes that aren't date objects

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -842,6 +842,7 @@ module GOVUKDesignSystemFormBuilder
     # @note When using this input be aware that Rails's multiparam time and date handling falls foul
     #   of {https://bugs.ruby-lang.org/issues/5988 this} bug, so incorrect dates like +2019-09-31+ will
     #   be 'rounded' up to +2019-10-01+.
+    # @note When using this input values will be retrieved from the attribute if it is a Date object or a multiparam date hash
     # @param attribute_name [Symbol] The name of the attribute
     # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
     #   supplied the hint will be wrapped in a +div+ instead of a +span+

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -8,6 +8,7 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Supplemental
 
       SEGMENTS = { day: '3i', month: '2i', year: '1i' }.freeze
+      MULTIPARAMETER_KEY = { day: 3, month: 2, year: 1 }.freeze
 
       def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, omit_day:, form_group:, wildcards:, date_of_birth: false, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
@@ -61,13 +62,17 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def date_part(segment, width:, link_errors: false)
-        value = @builder.object.try(@attribute_name).try(segment)
-
         tag.div(class: %(#{brand}-date-input__item)) do
           tag.div(class: %(#{brand}-form-group)) do
-            safe_join([label(segment, link_errors), input(segment, link_errors, width, value)])
+            safe_join([label(segment, link_errors), input(segment, link_errors, width, value(segment))])
           end
         end
+      end
+
+      def value(segment)
+        attribute = @builder.object.try(@attribute_name)
+
+        attribute.try(segment) || attribute.try(:[], MULTIPARAMETER_KEY[segment])
       end
 
       def label(segment, link_errors)

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -166,32 +166,65 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:birth_day) { 3 }
       let(:birth_month) { 2 }
       let(:birth_year) { 1970 }
-      let(:object) do
-        Person.new(
-          name: 'Joey',
-          born_on: Date.new(birth_year, birth_month, birth_day)
-        )
+
+      context "when the attribute is a `Date` object" do
+        let(:object) do
+          Person.new(
+            name: 'Joey',
+            born_on: Date.new(birth_year, birth_month, birth_day)
+          )
+        end
+
+        specify 'should set the day value correctly' do
+          expect(subject).to have_tag('input', with: {
+            id: day_identifier,
+            value: birth_day
+          })
+        end
+
+        specify 'should set the month value correctly' do
+          expect(subject).to have_tag('input', with: {
+            id: month_identifier,
+            value: birth_month
+          })
+        end
+
+        specify 'should set the year value correctly' do
+          expect(subject).to have_tag('input', with: {
+            id: year_identifier,
+            value: birth_year
+          })
+        end
       end
 
-      specify 'should set the day value correctly' do
-        expect(subject).to have_tag('input', with: {
-          id: day_identifier,
-          value: birth_day
-        })
-      end
+      context "when the attribute is a multiparameter hash object" do
+        let(:object) do
+          Person.new(
+            name: 'Joey',
+            born_on: { 3 => birth_day, 2 => birth_month, 1 => birth_year }
+          )
+        end
 
-      specify 'should set the month value correctly' do
-        expect(subject).to have_tag('input', with: {
-          id: month_identifier,
-          value: birth_month
-        })
-      end
+        specify 'should set the day value correctly' do
+          expect(subject).to have_tag('input', with: {
+            id: day_identifier,
+            value: birth_day
+          })
+        end
 
-      specify 'should set the year value correctly' do
-        expect(subject).to have_tag('input', with: {
-          id: year_identifier,
-          value: birth_year
-        })
+        specify 'should set the month value correctly' do
+          expect(subject).to have_tag('input', with: {
+            id: month_identifier,
+            value: birth_month
+          })
+        end
+
+        specify 'should set the year value correctly' do
+          expect(subject).to have_tag('input', with: {
+            id: year_identifier,
+            value: birth_year
+          })
+        end
       end
     end
 


### PR DESCRIPTION
In teaching vacancies we use a form model pattern which means sometimes the form builder renders date inputs where the builder object date attribute doesn't respond to `:day`, `:month`, `:year`. 

Rather than default values being blank, it would be nice to fallback to retrieving the values from the multi-parameter hash. 

Another approach would be for us to initialise date objects in our form models, but I'd rather the form builder supported this!