### PR TITLE
Allow custom sort order for error summaries

### DIFF
--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -41,6 +41,10 @@ module GOVUKDesignSystemFormBuilder
   # * +:default_collection_radio_buttons_include_hidden+ controls whether or not
   #   a hidden field is added when rendering a collection of radio buttons
   #
+  # * +:default_error_summary_error_order_method+ is the method that the library
+  #   will check for on the bound object to see whether or not to try ordering the
+  #   error messages
+  #
   # * +:localisation_schema_fallback+ sets the prefix elements for the array
   #   used to build the localisation string. The final two elements are always
   #   are the object name and attribute name. The _special_ value +__context__+,
@@ -62,6 +66,7 @@ module GOVUKDesignSystemFormBuilder
     default_submit_button_text: 'Continue',
     default_radio_divider_text: 'or',
     default_error_summary_title: 'There is a problem',
+    default_error_summary_error_order_method: :error_order,
     default_collection_check_boxes_include_hidden: true,
     default_collection_radio_buttons_include_hidden: true,
     default_submit_validate: false,

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -66,7 +66,7 @@ module GOVUKDesignSystemFormBuilder
     default_submit_button_text: 'Continue',
     default_radio_divider_text: 'or',
     default_error_summary_title: 'There is a problem',
-    default_error_summary_error_order_method: :error_order,
+    default_error_summary_error_order_method: nil,
     default_collection_check_boxes_include_hidden: true,
     default_collection_radio_buttons_include_hidden: true,
     default_submit_validate: false,

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -930,6 +930,9 @@ module GOVUKDesignSystemFormBuilder
     # @param title [String] the error summary heading
     # @param link_base_errors_to [Symbol,String] set the field that errors on +:base+ are linked
     #   to, as there won't be a field representing the object base.
+    # @param order [Array<Symbol>] the attribute order in which error messages are displayed. Ordered
+    #   attributes will appear first and unordered ones will be last, sorted in the default manner (in
+    #   which they were defined on the model).
     # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the error summary +div+ element
     #
     # @note Only the first error in the +#errors+ array for each attribute will
@@ -939,8 +942,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_error_summary 'Uh-oh, spaghettios'
     #
     # @see https://design-system.service.gov.uk/components/error-summary/ GOV.UK error summary
-    def govuk_error_summary(title = config.default_error_summary_title, link_base_errors_to: nil, **kwargs)
-      Elements::ErrorSummary.new(self, object_name, title, link_base_errors_to: link_base_errors_to, **kwargs).html
+    def govuk_error_summary(title = config.default_error_summary_title, link_base_errors_to: nil, order: nil, **kwargs)
+      Elements::ErrorSummary.new(self, object_name, title, link_base_errors_to: link_base_errors_to, order: order, **kwargs).html
     end
 
     # Generates a fieldset containing the contents of the block

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -35,9 +35,29 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def list
-        @builder.object.errors.messages.map do |attribute, messages|
+        error_messages.map do |attribute, messages|
           list_item(attribute, messages.first)
         end
+      end
+
+      def error_messages
+        messages = @builder.object.errors.messages
+
+        if reorder_errors?
+          return messages.sort_by.with_index(1) do |(attr, _val), i|
+            error_order.index(attr) || (i + messages.size)
+          end
+        end
+
+        @builder.object.errors.messages
+      end
+
+      def reorder_errors?
+        @builder.object.respond_to?(:error_order) && @builder.object.error_order.present?
+      end
+
+      def error_order
+        @builder.object.error_order
       end
 
       def list_item(attribute, message)

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -56,11 +56,19 @@ module GOVUKDesignSystemFormBuilder
       def reorder_errors?
         object = @builder.object
 
-        @order || (object.respond_to?(:error_order) && object.error_order.present?)
+        @order || (error_order_method &&
+                   object.respond_to?(error_order_method) &&
+                   object.send(error_order_method).present?)
       end
 
       def error_order
-        @order || @builder.object.error_order
+        @order || @builder.object.send(config.default_error_summary_error_order_method)
+      end
+
+      # this method will be called on the bound object to see if custom error ordering
+      # has been enabled
+      def error_order_method
+        config.default_error_summary_error_order_method
       end
 
       def list_item(attribute, message)

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -4,12 +4,13 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Error
       include Traits::HTMLAttributes
 
-      def initialize(builder, object_name, title, link_base_errors_to:, **kwargs)
+      def initialize(builder, object_name, title, link_base_errors_to:, order:, **kwargs)
         super(builder, object_name, nil)
 
         @title               = title
         @link_base_errors_to = link_base_errors_to
         @html_attributes     = kwargs
