### PR TITLE
Update Rails to latest versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Install gems
         env:
-          RAILS_VERSION: '6.1.3.1'
+          RAILS_VERSION: '6.0.3.7'
         run: |
           gem install bundler
           bundle install --jobs 4 --retry 3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['2.6.7', '2.7.3', '3.0.1']
-        rails: ['6.0.3.6', '6.1.3.1']
+        rails: ['6.0.3.7', '6.1.3.2']
     runs-on: ubuntu-20.04
     name: Testing with Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
     steps:
@@ -43,11 +43,11 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0.0'
+          ruby-version: '3.0.1'
 
       - name: Install gems
         env:
-          RAILS_VERSION: '6.1.1'
+          RAILS_VERSION: '6.1.3.2'
         run: |
           gem install bundler
           bundle install --jobs 4 --retry 3

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk_design_system_formbuilder)](https://github.com/DFE-Digital/govuk_design_system_formbuilder/blob/master/LICENSE)
 [![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.12.0-brightgreen)](https://design-system.service.gov.uk)
 [![Rails](https://img.shields.io/badge/Ruby-2.6.7%20%E2%95%B1%202.7.3%20%E2%95%B1%203.0.1-E16D6D)](https://www.ruby-lang.org/en/downloads/)
-[![Ruby](https://img.shields.io/badge/Rails-6.0.3.6%20%E2%95%B1%206.1.3.1-E16D6D)](https://weblog.rubyonrails.org/releases/)
+[![Ruby](https://img.shields.io/badge/Rails-6.0.3.7%20%E2%95%B1%206.1.3.2-E16D6D)](https://weblog.rubyonrails.org/releases/)
 
 This library provides an easy-to-use form builder for the [GOV.UK Design System](https://design-system.service.gov.uk/).
 

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -40,7 +40,7 @@ dl.govuk-summary-list
       ul.govuk-list
         li
           span.govuk-tag.govuk-tag-red
-            | 6.1.3.1
+            | 6.1.3.2
         li
           span.govuk-tag.govuk-tag-red
-            | 6.0.3.6
+            | 6.0.3.7

--- a/lib/govuk_design_system_formbuilder/version.rb
+++ b/lib/govuk_design_system_formbuilder/version.rb
@@ -1,3 +1,3 @@
 module GOVUKDesignSystemFormBuilder
-  VERSION = '2.5.3'.freeze
+  VERSION = '2.6.0b1'.freeze
 end


### PR DESCRIPTION
- Bump Rails to latest versions
- Build against the oldest supported Ruby version
- Release version 2.6.0b1
