### PR TITLE
Upgrade to GOV.UK Frontend version 3.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/fde73b5dc9476197281b/test_coverage)](https://codeclimate.com/github/DFE-Digital/govuk_design_system_formbuilder/test_coverage)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=DFE-Digital/govuk_design_system_formbuilder)](https://dependabot.com)
 [![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk_design_system_formbuilder)](https://github.com/DFE-Digital/govuk_design_system_formbuilder/blob/master/LICENSE)
-[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.12.0-brightgreen)](https://design-system.service.gov.uk)
+[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.13.0-brightgreen)](https://design-system.service.gov.uk)
 [![Rails](https://img.shields.io/badge/Ruby-2.6.7%20%E2%95%B1%202.7.3%20%E2%95%B1%203.0.1-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 [![Ruby](https://img.shields.io/badge/Rails-6.0.4%20%E2%95%B1%206.1.3.2-E16D6D)](https://weblog.rubyonrails.org/releases/)
 

--- a/guide/content/form-elements/checkboxes.slim
+++ b/guide/content/form-elements/checkboxes.slim
@@ -81,4 +81,24 @@ section
           <code>name</code> attribute is generated in the format that Rails
           expects for a single field.
 
+  == render('/partials/example-fig.*',
+    caption: "Adding an option for 'none of the above'",
+    code: checkbox_field_with_exclusive_option) do
+
+    p.govuk-body
+      | Sometimes none of the checkbox options apply, but leaving them
+        all blank isn't always intuitive for users.
+
+    p.govuk-body
+      | Check boxes created with <code>exclusive: true</code> have special
+        behaviour that:
+
+    ul.govuk-list.govuk-list--bullet
+      li unchecks all other check boxes in the fieldset when they are checked
+      li unchecks them when any other check boxes in the fieldset are checked
+
+    p.govuk-body
+      | It usually makes sense to separate exclusive check boxes from the
+        others with a divider.
+
 == render('/partials/related-info.*', links: checkbox_info)

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -16,7 +16,7 @@ dl.govuk-summary-list
       ul.govuk-list
         li
           span.govuk-tag.govuk-tag-govuk
-            | Version 3.12.0
+            | Version 3.13.0
 
   .govuk-summary-list__row
     dt.govuk-summary-list__key

--- a/guide/lib/examples/checkboxes.rb
+++ b/guide/lib/examples/checkboxes.rb
@@ -84,5 +84,31 @@ module Examples
             label: { text: "I agree to the terms and conditions" }
       SNIPPET
     end
+
+    def checkbox_field_with_exclusive_option
+      <<~SNIPPET
+        = f.govuk_check_boxes_fieldset :countries, legend: { text: "Will you be travelling to any of these countries?", size: "m" } do
+
+          = f.govuk_check_box :countries,
+            :france,
+            label: { text: "France" },
+            link_errors: true
+
+          = f.govuk_check_box :languages,
+            :portugal,
+            label: { text: "Portugal" }
+
+          = f.govuk_check_box :languages,
+            :spain,
+            label: { text: "Spain" }
+
+          = f.govuk_check_box_divider
+
+          = f.govuk_check_box :languages,
+            :none,
+            exclusive: true,
+            label: { text: "No, I will not be travelling to any of these countries " }
+      SNIPPET
+    end
   end
 end

--- a/guide/lib/helpers/person.rb
+++ b/guide/lib/helpers/person.rb
@@ -50,7 +50,8 @@ class Person
     :other_language,
     :movie_genres,
     :other_movie_genres,
-    :terms_and_conditions_agreed
+    :terms_and_conditions_agreed,
+    :countries
   )
 
   # textarea fields

--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -1,13 +1,30 @@
 {
   "name": "guide",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "govuk-frontend": "^3.13.0"
+      }
+    },
+    "node_modules/govuk-frontend": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.13.0.tgz",
+      "integrity": "sha512-JiPCeasuHZ+9m1VyqhsfE81PhWIW4Sweoe6Jvn6oMjQNr75ZpupiytN3DGwA+WKOoESHZibIG+heAzlkdZ/MhA==",
+      "engines": {
+        "node": ">= 4.2.0"
+      }
+    }
+  },
   "dependencies": {
     "govuk-frontend": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.12.0.tgz",
-      "integrity": "sha512-+mM8BqEUqsBVSV/ud0dEhE8OmMdhkK53eEUp5YyPN+y3mwcdRnwwP2A2B5qFdFi6E6j/2AYuCG8l5kXD+JXNxA=="
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.13.0.tgz",
+      "integrity": "sha512-JiPCeasuHZ+9m1VyqhsfE81PhWIW4Sweoe6Jvn6oMjQNr75ZpupiytN3DGwA+WKOoESHZibIG+heAzlkdZ/MhA=="
     }
   }
 }

