### PR TITLE
Add two-thirds custom width option in text-field guide

### DIFF
--- a/guide/lib/examples/text_input.rb
+++ b/guide/lib/examples/text_input.rb
@@ -24,6 +24,7 @@ module Examples
 
         = f.govuk_text_field :full,           width: 'full'
         = f.govuk_text_field :three_quarters, width: 'three-quarters'
+        = f.govuk_text_field :two_thirds,     width: 'two-thirds'
         = f.govuk_text_field :one_half,       width: 'one-half'
         = f.govuk_text_field :one_third,      width: 'one-third'
         = f.govuk_text_field :one_quarter,    width: 'one-quarter'


### PR DESCRIPTION
I don't see a principled reason to skip this custom width in the guide. I am able to add the relevant width class (.govuk-!-width-two-thirds) successfully when I use the width attribute.