### PR TITLE
Add Semgrep Ignore file

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,2 @@
+# Lots of eval in example_data but it's required to build the guide
+guide/lib/setup/example_data.rb


### PR DESCRIPTION
We _need_ to use eval while building the guide as the snippets are shown in both their raw and rendered forms.

.semgrepignore is the same format as .gitignore, as detailed in the docs

https://semgrep.dev/docs/semgrep-ci/
