### PR TITLE
Add basic select helper

### DIFF
--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency("sassc", "~> 2.4.0")
   s.add_development_dependency("sass")
   s.add_development_dependency("slim", "~> 4.1.0")
-  s.add_development_dependency("puma", "~> 5.2")
+  s.add_development_dependency("webrick", "~> 1.7.0")
 end

--- a/guide/content/form-elements/select.slim
+++ b/guide/content/form-elements/select.slim
@@ -5,14 +5,15 @@ title: Select boxes
 h1.govuk-heading-xl Select field
 
 p.govuk-body
-  | The select component allows users to choose an option from a long list.
+  | The select and collection select components allow users to choose an option
+    from a long list.
 
 p.govuk-body
-  | Before using the select component try asking users questions which will
+  | Before using a select component try asking users questions which will
     allow you to present them with fewer options.
 
 p.govuk-body
-  | Asking questions means you’re less likely to need to use the select
+  | Asking questions means you're less likely to need to use the select
     component and can consider using a different solution, such as radios.
 
 section
@@ -21,5 +22,28 @@ section
     caption: "Select field with a label and hint",
     code: select_field_with_label_and_hint,
     sample_data: departments_data_raw)
+
+  == render('/partials/example-fig.*',
+    caption: "Taking greater control over the options",
+    code: select_field_with_grouped_options,
+    sample_data: grouped_lunch_options_raw) do
+
+    p.govuk-body
+      | The <code>#govuk_select</code> helper offers extra control over the
+        contents of a <code>select</code> element. Like its Rails counterpart,
+        <code>#select</code> the options can be set in a number of ways:
+
+      ul.govuk-list.govuk-list--bullet
+        li
+          | #{link_to('<code>options_for_select</code>', rails_option_for_select_link).html_safe}
+        li
+          | #{link_to('<code>grouped_options_for_select</code>', rails_grouped_option_for_select_link).html_safe}
+        li
+          | #{link_to('<code>options_from_collection_for_select</code>', rails_options_from_collection_for_select_link).html_safe}
+        li
+          | #{link_to('<code>option_groups_from_collection_for_select</code>', rails_option_groups_from_collection_for_select_link).html_safe}
+        li
+          | manually specifying the options using a block of HTML
+          
 
 == render('/partials/related-info.*', links: select_info)

--- a/guide/lib/examples/select.rb
+++ b/guide/lib/examples/select.rb
@@ -10,5 +10,16 @@ module Examples
           hint: { text: "You can find it on your ID badge" }
       SNIPPET
     end
+
+    def select_field_with_grouped_options
+      <<~SNIPPET
+        = f.govuk_select(:lunch_id, label: { text: "Preferred lunch", size: "m" }) do
+          - grouped_lunch_options.each do |group_name, menu_items|
+            optgroup label=group_name
+              - menu_items.each do |name, value|
+                option value=value data-tags=name.downcase
+                  = name
+      SNIPPET
+    end
   end
 end

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -1,6 +1,7 @@
 require 'pry'
 require 'action_view'
 require 'active_model'
+require 'active_support/core_ext/string'
 require 'htmlbeautifier'
 require 'slim/erb_converter'
 

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -93,5 +93,21 @@ module Helpers
     def rails_checkbox_gotcha_link
       'https://api.rubyonrails.org/v6.1/classes/ActionView/Helpers/FormHelper.html#method-i-check_box-label-Gotcha'
     end
+
+    def rails_option_for_select_link
+      'https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-options_for_select'
+    end
+
+    def rails_grouped_option_for_select_link
+      'https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-grouped_options_for_select'
+    end
+
+    def rails_option_groups_from_collection_for_select_link
+      'https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-option_groups_from_collection_for_select'
+    end
+
+    def rails_options_from_collection_for_select_link
+      'https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-options_from_collection_for_select'
+    end
   end
 end

--- a/guide/lib/setup/example_data.rb
+++ b/guide/lib/setup/example_data.rb
@@ -48,6 +48,15 @@ module Setup
       DATA
     end
 
