### PR TITLE
Make date field value setting more lenient

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -77,7 +77,11 @@ module GOVUKDesignSystemFormBuilder
         if attribute.respond_to?(segment)
           attribute.send(segment)
         elsif attribute.respond_to?(:fetch)
-          attribute.fetch(MULTIPARAMETER_KEY[segment])
+          attribute.fetch(MULTIPARAMETER_KEY[segment]) do
+            Rails.logger.warn("No key '#{segment}' found in MULTIPARAMETER_KEY hash. Expected to find #{MULTIPARAMETER_KEY.values}")
+
+            nil
+          end
         else
           fail(ArgumentError, "invalid Date-like object: must be a Date, Time, DateTime or Hash in MULTIPARAMETER_KEY format")
         end

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -72,7 +72,15 @@ module GOVUKDesignSystemFormBuilder
       def value(segment)
         attribute = @builder.object.try(@attribute_name)
 
-        attribute.try(segment) || attribute.try(:[], MULTIPARAMETER_KEY[segment])
+        return unless attribute
+
+        if attribute.respond_to?(segment)
+          attribute.send(segment)
+        elsif attribute.respond_to?(:fetch)
+          attribute.fetch(MULTIPARAMETER_KEY[segment])
+        else
+          fail(ArgumentError, "invalid Date-like object: must be a Date, Time, DateTime or Hash in MULTIPARAMETER_KEY format")
+        end
       end
 
       def label(segment, link_errors)

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -274,5 +274,22 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         expect { subject }.to raise_error(ArgumentError, /invalid Date-like object/)
       end
     end
+
+    describe "hashes without the right keys" do
+      let(:wrong_hash) { { d: 20, m: 3, y: 2009 } }
+      before { object.born_on = wrong_hash }
+      before { allow(Rails).to receive_message_chain(:logger, :warn) }
+      before { subject }
+
+      specify "logs an appropriate warning" do
+        expect(Rails.logger).to have_received(:warn).with(/No key '.*' found in MULTIPARAMETER_KEY hash/).exactly(wrong_hash.length).times
+      end
+
+      specify "doesn't generate inputs with values" do
+        parsed_subject.css('input').each do |element|
+          expect(element.attributes.keys).not_to include('value')
+        end
+      end
+    end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -71,7 +71,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports a fieldset with legend'
     it_behaves_like 'a field that supports captions on the legend'
 
-    it_behaves_like 'a field that accepts a plain ruby object' do
+    it_behaves_like 'a date field that accepts a plain ruby object' do
       let(:described_element) { ['input', { count: 3 }] }
     end
 
@@ -263,6 +263,15 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
       specify "should have additional attributes" do
         expect(subject).to have_tag('div', with: { 'data-test': 'abc' })
+      end
+    end
+
+    describe "invalid date-like objects" do
+      let(:wrong_date) { WrongDate.new(nil, nil, nil) }
+      before { object.born_on = wrong_date }
+
+      specify "fails with an appropriate error message" do
+        expect { subject }.to raise_error(ArgumentError, /invalid Date-like object/)
       end
     end
   end

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -105,3 +105,5 @@ class Department
     self.name = name
   end
 end
+
+WrongDate = Struct.new(:d, :m, :y)

--- a/spec/support/shared/shared_plain_ruby_object_examples.rb
+++ b/spec/support/shared/shared_plain_ruby_object_examples.rb
@@ -1,10 +1,11 @@
 class Biscuit
-  attr_accessor :name, :weight, :calories
+  attr_accessor :name, :weight, :calories, :expires_on
 
-  def initialize(name, weight, calories)
-    self.name     = name
-    self.weight   = weight
-    self.calories = calories
+  def initialize(name, weight, calories, expires_on = Date.today.next_year)
+    self.name       = name
+    self.weight     = weight
+    self.calories   = calories
+    self.expires_on = expires_on
   end
 end
 
@@ -12,6 +13,16 @@ shared_examples 'a field that accepts a plain ruby object' do
   let(:object) { Biscuit.new('Pick-up!', 28, 143) }
   let(:object_name) { :biscuit }
   let(:attribute) { :calories }
+
+  specify 'should render the element successfully' do
+    expect(subject).to have_tag(*described_element)
+  end
+end
+
+shared_examples 'a date field that accepts a plain ruby object' do
+  let(:object) { Biscuit.new('Rocky', 32, 184) }
+  let(:object_name) { :biscuit }
+  let(:attribute) { :expires_on }
 
   specify 'should render the element successfully' do
     expect(subject).to have_tag(*described_element)


### PR DESCRIPTION
A recent change caused test failures in some projects because 'odd' values were used to set dates. These included a Struct with day, month and year accessors that allows nil values, as found in the Apply For Postgraduate Teacher Training project.

Now we're calling the method directly if the attribute responds to the segment; as this is now _within_ the if statement rather than a chain of ors, if the value is nil, nil will be returned.

There's an additional failure state to capture and inform when objectsthat are un-datelike are provided.

Fixes #259
