### PR TITLE
We shouldn't split value strings, since deeper_merge will remove repeated words

### DIFF
--- a/lib/govuk_design_system_formbuilder/traits/html_attributes.rb
+++ b/lib/govuk_design_system_formbuilder/traits/html_attributes.rb
@@ -22,7 +22,11 @@ module GOVUKDesignSystemFormBuilder
                           when Hash
                             deep_split_values(value)
                           when String
-                            value.split
+                            if key == :value
+                              value
+                            else
+                              value.split
+                            end
                           else
                             value
                           end

--- a/lib/govuk_design_system_formbuilder/traits/html_attributes.rb
+++ b/lib/govuk_design_system_formbuilder/traits/html_attributes.rb
@@ -1,11 +1,22 @@
 module GOVUKDesignSystemFormBuilder
   module Traits
     module HTMLAttributes
-      # Attributes eases working with default and custom attributes by
+      # Attributes eases working with default and custom attributes by:
       # * deeply merging them so both the default (required) attributes are
       #   present
       # * joins the arrays into strings to maintain Rails 6.0.3 compatibility
       class Attributes
+        # Don't try to deep merge these fields, when we remove duplicates
+        # whilst merging the resulting values later, repeating words are lost
+        SKIP = [
+          %i(id),
+          %i(value),
+          %i(title),
+          %i(alt),
+          %i(href),
+          %i(aria label)
+        ].freeze
+
         def initialize(defaults, custom)
           @merged = defaults.deeper_merge(deep_split_values(custom))
         end
@@ -16,20 +27,24 @@ module GOVUKDesignSystemFormBuilder
 
       private
 
-        def deep_split_values(hash)
+        def deep_split_values(hash, parent = nil)
           hash.each.with_object({}) do |(key, value), result|
             result[key] = case value
                           when Hash
-                            deep_split_values(value)
+                            deep_split_values(value, key)
                           when String
-                            if key == :value
-                              value
-                            else
-                              value.split
-                            end
+                            split_list_values(key, value, parent)
                           else
                             value
                           end
+          end
+        end
+
+        def split_list_values(key, value, parent = nil)
+          if [parent, key].compact.in?(SKIP)
+            value
+          else
+            value.split
           end
         end
 

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
@@ -36,6 +36,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     it_behaves_like 'a field that allows extra HTML attributes to be set' do
       let(:described_element) { 'input' }
+      let(:value) { 'Montgomery Montgomery' }
       let(:expected_class) { 'govuk-checkboxes__input' }
     end
 

--- a/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
@@ -33,6 +33,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     it_behaves_like 'a field that allows extra HTML attributes to be set' do
       let(:described_element) { 'input' }
+      let(:value) { 'Montgomery Montgomery' }
       let(:expected_class) { 'govuk-radios__input' }
     end
 

--- a/spec/support/shared/shared_html_attribute_examples.rb
+++ b/spec/support/shared/shared_html_attribute_examples.rb
@@ -7,9 +7,18 @@ shared_examples 'a field that allows extra HTML attributes to be set' do
       autocomplete: { provided: false,                   expected: 'false' },
       placeholder:  { provided: 'Seymour Skinner',       expected: 'Seymour Skinner' },
       data:         { provided: { a: 'b' },              expected: { 'data-a' => 'b' } },
-      aria:         { provided: { c: 'd' },              expected: { 'aria-c' => 'd' } },
       class:        { provided: %w(red spots),           expected: %w(red spots) },
-      value:        { provided: 'Montgomery Montgomery', expected: 'Montgomery Montgomery' }
+      value:        { provided: 'Montgomery Montgomery', expected: 'Montgomery Montgomery' },
+
+      # aria-label is a special case, along with value it should not be treated
+      # like a list when deep merging
+      aria: {
+        provided: {
+          c: 'd',
+          label: 'Burns Burns'
+        },
+        expected: { 'aria-c' => 'd', 'aria-label' => 'Burns Burns' }
+      },
     }
 
     let(:custom_attributes) { custom_attributes }

--- a/spec/support/shared/shared_html_attribute_examples.rb
+++ b/spec/support/shared/shared_html_attribute_examples.rb
@@ -3,12 +3,13 @@ shared_examples 'a field that allows extra HTML attributes to be set' do
 
   context 'with args in the expected formats' do
     custom_attributes = {
-      required:     { provided: true,              expected: 'required' },
-      autocomplete: { provided: false,             expected: 'false' },
-      placeholder:  { provided: 'Seymour Skinner', expected: 'Seymour Skinner' },
-      data:         { provided: { a: 'b' },        expected: { 'data-a' => 'b' } },
-      aria:         { provided: { c: 'd' },        expected: { 'aria-c' => 'd' } },
-      class:        { provided: %w(red spots),     expected: %w(red spots) }
+      required:     { provided: true,                    expected: 'required' },
+      autocomplete: { provided: false,                   expected: 'false' },
+      placeholder:  { provided: 'Seymour Skinner',       expected: 'Seymour Skinner' },
+      data:         { provided: { a: 'b' },              expected: { 'data-a' => 'b' } },
+      aria:         { provided: { c: 'd' },              expected: { 'aria-c' => 'd' } },
+      class:        { provided: %w(red spots),           expected: %w(red spots) },
+      value:        { provided: 'Montgomery Montgomery', expected: 'Montgomery Montgomery' }
     }
 
     let(:custom_attributes) { custom_attributes }
@@ -22,6 +23,14 @@ shared_examples 'a field that allows extra HTML attributes to be set' do
     describe 'input tag should have the extra attributes:' do
       extract_args(custom_attributes, :expected).each do |key, val|
         case
+        when key == :value
+          specify "#{key} has classes #{val}" do
+            if described_element == "textarea"
+              expect(subject).to have_tag(described_element, text: /#{val}/)
+            else
+              expect(subject).to have_tag(described_element, with: { key => val })
+            end
+          end
 
         # class is dealt with as a special case because we want to ensure that whatever
         # extra classes we provide are *added* to the pre-existing one (expected_class)


### PR DESCRIPTION
## Problem
On Teaching Vacancies, schools can define a description, which we pre-fill in an `About school` input as part of our `Create a job` journey...

![image](https://user-images.githubusercontent.com/25187547/118150503-893bc380-b40a-11eb-817a-a1fe6356855c.png)

The eagle eyed user will notice some words are missing...

![image](https://user-images.githubusercontent.com/25187547/118150665-b4beae00-b40a-11eb-9cc2-c1b5f1b1cfeb.png)

To be precise any repeated words (Case SenSitive) are missing... 😢 

## Solution
Stop splitting strings for value attributes, so that `deeper_merge` doesn't remove repeated words

## Next steps
- Perhaps we need to rethink how we split and merge custom attributes