### PR TITLE
Make better use of RSpec HTML matcher's with_tag

### DIFF
--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
@@ -12,8 +12,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     subject { builder.send(*args) }
 
     specify 'output should be a form group containing a form group and fieldset' do
-      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-        expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' })
+      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+        with_tag('fieldset', with: { class: 'govuk-fieldset' })
       end
     end
 
@@ -60,9 +60,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     describe 'check boxes' do
       specify 'output should contain the correct number of check boxes' do
-        expect(subject).to have_tag('div', with: { 'data-module' => 'govuk-checkboxes' }) do |cb|
-          expect(cb).to have_tag('input', count: projects.size, with: { type: 'checkbox' })
-          expect(cb).to have_tag('label', count: projects.size)
+        expect(subject).to have_tag('div', with: { 'data-module' => 'govuk-checkboxes' }) do
+          with_tag('input', count: projects.size, with: { type: 'checkbox' })
+          with_tag('label', count: projects.size)
         end
       end
 

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
@@ -87,8 +87,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     context 'when a block containing check boxes is supplied' do
       specify 'output should be a form group containing a form group and fieldset' do
-        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-          expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' })
+        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+          with_tag('fieldset', with: { class: 'govuk-fieldset' })
         end
       end
 
@@ -102,8 +102,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         specify 'there should be a hidden field to represent deselection' do
           expected_name = %(#{object_name}[#{attribute}][])
 
-          expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-            expect(fg).to have_tag('input', with: { type: 'hidden', name: expected_name })
+          expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+            with_tag('input', with: { type: 'hidden', name: expected_name })
           end
         end
       end
@@ -112,8 +112,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         let(:kwargs) { { multiple: false } }
 
         specify 'no hidden field should be present' do
-          expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-            expect(fg).not_to have_tag('input', with: { type: 'hidden' })
+          expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+            without_tag('input', with: { type: 'hidden' })
           end
         end
       end

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -76,11 +76,11 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     specify 'should output a form group with fieldset, date group and 3 inputs and labels' do
-      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-        expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
-          expect(fs).to have_tag('div', with: { class: 'govuk-date-input' }) do |di|
-            expect(di).to have_tag('input', with: { type: 'text' }, count: 3)
-            expect(di).to have_tag('label', count: 3)
+      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+        with_tag('fieldset', with: { class: 'govuk-fieldset' }) do
+          with_tag('div', with: { class: 'govuk-date-input' }) do
+            with_tag('input', with: { type: 'text' }, count: 3)
+            with_tag('label', count: 3)
           end
         end
       end
@@ -88,9 +88,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     context 'separate date part inputs' do
       specify 'inputs should have the correct labels' do
-        expect(subject).to have_tag('div', with: { class: 'govuk-date-input' }) do |di|
+        expect(subject).to have_tag('div', with: { class: 'govuk-date-input' }) do
           %w(Day Month Year).each do |label_text|
-            expect(di).to have_tag('label', text: label_text)
+            with_tag('label', text: label_text)
           end
         end
       end

--- a/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/fieldset_spec.rb
@@ -25,9 +25,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     specify 'output should be a fieldset containing the block contents' do
-      expect(subject).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
-        expect(fs).to have_tag('legend', text: legend_text)
-        expect(fs).to have_tag('span', text: inner_text)
+      expect(subject).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do
+        with_tag('legend', text: legend_text)
+        with_tag('span', text: inner_text)
       end
     end
 
@@ -35,9 +35,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:legend_options) { { text: legend_text, size: 'm', tag: 'h3', hidden: true } }
 
       specify 'output should have classes according to size and visibility' do
-        expect(subject).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
-          expect(fs).to have_tag('legend', with: { class: 'govuk-fieldset__legend--m govuk-visually-hidden' }) do |lg|
-            expect(lg).to have_tag('h3', text: legend_text)
+        expect(subject).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do
+          with_tag('legend', with: { class: 'govuk-fieldset__legend--m govuk-visually-hidden' }) do
+            with_tag('h3', text: legend_text)
           end
         end
       end