--- a/guide/package.json
+++ b/guide/package.json
@@ -12,6 +12,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "govuk-frontend": "^3.12.0"
+    "govuk-frontend": "^3.13.0"
   }
 }

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -27,6 +27,12 @@ module GOVUKDesignSystemFormBuilder
   # * +:default_submit_button_text+ sets the value assigned to +govuk_submit+,
   #   defaults to 'Continue'.
   #
+  # * +:default_radio_divider_text+ sets the text automatically added to the
+  #   radio button divider, defaults to 'or'
+  #
+  # * +:default_check_box_divider_text+ sets the text automatically added to the
+  #   checkbox divider, defaults to 'or'
+  #
   # * +:default_submit_button_text+ sets the text used to divide the last radio
   #   button in radio button fieldsets. As per the GOV.UK Design System spec,
   #   it defaults to 'or'.
@@ -65,6 +71,7 @@ module GOVUKDesignSystemFormBuilder
     default_caption_size: 'm',
     default_submit_button_text: 'Continue',
     default_radio_divider_text: 'or',
+    default_check_box_divider_text: 'or',
     default_error_summary_title: 'There is a problem',
     default_error_summary_error_order_method: nil,
     default_collection_check_boxes_include_hidden: true,

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -813,6 +813,8 @@ module GOVUKDesignSystemFormBuilder
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @option label kwargs [Hash] additional arguments are applied as attributes on the +label+ element
     # @param multiple [Boolean] controls whether the check box is part of a collection or represents a single attribute
+    # @param exclusive [Boolean] sets the checkbox so that when checked none of its siblings can be too. Usually
+    #   used for the 'None of these apply to me' option found beneath a {#govuk_check_box_divider}.
     # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     # @param block [Block] any HTML passed in will form the contents of the fieldset
     # @return [ActiveSupport::SafeBuffer] HTML output
@@ -825,7 +827,7 @@ module GOVUKDesignSystemFormBuilder
     #     label: { text: 'Do you agree with our terms and conditions?' },
     #     hint: { text: 'You will not be able to proceed unless you do' }
     #
-    def govuk_check_box(attribute_name, value, unchecked_value = false, hint: {}, label: {}, link_errors: false, multiple: true, **kwargs, &block)
+    def govuk_check_box(attribute_name, value, unchecked_value = false, hint: {}, label: {}, link_errors: false, multiple: true, exclusive: false, **kwargs, &block)
       Elements::CheckBoxes::FieldsetCheckBox.new(
         self,
         object_name,
@@ -836,6 +838,7 @@ module GOVUKDesignSystemFormBuilder
         label: label,
         link_errors: link_errors,
         multiple: multiple,
+        exclusive: exclusive,
         **kwargs,
         &block
       ).html

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -841,6 +841,18 @@ module GOVUKDesignSystemFormBuilder
       ).html
     end
 
+    # Inserts a text divider into a list of check boxes
+    #
+    # @param text [String] The divider text
+    # @note This should only be used from within a {#govuk_check_boxes_fieldset}
+    # @see https://design-system.service.gov.uk/components/checkboxes/#add-an-option-for-none- GOV.UK check boxes with a text divider
+    # @return [ActiveSupport::SafeBuffer] HTML output
+    # @example A custom divider
+    #   = govuk_check_box_divider 'On the other hand'
+    def govuk_check_box_divider(text = config.default_check_box_divider_text)
+      tag.div(text, class: %w(govuk-checkboxes__divider))
+    end
+
     # Generates a submit button, green by default
     #
     # @param text [String,Proc] the button text. When a +Proc+ is provided its contents will be rendered within the button element

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/fieldset_check_box.rb
@@ -7,7 +7,7 @@ module GOVUKDesignSystemFormBuilder
         include Traits::HTMLAttributes
         include Traits::FieldsetItem
 
-        def initialize(builder, object_name, attribute_name, value, unchecked_value, label:, hint:, link_errors:, multiple:, **kwargs, &block)
+        def initialize(builder, object_name, attribute_name, value, unchecked_value, label:, hint:, link_errors:, multiple:, exclusive:, **kwargs, &block)
           super(builder, object_name, attribute_name)
 
           @value           = value
@@ -17,6 +17,7 @@ module GOVUKDesignSystemFormBuilder
           @multiple        = multiple
           @link_errors     = link_errors
           @html_attributes = kwargs
+          @exclusive       = exclusive
 
           conditional_content(&block)
         end
