### PR TITLE
Omit empty div if contents is empty

### DIFF
--- a/lib/govuk_design_system_formbuilder/traits/conditional.rb
+++ b/lib/govuk_design_system_formbuilder/traits/conditional.rb
@@ -9,7 +9,7 @@ module GOVUKDesignSystemFormBuilder
 
       def wrap_conditional(block)
         tag.div(class: conditional_classes, id: conditional_id) do
-          capture { block.call }
+          capture { block.call || return }
         end
       end
     end


### PR DESCRIPTION
In [CCCD](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence) we encountered an issue with the display of a checkbox (`govuk_check_box`) with a block, but the block may be empty based on a conditional. Eg;

```ruby
= f.govuk_check_box(...) do
  - if (something)
    = f.govuk_collection_radio_buttons ...
```

If the condition is false the `<div govuk-checkboxes_conditional>` still appears meaning that some extra space is added before the next checkbox. I have created a simple example in https://github.com/jrmhaig/govuk_formbuilder_test

I have not added any tests and I would appreciate help, if necessary.

Our workaround is here: https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/blob/49f1f46cb95f1014382e036a210de76fcb977c50/app/views/external_users/admin/external_users/_form.html.haml#L29-L50