### PR TITLE
Prevent wrapping of empty block content

### DIFF
--- a/lib/govuk_design_system_formbuilder/traits/conditional.rb
+++ b/lib/govuk_design_system_formbuilder/traits/conditional.rb
@@ -8,8 +8,11 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def wrap_conditional(block)
+        block_result = block.call
+        return if block_result.blank?
+
         tag.div(class: conditional_classes, id: conditional_id) do
-          capture { block.call }
+          capture { block_result }
         end
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
@@ -179,6 +179,14 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             }
           )
         end
+
+        context 'with no content' do
+          subject { builder.send(*args) {} }
+
+          specify 'should not generate conditional div' do
+            expect(subject).not_to have_tag('div', with: { class: 'govuk-checkboxes__conditional' })
+          end
+        end
       end
 
       context 'when no block is given' do

--- a/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
@@ -123,6 +123,14 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             }
           )
         end
+
+        context 'with no content' do
+          subject { builder.govuk_radio_button(attribute, value) {} }
+
+          specify 'should not generate conditional div' do
+            expect(subject).not_to have_tag('div', with: { class: 'govuk-radios__conditional' })
+          end
+        end
       end
 
       context 'when no block is given' do


### PR DESCRIPTION
#### What
Prevent wrapping of empty block content

#### Why
The existing govuk_radio_button and govuk_check_box
wrap blocks in a div even when there is not content.

This causes a padding issue in use cases where the content
is conditionally rendered.

Example of use case
```ruby
- @a_role_collection.each_with_index do |role, idx|
          = f.govuk_check_box(:roles,
            role,
            label: { text: role.humanize },
            link_errors: idx.zero?) do

            - if some_conditional?
              = f.govuk_collection_radio_buttons :some_radio_options,
                [['Yes','true'],['No','false']],
                :last,
                :first,
                inline: true,
                legend: { text: 'my legend', size: 's' }
```