### PR TITLE
Change `govuk_submit` from an `input` element to a `button` element

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -843,7 +843,7 @@ module GOVUKDesignSystemFormBuilder
 
     # Generates a submit button, green by default
     #
-    # @param text [String] the button text
+    # @param text [String,Proc] the button text. When a +Proc+ is provided its contents will be rendered within the button element
     # @param warning [Boolean] makes the button red ({https://design-system.service.gov.uk/components/button/#warning-buttons warning}) when true
     # @param secondary [Boolean] makes the button grey ({https://design-system.service.gov.uk/components/button/#secondary-buttons secondary}) when true
     # @param classes [Array,String] Classes to add to the submit button
@@ -853,7 +853,7 @@ module GOVUKDesignSystemFormBuilder
     #   client-side validation provided by the browser. This is to provide a more consistent and accessible user
     #   experience
     # @param disabled [Boolean] makes the button disabled when true
-    # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
+    # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +button+ element
     # @param block [Block] When content is passed in via a block the submit element and the block content will
     #   be wrapped in a +<div class="govuk-button-group">+ which will space the buttons and links within
     #   evenly.
@@ -861,8 +861,9 @@ module GOVUKDesignSystemFormBuilder
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @note Only the first additional button or link (passed in via a block) will be given the
     #   correct left margin, subsequent buttons will need to be manually accounted for