@@ -51,10 +51,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       specify 'inner inputs should be contained in the fieldset' do
-        expect(subject).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
-          expect(fs).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-            expect(fg).to have_tag('label')
-            expect(fg).to have_tag('input')
+        expect(subject).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do
+          with_tag('div', with: { class: 'govuk-form-group' }) do
+            with_tag('label')
+            with_tag('input')
           end
         end
       end

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -18,8 +18,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     subject { builder.send(*args) }
 
     specify 'output should be a form group containing a form group and fieldset' do
-      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-        expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' })
+      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+        with_tag('fieldset', with: { class: 'govuk-fieldset' })
       end
     end
 

--- a/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
@@ -84,8 +84,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
     context 'when a block containing radio buttons is supplied' do
       specify 'output should be a form group containing a form group and fieldset' do
-        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-          expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' })
+        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+          with_tag('fieldset', with: { class: 'govuk-fieldset' })
         end
       end
 

--- a/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
@@ -10,13 +10,15 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     let(:attribute) { :stationery }
     let(:args) { [method, attribute, value] }
 
-    subject { builder.send(*args) }
+    subject do
+      builder.send(*args)
+    end
 
     it_behaves_like 'a field that supports custom branding'
 
     specify 'output should contain a radio item group with a radio input' do
-      expect(subject).to have_tag('div', with: { class: 'govuk-radios__item' }) do |ri|
-        expect(ri).to have_tag('input', with: { type: 'radio', value: value })
+      expect(subject).to have_tag('div', with: { class: 'govuk-radios__item' }) do
+        with_tag('input', with: { type: 'radio', value: value })
       end
     end
 

--- a/spec/govuk_design_system_formbuilder/builder/select_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/select_spec.rb
@@ -44,8 +44,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     specify 'output should be a form group containing a label and select box' do
-      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-        expect(fg).to have_tag('select', with: { class: 'govuk-select' })
+      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+        with_tag('select', with: { class: 'govuk-select' })
       end
     end
 

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -31,8 +31,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   end
 
   specify 'should output a form group containing a textarea' do
-    expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-      expect(fg).to have_tag('textarea')
+    expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+      with_tag('textarea')
     end
   end
 

--- a/spec/support/shared/shared_block_examples.rb
+++ b/spec/support/shared/shared_block_examples.rb
@@ -19,10 +19,10 @@ shared_examples 'a field that accepts arbitrary blocks of HTML' do
     end
 
     specify 'should include block content wrapped in a div with correct supplemental id' do
-      expect(subject).to have_tag('div', with: { id: supplemental_id }) do |sup|
-        expect(sup).to have_tag('h1', text: block_h1)
-        expect(sup).to have_tag('h2', text: block_h2)
-        expect(sup).to have_tag('p', text: block_p)
+      expect(subject).to have_tag('div', with: { id: supplemental_id }) do
+        with_tag('h1', text: block_h1)
+        with_tag('h2', text: block_h2)
+        with_tag('p', text: block_p)
       end
     end
   end

--- a/spec/support/shared/shared_hint_examples.rb
+++ b/spec/support/shared/shared_hint_examples.rb
@@ -3,14 +3,14 @@ shared_examples 'a field that supports hints' do
     subject { builder.send(*args, hint: { text: hint_text }) }
 
     specify 'output should contain a hint in a span tag' do
-      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-        expect(fg).to have_tag('span', text: hint_text, with: { class: 'govuk-hint' })
+      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+        with_tag('span', text: hint_text, with: { class: 'govuk-hint' })
       end
     end
 
     specify 'output should also contain the label and field elements' do
-      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-        ['label', field_type].each { |element| expect(fg).to have_tag(element) }
+      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+        ['label', field_type].each { |element| with_tag(element) }
       end
     end
 
@@ -43,8 +43,8 @@ shared_examples 'a field that supports hints' do
     subject { builder.send(*args, hint: hint) }
 
     specify 'output should contain a hint in a div tag' do
-      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-        expect(fg).to have_tag('div', with: { class: 'govuk-hint' })
+      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+        with_tag('div', with: { class: 'govuk-hint' })
       end
     end
 

--- a/spec/support/shared/shared_label_examples.rb
+++ b/spec/support/shared/shared_label_examples.rb
@@ -17,8 +17,8 @@ shared_examples 'a field that supports labels' do
       subject { builder.send(*args, label: { text: label_text, tag: wrapping_tag }) }
 
       specify 'the label should be wrapped in by the wrapping tag' do