+        @order               = order
       end
 
       def html
@@ -53,11 +54,13 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def reorder_errors?
-        @builder.object.respond_to?(:error_order) && @builder.object.error_order.present?
+        object = @builder.object
+
+        @order || (object.respond_to?(:error_order) && object.error_order.present?)
       end
 
       def error_order
-        @builder.object.error_order
+        @order || @builder.object.error_order
       end
 
       def list_item(attribute, message)

--- a/spec/govuk_design_system_formbuilder/builder/configuration/error_summary_configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration/error_summary_configuration_spec.rb
@@ -22,7 +22,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       expect(subject).to have_tag('h2', text: default_error_summary_title, with: { class: 'govuk-error-summary__title' })
     end
 
-    context %(overriding with 'Engage') do
+    context %(overriding with custom text) do
       let(:error_summary_title) { %(We've been hit!) }
       let(:args) { [method, error_summary_title] }
 

--- a/spec/govuk_design_system_formbuilder/builder/configuration/error_summary_error_message_sorting_configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration/error_summary_error_message_sorting_configuration_spec.rb
@@ -1,0 +1,30 @@
+describe GOVUKDesignSystemFormBuilder::FormBuilder do
+  include_context 'setup builder'
+  include_context 'setup examples'
+
+  let(:method) { :govuk_error_summary }
+
+  describe 'changing the default error order method' do
+    let(:object) { OrderedErrorsWithCustomOrderMethod.new }
+    let(:custom_method_name) { :sort_my_errors_in_the_following_manner_please }
+    let(:args) { [method] }
+
+    let(:actual_order) { extract_field_names_from_errors_summary_list(parsed_subject) }
+
+    before do
+      GOVUKDesignSystemFormBuilder.configure do |conf|
+        conf.default_error_summary_error_order_method = custom_method_name
+      end
+    end
+
+    before { object.valid? }
+
+    let(:expected_order) { %w(c e d a b) }
+
+    subject { builder.send(*args) }
+
+    specify "the error messages are displayed in the order they were defined in the model" do
+      expect(actual_order).to eql(expected_order)
+    end
+  end
+end

--- a/spec/govuk_design_system_formbuilder/builder/configuration/error_summary_error_message_sorting_configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration/error_summary_error_message_sorting_configuration_spec.rb
@@ -2,26 +2,22 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   include_context 'setup builder'
   include_context 'setup examples'
 
-  let(:method) { :govuk_error_summary }
-
   describe 'changing the default error order method' do
-    let(:object) { OrderedErrorsWithCustomOrderMethod.new }
-    let(:custom_method_name) { :sort_my_errors_in_the_following_manner_please }
-    let(:args) { [method] }
+    let(:object) { OrderedErrorsWithCustomOrder.new }
+    let(:custom_method_name) { :error_order }
+
+    before { object.valid? }
+
+    subject { builder.govuk_error_summary }
 
     let(:actual_order) { extract_field_names_from_errors_summary_list(parsed_subject) }
+    let(:expected_order) { object.error_order.map(&:to_s) }
 
     before do
       GOVUKDesignSystemFormBuilder.configure do |conf|
         conf.default_error_summary_error_order_method = custom_method_name
       end
     end
-
-    before { object.valid? }
-
-    let(:expected_order) { %w(c e d a b) }
-
-    subject { builder.send(*args) }
 
     specify "the error messages are displayed in the order they were defined in the model" do
       expect(actual_order).to eql(expected_order)

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -295,13 +295,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
 
         describe "custom sort order" do
-          let(:actual_order) do
-            parsed_subject
-              .css('li > a')
-              .map { |element| element['href'] }
-              .map { |href| href.match(%r[#{object_name}-(?<attribute_name>.*)-field-error])[:attribute_name] }
-              .map { |attribute| dashes_to_underscores(attribute) }
-          end
+          let(:actual_order) { extract_field_names_from_errors_summary_list(parsed_subject) }
 
           context "by default" do
             # the object here is Person, defined in spec/support/examples.rb

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -39,7 +39,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       describe 'error messages' do
         subject! { builder.send(method) }
 
-        context 'there are multiple errors each with one error message' do
+        context 'when there are multiple errors each with one error message' do
           let(:object) { Person.new(favourite_colour: nil, projects: []) }
 
           specify 'the error summary should contain a list with one error message per field' do
@@ -50,7 +50,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           end
         end
 
-        context 'there are multiple errors and one has multiple error messages' do
+        context 'when there are multiple errors and one has multiple error messages' do
           let(:object) { Person.new(name: nil, favourite_colour: nil) }
 
           specify 'the error summary should contain a list with one error message per field' do

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -37,7 +37,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       describe 'error messages' do
-        subject! { builder.send(method) }
+        let(:kwargs) { {} }
+        subject! { builder.send(*args, **kwargs) }
 
         context 'when there are multiple errors each with one error message' do
           let(:object) { Person.new(favourite_colour: nil, projects: []) }
@@ -364,6 +365,16 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
               # because #index will return nil
               specify "the error messages are displayed in the order they were defined in the model" do
                 expect(actual_order).to eql(expected_order)
+              end
+            end
+
+            context "setting the order via the :order argument" do
+              let(:object) { OrderedErrors.new }
+              let(:overridden_order) { %i(d e b a c) }
+              let(:kwargs) { { order: overridden_order } }
+
+              specify "the error messages are displayed in the overridden order" do
+                expect(actual_order).to eql(overridden_order.map(&:to_s))
               end
             end
           end

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -311,21 +311,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           end
 
           describe "overriding" do
-            let(:overridden_order) { object.error_order.map(&:to_s) }
-
-            context "when the object has no overridden ordering" do
-              let(:object) { OrderedErrors.new }
-              let(:expected_order) { %w(a b c d e) }
-
-              # there's no error_order method on the object, ensure nothing blows up
-              specify "the error messages are displayed in the order they were defined in the model" do
-                expect(actual_order).to eql(expected_order)
-              end
-            end
+            let(:object) { OrderedErrors.new }
+            let(:overridden_order) { %w(e d c b a) }
+            let(:overridden_order_symbols) { overridden_order.map(&:to_sym) }
+            let(:kwargs) { { order: overridden_order_symbols } }
 
             context "when all attributes are named in the ordering" do
-              let(:object) { OrderedErrorsWithCustomOrder.new }
-
               # the default validation order is (:a, :b, :c, :d, :e)
               #
               # the overridden order is (:e, :d, :c, :b, :a)
@@ -352,23 +343,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             end
 
             context "when the ordering specifies attributes that aren't present on the object" do
-              let(:object) { OrderedErrorsWithCustomOrderAndInvalidAttributes.new }
-              let(:expected_order) { %w(a b c d e) }
+              let(:kwargs) { { order: overridden_order_symbols.append(%i(x y z)) } }
 
               # there's no error_order method, ensure it doesn't blow up. it shouldn't
               # because #index will return nil
               specify "the error messages are displayed in the order they were defined in the model" do
-                expect(actual_order).to eql(expected_order)
-              end
-            end
-
-            context "setting the order via the :order argument" do
-              let(:object) { OrderedErrors.new }
-              let(:overridden_order) { %i(d e b a c) }
-              let(:kwargs) { { order: overridden_order } }
-
-              specify "the error messages are displayed in the overridden order" do
-                expect(actual_order).to eql(overridden_order.map(&:to_s))
+                expect(actual_order).to eql(overridden_order)
               end
             end
           end

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -33,14 +33,15 @@ end
 class Person < Being
   include ActiveModel::Model
 
-  validates :name, presence: { message: 'Enter a name' }
+  validates :name,
+            presence: { message: 'Enter a name' },
+            length: { minimum: 2, message: 'Name should be longer than 1' }
   validates :favourite_colour, presence: { message: 'Choose a favourite colour' }
   validates :projects, presence: { message: 'Select at least one project' }
   validates :cv, length: { maximum: 30 }, presence: true
 
   validate :born_on_must_be_in_the_past, if: -> { born_on.present? }
   validate :photo_must_be_jpeg, if: -> { photo.present? }
-  validates :name, length: { minimum: 2, message: 'Name should be longer than 1' }
 
   def self.valid_example
     new(

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -33,8 +33,6 @@ end
 class Person < Being
   include ActiveModel::Model
 
-  attr_accessor :error_order
-
   validates :name,
             presence: { message: 'Enter a name' },
             length: { minimum: 2, message: 'Name should be longer than 1' }
@@ -130,23 +128,11 @@ end
 
 class OrderedErrorsWithCustomOrder < OrderedErrors
   def error_order
-    %i(a b c d e).reverse
+    %i(e d c b a)
   end
 end
 
-class OrderedErrorsWithCustomOrderAndInvalidAttributes < OrderedErrors
-  def error_order
-    %i(x y z)
-  end
-end
-
-class OrderedErrorsWithCustomOrderMethod < OrderedErrors
-  def sort_my_errors_in_the_following_manner_please
-    %i(c e d a b)
-  end
-end
-
-class OrderedErrorsWithCustomOrderAndExtraAttributes < OrderedErrorsWithCustomOrder
+class OrderedErrorsWithCustomOrderAndExtraAttributes < OrderedErrors
   attribute :g, :string
   attribute :h, :string
   attribute :i, :string

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -140,6 +140,12 @@ class OrderedErrorsWithCustomOrderAndInvalidAttributes < OrderedErrors
   end
 end
 
+class OrderedErrorsWithCustomOrderMethod < OrderedErrors
+  def sort_my_errors_in_the_following_manner_please
+    %i(c e d a b)
+  end
+end
+
 class OrderedErrorsWithCustomOrderAndExtraAttributes < OrderedErrorsWithCustomOrder
   attribute :g, :string
   attribute :h, :string

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -33,6 +33,8 @@ end
 class Person < Being
   include ActiveModel::Model
 
+  attr_accessor :error_order
+
   validates :name,
             presence: { message: 'Enter a name' },
             length: { minimum: 2, message: 'Name should be longer than 1' }
@@ -108,3 +110,42 @@ class Department
 end
 
 WrongDate = Struct.new(:d, :m, :y)
+
+class OrderedErrors
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :a, :string
+  attribute :b, :string
+  attribute :c, :string
+  attribute :d, :string
+  attribute :e, :string
+
+  validates :a, presence: true, length: { minimum: 3 }
+  validates :b, presence: true, length: { minimum: 3 }
+  validates :c, presence: true, length: { minimum: 3 }
+  validates :d, presence: true, length: { minimum: 3 }
+  validates :e, presence: true, length: { minimum: 3 }
+end
+
+class OrderedErrorsWithCustomOrder < OrderedErrors
+  def error_order
+    %i(a b c d e).reverse
+  end
+end
+
+class OrderedErrorsWithCustomOrderAndInvalidAttributes < OrderedErrors
+  def error_order
+    %i(x y z)
+  end
+end
+
+class OrderedErrorsWithCustomOrderAndExtraAttributes < OrderedErrorsWithCustomOrder
+  attribute :g, :string
+  attribute :h, :string
+  attribute :i, :string
+
+  validates :i, presence: true, length: { minimum: 3 }
+  validates :h, presence: true, length: { minimum: 3 }
+  validates :g, presence: true, length: { minimum: 3 }
+end

--- a/spec/support/utility.rb
+++ b/spec/support/utility.rb
@@ -25,3 +25,11 @@ end
 def rails_version_later_than_6_1_0?
   rails_version >= '6.1.0'
 end
+
+def extract_field_names_from_errors_summary_list(document)
+  document
+    .css('li > a')
+    .map { |element| element['href'] }
+    .map { |href| href.match(%r[#{object_name}-(?<attribute_name>.*)-field-error])[:attribute_name] }
+    .map { |attribute| dashes_to_underscores(attribute) }
+end

--- a/spec/support/utility.rb
+++ b/spec/support/utility.rb
@@ -14,6 +14,10 @@ def underscores_to_dashes(val)
   val.to_s.tr('_', '-')
 end
 
+def dashes_to_underscores(val)
+  val.to_s.tr('-', '_')
+end
+
 def rails_version
   ENV.fetch('RAILS_VERSION') { '6.1.1' }
 end


### PR DESCRIPTION
Ordering can be defined in one of two ways:

* passing in an `order` argument, to `#govuk_error_summary`, e.g., `order: %i(name email date_of_birth)`
* configuring an `default_error_summary_error_order_method` method, like this:
  ```ruby
  GOVUKDesignSystemFormBuilder.configure do |conf|
     conf.default_error_summary_error_order_method = :error_order
  end
  ```

  Then the error order can be defined on a per-model basis like this:
 
   ```ruby
   def error_order
     %i(name email date_of_birth)
   end
   ```

The method approach has the benefit of being automatically applied on any bound form automatically. The argument-based approach takes precedence and  allows for some extra flexibility, but requires a little extra attention and possibly repetition.

Ordered attributes will have their error messages displayed first, in the order defined.

Any errors on attributes that aren't covered by #error_order will appear after those that are, in the order they were defined in the object or model.

If no custom ordering is provided the current default behaviour will apply and the errors will be displayed in the same order they're defined in the model.