### PR TITLE
Allow logging instead of failure on invalid dates

### DIFF
--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -72,7 +72,8 @@ module GOVUKDesignSystemFormBuilder
     localisation_schema_legend: nil,
     localisation_schema_caption: nil,
 
-    enable_logger: true
+    enable_logger: true,
+    enable_log_on_invalid_date: false
   }.freeze
 
   DEFAULTS.each_key { |k| config_accessor(k) { DEFAULTS[k] } }

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -70,19 +70,18 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def value(segment)
-        attribute = @builder.object.try(@attribute_name)
+        return unless (attribute = @builder.object.try(@attribute_name))
 
-        return unless attribute
-
-        if attribute.respond_to?(segment)
+        case
+        when attribute.respond_to?(segment)
           attribute.send(segment)
-        elsif attribute.respond_to?(:fetch)
+        when attribute.respond_to?(:fetch)
           attribute.fetch(MULTIPARAMETER_KEY[segment]) do
             warn("No key '#{segment}' found in MULTIPARAMETER_KEY hash. Expected to find #{MULTIPARAMETER_KEY.values}")
 
             nil
           end
-        elsif config.enable_log_on_invalid_date
+        when config.enable_log_on_invalid_date
           warn("invalid Date-like object: should be a Date, Time, DateTime or Hash in MULTIPARAMETER_KEY format")
 
           nil

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -82,6 +82,10 @@ module GOVUKDesignSystemFormBuilder
 
             nil
           end
+        elsif config.enable_log_on_invalid_date
+          warn("invalid Date-like object: should be a Date, Time, DateTime or Hash in MULTIPARAMETER_KEY format")
+
+          nil
         else
           fail(ArgumentError, "invalid Date-like object: must be a Date, Time, DateTime or Hash in MULTIPARAMETER_KEY format")
         end

--- a/lib/govuk_design_system_formbuilder/version.rb
+++ b/lib/govuk_design_system_formbuilder/version.rb
@@ -1,3 +1,3 @@
 module GOVUKDesignSystemFormBuilder
-  VERSION = '2.5.0'.freeze
+  VERSION = '2.5.1b1'.freeze
 end

--- a/spec/govuk_design_system_formbuilder/builder/configuration/invalid_date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration/invalid_date_spec.rb
@@ -1,0 +1,26 @@
+describe GOVUKDesignSystemFormBuilder::FormBuilder do
+  # this is intended to be a temporary measure that can be enabled
+  # while projects are moving towards Rails-style dates, see #266
+  # for more details.
+  include_context 'setup builder'
+  include_context 'setup examples'
+
+  describe "invalid date config" do
+    let(:wrong_date) { WrongDate.new(nil, nil, nil) }
+    before { object.born_on = wrong_date }
+    before { allow(Rails).to receive_message_chain(:logger, :warn) }
+
+    before do
+      GOVUKDesignSystemFormBuilder.configure do |conf|
+        conf.enable_log_on_invalid_date = true
+      end
+    end
+
+    subject! { builder.send(:govuk_date_field, :born_on) }
+
+    specify "fails with an appropriate error message" do
+      # three times, once per input
+      expect(Rails.logger).to have_received(:warn).exactly(3).times.with(/invalid Date-like object/)
+    end
+  end
+end


### PR DESCRIPTION
Add option to allow date values to log when invalid instead of failing.

Failure is a sensible choice for most projects but is likely to become a reason why those in the process of reworking their codebase can't stay up to date with the gem.

The new option, enable_log_on_invalid_date, is disabled by default so the behaviour of the library won't change uninvited.
