### PR TITLE
Improve the error sorting index behaviour

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -41,8 +41,10 @@ module GOVUKDesignSystemFormBuilder
         messages = @builder.object.errors.messages
 
         if reorder_errors?
-          return messages.sort_by.with_index(1) do |(attr, _val), i|
-            error_order.index(attr) || (i + messages.size)
+          adjustment = error_order.size + messages.size
+
+          return messages.sort_by.with_index do |(attr, _val), i|
+            error_order.index(attr) || (i + adjustment)
           end
         end
 

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -132,7 +132,7 @@ class OrderedErrorsWithCustomOrder < OrderedErrors
   end
 end
 
-class OrderedErrorsWithCustomOrderAndExtraAttributes < OrderedErrors
+class OrderedErrorsWithExtraAttributes < OrderedErrors
   attribute :g, :string
   attribute :h, :string
   attribute :i, :string


### PR DESCRIPTION
Although it's unlikely to happen, using the number of error messages as the offset when placing unordered errors at the end of the list is the wrong strategy. If there are enough attributes before the ones we care about in the order arg, we can result in:

`total errors + count < ordered error index`

This leads to the ordered and unordered errors being shuffled together.

This is now avoided by creating an adjustment that's the combined total of error messages and custom ordered attributes, and adding the error counter to it.
