### PR TITLE
Allow extra content to be injected into error summaries

### DIFF
--- a/guide/content/building-blocks/injecting-content.slim
+++ b/guide/content/building-blocks/injecting-content.slim
@@ -31,6 +31,8 @@ ul.govuk-list.govuk-list--bullet
   li
     code #govuk_email_field
   li
+    code #govuk_error_summary
+  li
     code #govuk_file_field
   li
     code #govuk_number_field

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -934,6 +934,7 @@ module GOVUKDesignSystemFormBuilder
     #   attributes will appear first and unordered ones will be last, sorted in the default manner (in
     #   which they were defined on the model).
     # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the error summary +div+ element
+    # @param block [Block] arbitrary HTML that will be rendered between title and error message list
     #
     # @note Only the first error in the +#errors+ array for each attribute will
     #   be included.
@@ -942,8 +943,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_error_summary 'Uh-oh, spaghettios'
     #
     # @see https://design-system.service.gov.uk/components/error-summary/ GOV.UK error summary
-    def govuk_error_summary(title = config.default_error_summary_title, link_base_errors_to: nil, order: nil, **kwargs)
-      Elements::ErrorSummary.new(self, object_name, title, link_base_errors_to: link_base_errors_to, order: order, **kwargs).html
+    def govuk_error_summary(title = config.default_error_summary_title, link_base_errors_to: nil, order: nil, **kwargs, &block)
+      Elements::ErrorSummary.new(self, object_name, title, link_base_errors_to: link_base_errors_to, order: order, **kwargs, &block).html
     end
 
     # Generates a fieldset containing the contents of the block

--- a/lib/govuk_design_system_formbuilder/builder_helper.rb
+++ b/lib/govuk_design_system_formbuilder/builder_helper.rb
@@ -42,10 +42,10 @@ module GOVUKDesignSystemFormBuilder
     #   = govuk_error_summary(@registration)
     #
     # @see https://design-system.service.gov.uk/components/error-summary/ GOV.UK error summary
-    def govuk_error_summary(object, object_name = nil, *args, **kwargs)
+    def govuk_error_summary(object, object_name = nil, *args, **kwargs, &block)
       (object_name = retrieve_object_name(object)) if object_name.nil?
 
-      proxy_builder(object, object_name, self, {}).govuk_error_summary(*args, **kwargs)
+      proxy_builder(object, object_name, self, {}).govuk_error_summary(*args, **kwargs, &block)
     end
 
   private

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -4,8 +4,8 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Error
       include Traits::HTMLAttributes
 
-      def initialize(builder, object_name, title, link_base_errors_to:, order:, **kwargs)
-        super(builder, object_name, nil)
+      def initialize(builder, object_name, title, link_base_errors_to:, order:, **kwargs, &block)
+        super(builder, object_name, nil, &block)
 
         @title               = title
         @link_base_errors_to = link_base_errors_to
@@ -28,16 +28,12 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def summary
-        tag.div(class: summary_class('body')) do
-          tag.ul(class: [%(#{brand}-list), summary_class('list')]) do
-            safe_join(list)
-          end
-        end
+        tag.div(class: summary_class('body')) { safe_join([@block_content, list]) }
       end
 
       def list
-        error_messages.map do |attribute, messages|
-          list_item(attribute, messages.first)
+        tag.ul(class: [%(#{brand}-list), summary_class('list')]) do
+          safe_join(error_messages.map { |attribute, messages| list_item(attribute, messages.first) })
         end
       end
 

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -404,5 +404,25 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         let(:expected_class) { 'govuk-error-summary' }
       end
     end
+
+    context 'when a block of html is supplied' do
+      let(:custom_content_tag) { :marquee }
+      let(:custom_content_text) { "Fix the things below" }
+      subject do
+        builder.send(*args) do
+          builder.content_tag(custom_content_tag, custom_content_text)
+        end
+      end
+
+      before { object.valid? }
+
+      specify "the custom content should be present in the error summary" do
+        expect(subject).to have_tag("div", with: { class: "govuk-error-summary" }) do
+          with_tag("div", with: { class: "govuk-error-summary__body" }) do
+            with_tag(custom_content_tag, text: custom_content_text)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/govuk_design_system_formbuilder/helper/builder_helper_spec.rb
+++ b/spec/govuk_design_system_formbuilder/helper/builder_helper_spec.rb
@@ -106,5 +106,21 @@ describe GOVUKDesignSystemFormBuilder::BuilderHelper, type: :helper do
         is_expected.to render_an_error_summary.with(object.errors.size).errors
       end
     end
+
+    context 'when a block is provided' do
+      let(:custom_content_text) { "Fix the things below" }
+
+      subject do
+        helper.govuk_error_summary(*args) do
+          custom_content_text
+        end
+      end
+
+      specify "the custom content should be present in the error summary" do
+        expect(subject).to have_tag("div", with: { class: "govuk-error-summary" }) do
+          with_tag("div", with: { class: "govuk-error-summary__body" }, text: Regexp.new(custom_content_text))
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Allowing additional HTML to be passed into an error summary will help authors provide extra context around an error, as well as just listing the messages.