+    def grouped_lunch_options_raw
+      <<~DATA
+        grouped_lunch_options = {
+          "Sandwiches" => { "Ploughman's lunch" => :pl, "Tuna mayo" => :tm },
+          "Salads" => { "Greek salad" => :gs, "Tabbouleh" => :tb }
+        }
+      DATA
+    end
+
     def primary_colours_raw
       <<~DATA
         primary_colours = [
@@ -106,6 +115,10 @@ module Setup
       eval(lunch_options_raw)
     end
 
+    def grouped_lunch_options
+      eval(grouped_lunch_options_raw)
+    end
+
     def primary_colours
       eval(primary_colours_raw)
     end
@@ -125,6 +138,7 @@ module Setup
         departments_collection: departments_collection,
         contact_types: contact_types,
         lunch_options: lunch_options,
+        grouped_lunch_options: grouped_lunch_options,
         primary_colours: primary_colours,
         laptops: laptops
       }

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -429,6 +429,10 @@ module GOVUKDesignSystemFormBuilder
       ).html
     end
 
+    def govuk_select(attribute_name, choices, options: {}, label: {}, hint: {}, form_group: {}, caption: {}, **kwargs, &block)
+      Elements::Select.new(self, object_name, attribute_name, choices, options: options, label: label, hint: hint, form_group: form_group, caption: caption, **kwargs, &block).html
+    end
+
     # Generates a radio button for each item in the supplied collection
     #
     # @note Unlike the Rails +#collection_radio_buttons+ helper, this version can also insert

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -429,7 +429,7 @@ module GOVUKDesignSystemFormBuilder
       ).html
     end
 
-    def govuk_select(attribute_name, choices, options: {}, label: {}, hint: {}, form_group: {}, caption: {}, **kwargs, &block)
+    def govuk_select(attribute_name, choices = nil, options: {}, label: {}, hint: {}, form_group: {}, caption: {}, **kwargs, &block)
       Elements::Select.new(self, object_name, attribute_name, choices, options: options, label: label, hint: hint, form_group: form_group, caption: caption, **kwargs, &block).html
     end
 

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -381,6 +381,7 @@ module GOVUKDesignSystemFormBuilder
     #   supplied the hint will be wrapped in a +div+ instead of a +span+
     # @option hint text [String] the hint text
     # @option hint kwargs [Hash] additional arguments are applied as attributes to the hint
+    # @param label [Hash,Proc] configures or sets the associated label content
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
     # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
@@ -429,6 +430,38 @@ module GOVUKDesignSystemFormBuilder
       ).html
     end
 
+    # Generates a +select+ element containing an +option+ for every choice provided
+    #
+    # @param attribute_name [Symbol] The name of the attribute
+    # @param choices [Array,Hash] The +option+ values, usually provided via
+    #   the +options_for_select+ or +grouped_options_for_select+ helpers.
+    # @param options [Hash] Options hash passed through to Rails' +select+ helper
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint kwargs [Hash] additional arguments are applied as attributes to the hint
+    # @param label [Hash,Proc] configures or sets the associated label content
+    # @option label text [String] the label text
+    # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
+    # @option label tag [Symbol,String] the label's wrapper tag, intended to allow labels to act as page headings
+    # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
+    # @option label kwargs [Hash] additional arguments are applied as attributes on the +label+ element
+    # @param form_group [Hash] configures the form group
+    # @option form_group classes [Array,String] sets the form group's classes
+    # @option form_group kwargs [Hash] additional attributes added to the form group
+    # @param block [Block] build the contents of the select element manually for exact control
+    # @see https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-select Rails select (called by govuk_collection_select)
+    # @return [ActiveSupport::SafeBuffer] HTML output
+    #
+    # @example A select box with custom data attributes
+    #
+    #   @colours = [
+    #     ["PapayaWhip", "pw",  { data: { hex: "#ffefd5" } }],
+    #     ["Chocolate", "choc", { data: { hex: "#d2691e" } }],
+    #   ]
+    #
+    #   = f.govuk_select :hat_colour, options_for_select(@colours)
+    #
     def govuk_select(attribute_name, choices = nil, options: {}, label: {}, hint: {}, form_group: {}, caption: {}, **kwargs, &block)
       Elements::Select.new(self, object_name, attribute_name, choices, options: options, label: label, hint: hint, form_group: form_group, caption: caption, **kwargs, &block).html
     end

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -412,7 +412,7 @@ module GOVUKDesignSystemFormBuilder
     #     label: -> { tag.h3("Which team did you represent?") }
     #
     def govuk_collection_select(attribute_name, collection, value_method, text_method, options: {}, hint: {}, label: {}, caption: {}, form_group: {}, **kwargs, &block)
