### PR TITLE
Don't render any conditional content when block is empty

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -21,8 +21,8 @@ module GOVUKDesignSystemFormBuilder
           @link_errors     = link_errors
           @html_attributes = kwargs
 
-          if block_given?
-            @conditional_content = wrap_conditional(block)
+          if (conditional_block_content = block_given? && block.call.presence)
+            @conditional_content = wrap_conditional(conditional_block_content)
             @conditional_id      = conditional_id
           end
         end

--- a/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/fieldset_radio_button.rb
@@ -19,8 +19,8 @@ module GOVUKDesignSystemFormBuilder
           @link_errors     = has_errors? && link_errors
           @html_attributes = kwargs
 
-          if block_given?
-            @conditional_content = wrap_conditional(block)
+          if (conditional_block_content = block_given? && block.call.presence)
+            @conditional_content = wrap_conditional(conditional_block_content)
             @conditional_id      = conditional_id
           end
         end

--- a/lib/govuk_design_system_formbuilder/traits/conditional.rb
+++ b/lib/govuk_design_system_formbuilder/traits/conditional.rb
@@ -9,7 +9,7 @@ module GOVUKDesignSystemFormBuilder
 
       def wrap_conditional(block)
         tag.div(class: conditional_classes, id: conditional_id) do
-          capture { block.call }
+          capture { block.call || return }
         end
       end
     end

--- a/lib/govuk_design_system_formbuilder/traits/conditional.rb
+++ b/lib/govuk_design_system_formbuilder/traits/conditional.rb
@@ -7,9 +7,9 @@ module GOVUKDesignSystemFormBuilder
         build_id('conditional')
       end
 
-      def wrap_conditional(block)
+      def wrap_conditional(content)
         tag.div(class: conditional_classes, id: conditional_id) do
-          capture { block.call || return }
+          capture { content }
         end
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
@@ -181,6 +181,20 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
 
+      context 'when an empty block is given' do
+        subject { builder.send(*args) { "" } }
+
+        specify "the data-aria-controls attribute should be blank" do
+          input_data_aria_controls = parsed_subject.at_css("input[type='checkbox']")['data-aria-controls']
+
+          expect(input_data_aria_controls).to be_nil
+        end
+
+        specify "the conditional container should not be present" do
+          expect(subject).not_to have_tag('.govuk-checkboxes__conditional')
+        end
+      end
+
       context 'when no block is given' do
         subject { builder.send(*args) }
 

--- a/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
@@ -125,8 +125,23 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
 
+      context 'when an empty block is given' do
+        subject do
+          builder.send(*args) { "" }
+        end
+
+        specify "the data-aria-controls attribute should not be present" do
+          input_data_aria_controls = parsed_subject.at_css("input[type='radio']")['data-aria-controls']
+          expect(input_data_aria_controls).to be_nil
+        end
+
+        specify "the conditional container should not be present" do
+          expect(subject).not_to have_tag('.govuk-radios__conditional')
+        end
+      end
+
       context 'when no block is given' do
-        subject { builder.govuk_radio_button(attribute, value) }
+        subject { builder.send(*args) }
 
         specify "the data-aria-controls attribute should not be present" do
           input_data_aria_controls = parsed_subject.at_css("input[type='radio']")['data-aria-controls']


### PR DESCRIPTION
When either no block or an empty block (i.e., one that fails Rails' `#presence` check) is provided in the block passed to a radio button or check box no conditional content shouldn't be rendered and the data-attribute that's used to toggle it should be omitted.

This tweak moves the logic to earlier in the object's initialisation so that both the `@conditional_content` and `@conditional_id` will not be set when the block is blank.

Closes #281, #282
