### PR TITLE
Remove `aria-describedby` link between labels/legends and supplemental content

### DIFF
--- a/guide/content/building-blocks/injecting-content.slim
+++ b/guide/content/building-blocks/injecting-content.slim
@@ -9,11 +9,6 @@ p.govuk-body
     into most helpers. This content is inserted after the hint and before the
     form control.
 
-p.govuk-inset-text
-  | Injected content is automatically associated with the element via its
-    <code>aria-describedby</code> attribute allowing assistive technologies to
-    provide the user with a full explanation of what is required.
-
 p.govuk-body
   | The following helpers support content injection:
 

--- a/lib/govuk_design_system_formbuilder/containers/supplemental.rb
+++ b/lib/govuk_design_system_formbuilder/containers/supplemental.rb
@@ -10,15 +10,7 @@ module GOVUKDesignSystemFormBuilder
       def html
         return if @content.blank?
 
-        warn("Supplemental content is deprecated and support will soon be removed. See https://github.com/x-govuk/govuk-form-builder/issues/445")
-
-        tag.div(id: supplemental_id) { @content }
-      end
-
-    private
-
-      def supplemental_id
-        build_id('supplemental')
+        tag.div { @content }
       end
     end
   end

--- a/spec/support/shared/shared_block_examples.rb
+++ b/spec/support/shared/shared_block_examples.rb
@@ -3,8 +3,6 @@ shared_examples 'a field that accepts arbitrary blocks of HTML' do
   let(:block_h2) { 'Jumped over the' }
   let(:block_p) { 'Lazy dog.' }
 
-  let(:supplemental_id) { underscores_to_dashes([object_name, attribute, 'supplemental'].join('-')) }
-
   context 'when a block is supplied' do
     subject do
       builder.send(*args) do
@@ -14,37 +12,12 @@ shared_examples 'a field that accepts arbitrary blocks of HTML' do
       end
     end
 
-    specify 'should be associated with the containing element' do
-      expect(subject).to have_tag(described_element, with: { 'aria-describedby' => supplemental_id })
-    end
-
-    specify 'should include block content wrapped in a div with correct supplemental id' do
-      expect(subject).to have_tag('div', with: { id: supplemental_id }) do
+    specify 'should include block content wrapped in a div' do
+      expect(subject).to have_tag('div') do
         with_tag('h1', text: block_h1)
         with_tag('h2', text: block_h2)
         with_tag('p', text: block_p)
       end
-    end
-
-    describe "deprecation warning message" do
-      before { allow(Rails).to receive_message_chain(:logger, :warn).with(any_args).and_return(true) }
-
-      specify 'logs a deprecation warning' do
-        subject
-        expect(Rails.logger).to have_received(:warn).with(/Supplemental content is deprecated/)
-      end
-    end
-  end
-
-  context 'when no block is supplied' do
-    subject { builder.send(*args) }
-
-    specify 'should be no supplemental container' do
-      expect(subject).not_to have_tag('div', with: { id: supplemental_id })
-    end
-
-    specify 'should be no association with the supplemental container' do
-      expect(subject).not_to have_tag(described_element, with: { 'aria-describedby' => supplemental_id })
     end
   end
 end


### PR DESCRIPTION
This change removes the aria-describedby link between labels/legends and supplemental content, and the warnings that were added in #456.

It still allows arbitrary HTML content to be passed in, and it'll be rendered in the same place - but importantly, now it won't be read out by screen readers. This can be a frustrating experience for screenreader users if there's multiple paragraphs read out between the label and the input itself.