-      Elements::Select.new(
+      Elements::CollectionSelect.new(
         self,
         object_name,
         attribute_name,

--- a/lib/govuk_design_system_formbuilder/elements/collection_select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/collection_select.rb
@@ -6,6 +6,7 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Hint
       include Traits::Supplemental
       include Traits::HTMLAttributes
+      include Traits::Select
 
       def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint:, label:, caption:, form_group:, options: {}, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
@@ -35,10 +36,6 @@ module GOVUKDesignSystemFormBuilder
 
     private
 
-      def collection_select
-        @builder.collection_select(@attribute_name, @collection, @value_method, @text_method, @options, **attributes(@html_attributes))
-      end
-
       def options
         {
           id: field_id(link_errors: true),
@@ -47,12 +44,8 @@ module GOVUKDesignSystemFormBuilder
         }
       end
 
-      def classes
-        [%(#{brand}-select), error_class].flatten.compact
-      end
-
-      def error_class
-        %(#{brand}-select--error) if has_errors?
+      def collection_select
+        @builder.collection_select(@attribute_name, @collection, @value_method, @text_method, @options, **attributes(@html_attributes))
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/collection_select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/collection_select.rb
@@ -1,6 +1,6 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
-    class Select < Base
+    class CollectionSelect < Base
       include Traits::Error
       include Traits::Label
       include Traits::Hint
@@ -29,13 +29,13 @@ module GOVUKDesignSystemFormBuilder
 
       def html
         Containers::FormGroup.new(*bound, **@form_group).html do
-          safe_join([label_element, supplemental_content, hint_element, error_element, select])
+          safe_join([label_element, supplemental_content, hint_element, error_element, collection_select])
         end
       end
 
     private
 
-      def select
+      def collection_select
         @builder.collection_select(@attribute_name, @collection, @value_method, @text_method, @options, **attributes(@html_attributes))
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -1,0 +1,43 @@
+module GOVUKDesignSystemFormBuilder
+  module Elements
+    class Select < Base
+      include Traits::Error
+      include Traits::Label
+      include Traits::Hint
+      include Traits::HTMLAttributes
+      include Traits::Select
+
+      def initialize(builder, object_name, attribute_name, choices, options:, form_group:, label:, hint:, caption:, **kwargs, &block)
+        super(builder, object_name, attribute_name, &block)
+
+        @form_group      = form_group
+        @hint            = hint
+        @label           = label
+        @caption         = caption
+        @choices         = choices
+        @options         = options
+        @html_attributes = kwargs
+      end
+
+      def html
+        Containers::FormGroup.new(*bound, **@form_group).html do
+          safe_join([label_element, hint_element, error_element, select])
+        end
+      end
+
+    private
+
+      def select
+        @builder.select(@attribute_name, (@choices || @block_content), @options, **attributes(@html_attributes))
+      end
+
+      def options
+        {
+          id: field_id(link_errors: true),
+          class: classes,
+          aria: { describedby: described_by(hint_id, error_id) }
+        }
+      end
+    end
+  end
+end

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -8,7 +8,10 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Select
 
       def initialize(builder, object_name, attribute_name, choices, options:, form_group:, label:, hint:, caption:, **kwargs, &block)
-        super(builder, object_name, attribute_name, &block)
+        # assign the block to an variable rather than passing to super so
+        # we can send it through to #select
+        super(builder, object_name, attribute_name)
+        @block           = block
 
         @form_group      = form_group
         @hint            = hint
@@ -28,7 +31,7 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def select
-        @builder.select(@attribute_name, (@choices || @block_content), @options, **attributes(@html_attributes))
+        @builder.select(@attribute_name, @choices, @options, attributes(@html_attributes), &@block)
       end
 
       def options

--- a/lib/govuk_design_system_formbuilder/traits/select.rb
+++ b/lib/govuk_design_system_formbuilder/traits/select.rb
@@ -1,0 +1,15 @@
+module GOVUKDesignSystemFormBuilder
+  module Traits
+    module Select
+    private
+
+      def classes
+        [%(#{brand}-select), error_class].flatten.compact
+      end
+
+      def error_class
+        %(#{brand}-select--error) if has_errors?
+      end
+    end
+  end
+end

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -128,7 +128,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       colour_names.each { |cn| expect(subject).to have_tag('select > option', with: { value: cn }, text: cn) }
     end
 
-    context 'when a block of options is passed in' do
+    context 'blocks' do
       let(:items) { %w(LemonChiffon PaleTurquoise FloralWhite Bisque) }
 
       let(:sample_block) do
@@ -142,6 +142,49 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       specify 'the block content should be rendered inside the select element' do
         items.each do |web_colour|
           expect(subject).to have_tag('select > option', text: web_colour, with: { value: web_colour })
+        end
+      end
+    end
+
+    context 'options_for_select' do
+      let(:items) { %w(Firebrick Peachpuff Honeydew Orhid) }
+
+      let(:options_for_select) do
+        helper.options_for_select(items.map { |web_colour| [web_colour, web_colour.downcase] })
+      end
+
+      subject do
+        builder.send(method, attribute, options_for_select)
+      end
+
+      specify 'the options should be present in the select element' do
+        items.each do |web_colour|
+          expect(subject).to have_tag('select > option', text: web_colour, with: { value: web_colour.downcase })
+        end
+      end
+    end
+
+    context 'grouped_options_for_select' do
+      let(:items) do
+        {
+          "Reds" => [%w(Tomato tomato), %w(Crimson crimson)],
+          "Blues" => [%w(Navy navy), %w(PowderBlue powderblue)],
+        }
+      end
+
+      let(:grouped_options_for_select) do
+        helper.grouped_options_for_select(items)
+      end
+
+      subject do
+        builder.send(method, attribute, grouped_options_for_select)
+      end
+
+      specify 'the options should be grouped in the correct optgroup' do
+        items.each do |group, colours|
+          expect(subject).to have_tag('select > optgroup', with: { label: group }) do
+            colours.each { |name, value| with_tag('option', text: name, with: { value: value }) }
+          end
         end
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -127,5 +127,23 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     specify 'the select element has the right options' do
       colour_names.each { |cn| expect(subject).to have_tag('select > option', with: { value: cn }, text: cn) }
     end
+
+    context 'when a block of options is passed in' do
+      let(:items) { %w(LemonChiffon PaleTurquoise FloralWhite Bisque) }
+
+      let(:sample_block) do
+        helper.safe_join(items.map { |web_colour| helper.tag.option(web_colour, value: web_colour) })
+      end
+
+      subject do
+        builder.send(method, attribute) { sample_block }
+      end
+
+      specify 'the block content should be rendered inside the select element' do
+        items.each do |web_colour|
+          expect(subject).to have_tag('select > option', text: web_colour, with: { value: web_colour })
+        end
+      end
+    end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -164,6 +164,37 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
+    context 'options_for_select with custom attributes' do
+      let(:custom_data_attribute) { :hex }
+      let(:options_for_select_with_attributes) do
+        [
+          ["PapayaWhip", "pw",  { data: { custom_data_attribute => "#ffefd5" } }],
+          ["Chocolate", "choc", { data: { custom_data_attribute => "#d2691e" } }],
+        ]
+      end
+
+      let(:options_for_select) { helper.options_for_select(options_for_select_with_attributes) }
+
+      subject do
+        builder.send(method, attribute, options_for_select_with_attributes)
+      end
+
+      specify 'the options with their custom attributes should be present in the select element' do
+        expect(subject).to have_tag('select') do
+          options_for_select_with_attributes.each do |colour_name, value, custom_attributes|
+            with_tag(
+              'option',
+              text: colour_name,
+              with: {
+                :value => value,
+                %(data-#{custom_data_attribute}) => custom_attributes.dig(:data, custom_data_attribute)
+              }
+            )
+          end
+        end
+      end
+    end
+
     context 'grouped_options_for_select' do
       let(:items) do
         {

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -121,7 +121,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     specify 'a select element is rendered' do
-      expect(subject).to have_tag('select', with: { class: "govuk-select" })
+      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+        with_tag('select', with: { class: "govuk-select" })
+      end
     end
 
     specify 'the select element has the right options' do

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -2,6 +2,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   include_context 'setup builder'
   include_context 'setup examples'
 
+  let(:field_type) { 'select' }
+  let(:aria_described_by_target) { 'select' }
+
   describe '#govuk_collection_select' do
     let(:attribute) { :favourite_colour }
     let(:label_text) { 'Cherished shade' }
@@ -9,9 +12,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     let(:method) { :govuk_collection_select }
     let(:args) { [method, attribute, colours, :id, :name] }
     subject { builder.send(*args) }
-
-    let(:field_type) { 'select' }
-    let(:aria_described_by_target) { 'select' }
 
     include_examples 'HTML formatting checks'
 
@@ -83,6 +83,49 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       specify do
         expect(Rails.logger).to have_received(:warn).with(/html_options has been deprecated/)
       end
+    end
+  end
+
+  describe "#govuk_select" do
+    let(:attribute) { :favourite_colour }
+    let(:label_text) { 'Prized tint' }
+    let(:hint_text) { 'The colour of your favourite cravat' }
+    let(:method) { :govuk_select }
+    let(:options_for_select) { colour_names }
+
+    let(:args) { [method, attribute, options_for_select] }
+    subject { builder.send(*args) }
+
+    include_examples 'HTML formatting checks'
+
+    it_behaves_like 'a field that supports labels'
+    it_behaves_like 'a field that supports captions on the label'
+    it_behaves_like 'a field that supports labels as procs'
+
+    it_behaves_like 'a field that supports errors' do
+      let(:error_message) { /Choose a favourite colour/ }
+      let(:error_identifier) { 'person-favourite-colour-error' }
+      let(:error_class) { 'govuk-select--error' }
+    end
+
+    it_behaves_like 'a field that supports setting the label via localisation'
+    it_behaves_like 'a field that supports setting the label caption via localisation'
+    it_behaves_like 'a field that supports setting the hint via localisation'
+
+    it_behaves_like 'a field that supports setting the label via localisation'
+    it_behaves_like 'a field that supports setting the label caption via localisation'
+    it_behaves_like 'a field that supports setting the hint via localisation'
+
+    it_behaves_like 'a field that accepts a plain ruby object' do
+      let(:described_element) { 'select' }
+    end
+
+    specify 'a select element is rendered' do
+      expect(subject).to have_tag('select', with: { class: "govuk-select" })
+    end
+
+    specify 'the select element has the right options' do
+      colour_names.each { |cn| expect(subject).to have_tag('select > option', with: { value: cn }, text: cn) }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'action_controller'
 require 'action_view'
 require 'active_model'
 require 'active_support'
+require 'active_support/core_ext/string'
 require 'pry'
 require 'simplecov'
 

--- a/spec/support/shared/setup_examples.rb
+++ b/spec/support/shared/setup_examples.rb
@@ -4,6 +4,7 @@ shared_context 'setup examples' do
   let(:green_option) { OpenStruct.new(id: 'green', name: 'Green') }
   let(:yellow_option) { OpenStruct.new(id: 'yellow', name: 'Yellow') }
   let(:colours) { [red_option, blue_option, green_option, yellow_option] }
+  let(:colour_names) { colours.map(&:name) }
 
   let(:red_label) { 'Rosso' }
   let(:green_label) { 'Verde' }


### PR DESCRIPTION
Currently users aren't given much flexibility by `#govuk_collection_select`, which wraps Rails' `#collection_select`. This change introduces a `#govuk_select` helper that wraps `#select` and, as a result, offers the following advantages:

* allows the provision of options via any array
* supports Rails' `#options_for_select`
* allows grouped select boxes
* lets users provide their options using a block.

### Remaining tasks

* [x] Rename `GOVUKDesignSystemFormbuilder::Elements::CollectionSelect` to `GOVUKDesignSystemFormbuilder::Elements::Select`
* [x] Flesh out a basic helper and functionality for `#govuk_select`
* [x] Add and test block support
* [x] Add some more comprehensive tests (ie covering `#options_for_select`)
* [x] Create RDoc documentation
* [x] Add an entry to the guide
