### PR TITLE
Fix conditional content rendering bug

### DIFF
--- a/lib/govuk_design_system_formbuilder/traits/fieldset_item.rb
+++ b/lib/govuk_design_system_formbuilder/traits/fieldset_item.rb
@@ -62,7 +62,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def conditional_content(&block)
-        if (conditional_block_content = block_given? && block.call.presence)
+        if (conditional_block_content = block_given? && (capture { block.call }).presence)
           @conditional    = conditional_container(conditional_block_content)
           @conditional_id = conditional_id
         end
@@ -70,7 +70,7 @@ module GOVUKDesignSystemFormBuilder
 
       def conditional_container(content)
         tag.div(class: conditional_classes, id: conditional_id) do
-          capture { content }
+          content
         end
       end
 


### PR DESCRIPTION
This was a bit of a tricky one to trace as it doesn't manifest in plain Ruby (so wasn't caught by the specs and works properly in the guide) but does from ERB.

Essentially, the refactor to remove duplication between fieldset radios and checkboxes (10fd3fb6f7b6894b2), while looking harmless, sets the `block.call` to a variable that's then captured, rather than capturing the `block.call` directly.