-    # @note This helper always renders an +<input type='submit'>+ tag, HTML content is not supported inside. You
-    #   can place +<button>+ tags inside the form to have the same effect
+    # @note This helper always renders an +<button type='submit'>+ tag. Previous versions of this gem rendered
+    #   a +`<input type='submit'>' tag instead, but there is a {https://github.com/alphagov/govuk_elements/issues/545 longstanding bug}
+    #   with this approach where the top few pixels don't initiate a submission when clicked.
     # @see https://design-system.service.gov.uk/components/button/#stop-users-from-accidentally-sending-information-more-than-once
     #   GOV.UK double click prevention
     #

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -35,11 +35,12 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def submit
-        @builder.submit(@text, **attributes(@html_attributes))
+        @builder.tag.button(@text, **attributes(@html_attributes))
       end
 
       def options
         {
+          type: 'submit',
           formnovalidate: !@validate,
           disabled: @disabled,
           class: classes,

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -9,7 +9,7 @@ module GOVUKDesignSystemFormBuilder
 
         fail ArgumentError, 'buttons can be warning or secondary' if warning && secondary
 
-        @text                 = text
+        @text                 = build_text(text)
         @prevent_double_click = prevent_double_click
         @warning              = warning
         @secondary            = secondary
@@ -25,6 +25,17 @@ module GOVUKDesignSystemFormBuilder
       end
 
     private
+
+      def build_text(text)
+        case text
+        when String
+          text
+        when Proc
+          capture { text.call }
+        else
+          fail(ArgumentError, %(text must be a String or Proc))
+        end
+      end
 
       def button_group
         Containers::ButtonGroup.new(@builder, buttons).html

--- a/spec/govuk_design_system_formbuilder/builder/configuration/submit_configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration/submit_configuration_spec.rb
@@ -25,7 +25,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
 
         specify 'should use the default value when no override supplied' do
-          expect(subject).to have_tag('input', with: { type: 'submit', value: default_submit_button_text })
+          expect(subject).to have_tag('button', with: { type: 'submit' }, text: default_submit_button_text)
         end
 
         context %(overriding with 'Engage') do
@@ -33,7 +33,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           let(:args) { [method, submit_button_text] }
 
           specify 'should use supplied value when overridden' do
-            expect(subject).to have_tag('input', with: { type: 'submit', value: submit_button_text })
+            expect(subject).to have_tag('button', with: { type: 'submit' }, text: submit_button_text)
           end
         end
       end
@@ -55,14 +55,14 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
 
         specify 'should have no formnovalidate attribute' do
-          expect(parsed_subject.at_css('input').attributes.keys).not_to include('formnovalidate')
+          expect(parsed_subject.at_css('button').attributes.keys).not_to include('formnovalidate')
         end
 
         context %(overriding with false) do
           let(:kwargs) { { validate: false } }
 
           specify 'should have a formnovalidate attribute' do
-            expect(subject).to have_tag('input', with: { type: 'submit', formnovalidate: 'formnovalidate' })
+            expect(subject).to have_tag('button', with: { type: 'submit', formnovalidate: 'formnovalidate' })
           end
         end
       end

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -12,37 +12,37 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports custom branding'
 
     it_behaves_like 'a field that supports custom classes' do
-      let(:element) { 'input' }
+      let(:element) { 'button' }
       let(:default_classes) { %w(govuk-button) }
       let(:block_content) { -> { %(Example) } }
     end
 
     it_behaves_like 'a field that allows extra HTML attributes to be set' do
-      let(:described_element) { 'input' }
+      let(:described_element) { 'button' }
       let(:expected_class) { 'govuk-button' }
     end
 
-    specify 'output should be a submit input' do
-      expect(subject).to have_tag('input', with: { type: 'submit' })
+    specify 'output should be a button element' do
+      expect(subject).to have_tag('button', with: { type: 'submit' })
     end
 
     specify 'button should have the correct classes' do
-      expect(subject).to have_tag('input', with: { class: 'govuk-button' })
+      expect(subject).to have_tag('button', with: { class: 'govuk-button' })
     end
 
     specify 'button should have the correct text' do
-      expect(subject).to have_tag('input', with: { value: text })
+      expect(subject).to have_tag('button', text: text)
     end
 
     specify 'button should have the govuk-button data-module' do
-      expect(subject).to have_tag('input', with: { 'data-module' => 'govuk-button' })
+      expect(subject).to have_tag('button', with: { 'data-module' => 'govuk-button' })
     end
 
     context 'when no value is passed in' do
       subject { builder.send(method) }
 
       specify %(it should default to 'Continue) do
-        expect(subject).to have_tag('input', with: { value: 'Continue' })
+        expect(subject).to have_tag('button', text: 'Continue')
       end
     end
 
@@ -51,7 +51,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         subject { builder.send(*args.push('Create'), warning: true) }
 
         specify 'button should have the warning class' do
-          expect(subject).to have_tag('input', with: { class: %w(govuk-button govuk-button--warning) })
+          expect(subject).to have_tag('button', with: { class: %w(govuk-button govuk-button--warning) })
         end
       end
 
@@ -59,7 +59,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         subject { builder.send(*args.push('Create'), secondary: true) }
 
         specify 'button should have the secondary class' do
-          expect(subject).to have_tag('input', with: { class: %w(govuk-button govuk-button--secondary) })
+          expect(subject).to have_tag('button', with: { class: %w(govuk-button govuk-button--secondary) })
         end
       end
 
@@ -75,14 +75,14 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         subject { builder.send(*args.push('Create'), classes: %w(custom-class--one custom-class--two)) }
 
         specify 'button should have the custom class' do
-          expect(subject).to have_tag('input', with: { class: %w(govuk-button custom-class--one custom-class--two) })
+          expect(subject).to have_tag('button', with: { class: %w(govuk-button custom-class--one custom-class--two) })
         end
       end
     end
 
     describe 'preventing double clicks' do
       specify 'data attribute should be present by default' do
-        expect(subject).to have_tag('input', with: { 'data-prevent-double-click' => true })
+        expect(subject).to have_tag('button', with: { 'data-prevent-double-click' => true })
       end
 
       context 'when disabled' do
@@ -90,7 +90,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
         specify 'data attribute should not be present by default' do
           expect(
-            parsed_subject.at_css('input').attributes.keys
+            parsed_subject.at_css('button').attributes.keys
           ).not_to include('data-prevent-double-click')
         end
       end
@@ -112,8 +112,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
       specify 'should wrap the buttons and extra content in a button group' do
         expect(subject).to have_tag('div', with: { class: 'govuk-button-group' }) do
-          with_tag('input', value: text)
-          with_tag('a', with: { href: target })
+          with_tag('button', text: 'Continue')
+          with_tag('a', text: text, with: { href: target })
         end
       end
     end
@@ -123,7 +123,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         subject { builder.send(*args) }
 
         specify 'should have attribute formnovalidate' do
-          expect(subject).to have_tag('input', with: { type: 'submit', formnovalidate: 'formnovalidate' })
+          expect(subject).to have_tag('button', with: { type: 'submit', formnovalidate: 'formnovalidate' })
         end
       end
 
@@ -131,7 +131,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         subject { builder.send(*args, validate: false) }
 
         specify 'should have attribute formnovalidate' do
-          expect(subject).to have_tag('input', with: { type: 'submit', formnovalidate: 'formnovalidate' })
+          expect(subject).to have_tag('button', with: { type: 'submit', formnovalidate: 'formnovalidate' })
         end
       end
 
@@ -139,7 +139,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         subject { builder.send(*args, validate: true) }
 
         specify 'should have attribute formnovalidate' do
-          expect(parsed_subject.at_css('input').attributes.keys).not_to include('formnovalidate')
+          expect(parsed_subject.at_css('button').attributes.keys).not_to include('formnovalidate')
         end
       end
     end
@@ -148,17 +148,17 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       context 'when disabled is false' do
         subject { builder.send(*args.push('Create')) }
 
-        specify 'input should not have the disabled attribute' do
-          expect(parsed_subject.at_css('input').attributes.keys).not_to include('disabled')
+        specify 'button should not have the disabled attribute' do
+          expect(parsed_subject.at_css('button').attributes.keys).not_to include('disabled')
         end
       end
 
       context 'when disabled is true' do
         subject { builder.send(*args.push('Create'), disabled: true) }
 
-        specify 'input should have the disabled attribute' do
-          expect(parsed_subject.at_css('input').attributes.keys).to include('disabled')
-          expect(subject).to have_tag('input', with: { class: %w(govuk-button govuk-button--disabled) })
+        specify 'button should have the disabled attribute' do
+          expect(parsed_subject.at_css('button').attributes.keys).to include('disabled')
+          expect(subject).to have_tag('button', with: { class: %w(govuk-button govuk-button--disabled) })
         end
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -162,5 +162,27 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
     end
+
+    describe 'setting the button content with a proc' do
+      let(:custom_text) { "Click me!" }
+      let(:custom_wrapper) { :strong }
+      let(:custom_content) { builder.content_tag(custom_wrapper, custom_text) }
+
+      subject { builder.send(*args, custom_content) }
+
+      specify "renders the custom content inside the button element" do
+        expect(subject).to have_tag("button") do
+          with_tag(custom_wrapper, text: custom_text)
+        end
+      end
+
+      context "when the button content is invalid" do
+        subject { builder.send(*args, Date.today) }
+
+        specify "fails with an appropriate error message" do
+          expect { subject }.to raise_error(ArgumentError, /text must be a String or Proc/)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This addresses [a bug where `<input type="submit">` doesn't initiate a submission when the very top of the element is clicked](https://github.com/alphagov/govuk_elements/issues/545) and is [more in-line with the Design System guidance](https://design-system.service.gov.uk/components/button/#default-buttons).

Additionally, now it's rendering a `<button>` element the text argument can be provided with a block to allow for custom HTML.