@@ -28,11 +29,17 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def input
-          @builder.check_box(@attribute_name, attributes(@html_attributes), @value, @unchecked_value)
+          @builder.check_box(@attribute_name, attributes(@html_attributes.deep_merge(exclusive_options)), @value, @unchecked_value)
         end
 
         def fieldset_options
           { checkbox: true }
+        end
+
+        def exclusive_options
+          return {} unless @exclusive
+
+          { data: { behaviour: 'exclusive' } }
         end
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
@@ -133,7 +133,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
-    context 'multiple' do
+    describe 'multiple' do
       context 'default to multiple' do
         specify 'check box name should allow multiple values' do
           expect(subject).to have_tag('input', with: {
@@ -151,6 +151,37 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             type: 'checkbox',
             name: "#{object_name}[#{attribute}]"
           })
+        end
+      end
+    end
+
+    describe 'exclusive' do
+      context 'default to non-exclusive' do
+        specify 'check box should have no data behaviour attribute' do
+          expect(subject).not_to have_tag('input', with: { type: 'checkbox', 'data-behaviour' => 'exclusive' })
+        end
+      end
+
+      context 'when overriden to exclusive' do
+        subject { builder.send(*args, exclusive: true) }
+
+        specify %(check box should has a data behaviour attribute of 'exclusive') do
+          expect(subject).to have_tag('input', with: { type: 'checkbox', 'data-behaviour' => 'exclusive' })
+        end
+      end
+
+      context 'not clashing with other data attributes' do
+        subject { builder.send(*args, exclusive: true, data: { index: '1234' }) }
+
+        specify %(check box should has a data behaviour attribute of 'exclusive') do
+          expect(subject).to have_tag(
+            'input',
+            with: {
+              type: 'checkbox',
+              'data-behaviour' => 'exclusive',
+              'data-index' => '1234'
+            }
+          )
         end
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/fieldset_spec.rb
@@ -151,6 +151,31 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           end
         end
       end
+
+      context 'dividers' do
+        subject do
+          builder.send(*args) do
+            builder.govuk_check_box_divider
+          end
+        end
+
+        specify "should output a 'or' divider by default" do
+          expect(subject).to have_tag('div', text: 'or', with: { class: %w(govuk-checkboxes__divider) })
+        end
+
+        context 'when divider text overridden' do
+          let(:other_text) { 'alternatively' }
+          subject do
+            builder.send(method, attribute) do
+              builder.govuk_check_box_divider(other_text)
+            end
+          end
+
+          specify "should output a divider containing the supplied text" do
+            expect(subject).to have_tag('div', text: other_text, with: { class: %w(govuk-checkboxes__divider) })
+          end
+        end
+      end
     end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/configuration/check_box_divider_configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration/check_box_divider_configuration_spec.rb
@@ -1,0 +1,41 @@
+describe GOVUKDesignSystemFormBuilder::FormBuilder do
+  include_context 'setup builder'
+  include_context 'setup examples'
+
+  after { GOVUKDesignSystemFormBuilder.reset! }
+
+  describe 'checkbox divider config' do
+    specify %(the default should be 'or') do
+      expect(GOVUKDesignSystemFormBuilder.config.default_check_box_divider_text).to eql('or')
+    end
+
+    context 'overriding with custom text' do
+      let(:method) { :govuk_check_box_divider }
+      let(:args) { [method] }
+      let(:default_check_box_divider_text) { 'Actually, how about' }
+
+      subject { builder.send(*args) }
+
+      before do
+        GOVUKDesignSystemFormBuilder.configure do |conf|
+          conf.default_check_box_divider_text = default_check_box_divider_text
+        end
+      end
+
+      specify 'should use the default value when no override supplied' do
+        expect(subject).to have_tag('div', text: default_check_box_divider_text, with: { class: 'govuk-checkboxes__divider' })
+      end
+
+      context %(overriding with 'Alternately') do
+        let(:check_box_divider_text) { 'Alternately' }
+        let(:args) { [method, check_box_divider_text] }
+
+        subject { builder.send(*args) }
+
+        specify 'should use supplied text when overridden' do
+          expect(subject).to have_tag('div', text: check_box_divider_text, with: { class: 'govuk-checkboxes__divider' })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add the `#govuk_check_box_divider` helper
- Add support for [exclusive checkboxes](/alphagov/govuk-frontend/pull/2151) via an `exclusive:` keyword argument
- Bump GOV.UK frontend supported version to [3.13.0](/alphagov/govuk-frontend/pull/2259)
- Add an guide entry for exclusive checkbox options
