### PR TITLE
Replace `Base#described_by`

### DIFF
--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -57,7 +57,7 @@ module GOVUKDesignSystemFormBuilder
         @builder.object.errors.messages[@attribute_name].present?
     end
 
-    def described_by(*ids)
+    def combine_references(*ids)
       ids.flatten.compact
     end
 

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
@@ -22,7 +22,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def classes
-        [%(#{brand}-checkboxes), small_class, custom_classes].flatten.compact
+        combine_references(%(#{brand}-checkboxes), small_class, custom_classes)
       end
 
       def small_class

--- a/lib/govuk_design_system_formbuilder/containers/fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/fieldset.rb
@@ -8,7 +8,7 @@ module GOVUKDesignSystemFormBuilder
 
         @legend          = legend
         @caption         = caption
-        @described_by    = described_by(described_by)
+        @described_by    = combine_references(described_by)
         @attribute_name  = attribute_name
         @html_attributes = kwargs
       end

--- a/lib/govuk_design_system_formbuilder/containers/form_group.rb
+++ b/lib/govuk_design_system_formbuilder/containers/form_group.rb
@@ -15,7 +15,7 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def classes
-        [form_group_class, error_class, custom_classes].flatten.compact
+        combine_references(form_group_class, error_class, custom_classes)
       end
 
       def form_group_class

--- a/lib/govuk_design_system_formbuilder/containers/radios.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radios.rb
@@ -25,7 +25,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def classes
-        [%(#{brand}-radios), inline_class, small_class, custom_classes].flatten.compact
+        combine_references(%(#{brand}-radios), inline_class, small_class, custom_classes)
       end
 
       def inline_class

--- a/lib/govuk_design_system_formbuilder/elements/collection_select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/collection_select.rb
@@ -40,7 +40,7 @@ module GOVUKDesignSystemFormBuilder
         {
           id: field_id(link_errors: true),
           class: classes,
-          aria: { describedby: described_by(hint_id, error_id, supplemental_id) }
+          aria: { describedby: combine_references(hint_id, error_id, supplemental_id) }
         }
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -35,7 +35,7 @@ module GOVUKDesignSystemFormBuilder
         {
           id: field_id(link_errors: true),
           class: classes,
-          aria: { describedby: described_by(hint_id, error_id, supplemental_id) }
+          aria: { describedby: combine_references(hint_id, error_id, supplemental_id) }
         }
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/select.rb
@@ -38,7 +38,7 @@ module GOVUKDesignSystemFormBuilder
         {
           id: field_id(link_errors: true),
           class: classes,
-          aria: { describedby: described_by(hint_id, error_id) }
+          aria: { describedby: combine_references(hint_id, error_id) }
         }
       end
     end

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -53,7 +53,7 @@ module GOVUKDesignSystemFormBuilder
           id: field_id(link_errors: true),
           class: classes,
           rows: @rows,
-          aria: { describedby: described_by(hint_id, error_id, supplemental_id, limit_description_id) },
+          aria: { describedby: combine_references(hint_id, error_id, supplemental_id, limit_description_id) },
         }
       end
 

--- a/lib/govuk_design_system_formbuilder/traits/input.rb
+++ b/lib/govuk_design_system_formbuilder/traits/input.rb
@@ -48,7 +48,7 @@ module GOVUKDesignSystemFormBuilder
         {
           id: field_id(link_errors: true),
           class: classes,
-          aria: { describedby: described_by(hint_id, error_id, supplemental_id) }
+          aria: { describedby: combine_references(hint_id, error_id, supplemental_id) }
         }
       end
 

--- a/lib/govuk_design_system_formbuilder/traits/select.rb
+++ b/lib/govuk_design_system_formbuilder/traits/select.rb
@@ -4,7 +4,7 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def classes
-        [%(#{brand}-select), error_class].flatten.compact
+        combine_references(%(#{brand}-select), error_class)
       end
 
       def error_class


### PR DESCRIPTION
The `#described_by` method was poorly-named and its functionality didn't actually have anything specifically to do with setting the `aria-describedby` value - it's just a generic method that combines the provided arguments into a unique array.

It has been renamed to `#combine_references` and it's now used in several other places where arrays of references to elements are combined.


### Bonus

We can finally get rid of this amazing line from an initializer 😅 

```diff
- @described_by    = described_by(described_by)
+ @described_by    = combine_references(described_by)
```