-        expect(subject).to have_tag(wrapping_tag, with: { class: %w(govuk-label-wrapper) }) do |wt|
-          expect(wt).to have_tag('label', text: label_text)
+        expect(subject).to have_tag(wrapping_tag, with: { class: %w(govuk-label-wrapper) }) do
+          with_tag('label', text: label_text)
         end
       end
     end
@@ -115,10 +115,10 @@ shared_examples 'a field that supports labels as procs' do
   subject { builder.send(*args, label: label) }
 
   specify 'output fieldset should contain the specified tag' do
-    expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-      expect(fg).to have_tag('label', with: { class: 'govuk-label' }) do |fs|
-        expect(fs).to have_tag('span', class: caption_classes, text: caption)
-        expect(fs).to have_tag('h1', class: heading_classes, text: heading)
+    expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+      with_tag('label', with: { class: 'govuk-label' }) do
+        with_tag('span', class: caption_classes, text: caption)
+        with_tag('h1', class: heading_classes, text: heading)
       end
     end
   end

--- a/spec/support/shared/shared_legend_examples.rb
+++ b/spec/support/shared/shared_legend_examples.rb
@@ -18,8 +18,8 @@ shared_examples 'a field that supports a fieldset with legend' do
       subject { builder.send(*args, legend: { text: nil }) }
 
       specify 'output should contain a header set to the attribute name' do
-        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-          expect(fg).to have_tag('fieldset', text: attribute.capitalize, with: { class: 'govuk-fieldset' })
+        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+          with_tag('fieldset', text: attribute.capitalize, with: { class: 'govuk-fieldset' })
         end
       end
     end
@@ -29,9 +29,9 @@ shared_examples 'a field that supports a fieldset with legend' do
       subject { builder.send(*args, legend: { text: legend_text, tag: tag }) }
 
       specify 'output fieldset should contain the specified tag' do
-        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-          expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
-            expect(fs).to have_tag(tag, text: legend_text)
+        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+          with_tag('fieldset', with: { class: 'govuk-fieldset' }) do
+            with_tag(tag, text: legend_text)
           end
         end
       end
@@ -45,9 +45,9 @@ shared_examples 'a field that supports a fieldset with legend' do
             subject { builder.send(*args, legend: { text: legend_text, size: size }) }
 
             specify %(the legend size should be #{size}) do
-              expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-                expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
-                  expect(fs).to have_tag('legend', text: legend_text, class: "govuk-fieldset__legend--#{size}")
+              expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+                with_tag('fieldset', with: { class: 'govuk-fieldset' }) do
+                  with_tag('legend', text: legend_text, class: "govuk-fieldset__legend--#{size}")
                 end
               end
             end
@@ -107,10 +107,10 @@ shared_examples 'a field that supports a fieldset with legend' do
       subject { builder.send(*args, legend: legend) }
 
       specify 'output fieldset should contain the specified tag' do
-        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-          expect(fg).to have_tag('fieldset', with: { class: 'govuk-fieldset' }) do |fs|
-            expect(fs).to have_tag('span', class: caption_classes, text: caption)
-            expect(fs).to have_tag('h1', class: heading_classes, text: heading)
+        expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+          with_tag('fieldset', with: { class: 'govuk-fieldset' }) do
+            with_tag('span', class: caption_classes, text: caption)
+            with_tag('h1', class: heading_classes, text: heading)
           end
         end
       end

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -11,9 +11,9 @@ shared_examples 'a regular input' do |method_identifier, field_type|
   end
 
   specify 'output should be form group containing a label and input' do
-    expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do |fg|
-      expect(fg).to have_tag('label', text: label_text)
-      expect(fg).to have_tag('input')
+    expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+      with_tag('label', text: label_text)
+      with_tag('input')
     end
   end
 


### PR DESCRIPTION
The `#with_tag` syntax allows for traversing a HTML document without needing to provide blocks and block parameters at every level.

The following two snippets are equivalent:

```
specify "the div contains a p" do
  expect(subject).to have_tag("div") do |container|
    expect(container).to have_tag("p")
  end
end
```

```
specify "the div contains a p" do
  expect(subject).to have_tag("div") { with_tag("p") }
end
```
