### PR TITLE
Add `govuk_time_field`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,8 @@ AllCops:
     - govuk_design_system_formbuilder.gemspec
 Rails/Date:
   Enabled: false
+Rails/TimeZone:
+  Enabled: false
 Rails/ActiveSupportAliases:
   Enabled: false
 Style/StringLiterals:

--- a/guide/content/form-elements/date-input.slim
+++ b/guide/content/form-elements/date-input.slim
@@ -65,4 +65,36 @@ ul.govuk-list.govuk-list--bullet
       This will default the day and month inputs to 2 characters and the year
       input to 4 characters.
 
+== render('/partials/example.*',
+  caption: 'Exact time input with legend and hint and birth date autocompletion',
+  code: time_field)
+
+  p.govuk-body
+    | When asking for a time, a variation of the date input can be used which
+      displays an input for the hour, minute and second. The time input’s
+      parameters match those used by Rails’ <code>time_select</code> helper.
+
+  .govuk-warning-text
+    span.govuk-warning-text__icon aria-hidden=true
+      | !
+    strong.govuk-warning-text__text
+      span.govuk-warning-text__assistive Warning
+
+      | Time inputs are not currently part of the GOV.UK Design System.
+
+== render('/partials/example.*',
+  caption: 'Approximate times – recording the minute',
+  code: time_omit_second_field) do
+
+  p.govuk-body
+    | When asking for times that are not required to be precise to the nearest
+      second, the second can be optionally omitted by providing the
+      <code>omit_second</code> parameter.
+
+  p.govuk-body
+    | When mapped to a <code>Time</code> attribute, Ruby will automatically
+      set the <code>Second</code> to be <code>0</code> when none is provided.
+      This should be taken into account when displaying the data or using it
+      for analysis.
+
 == render('/partials/related-navigation.*', links: date_info)

--- a/guide/lib/examples/date.rb
+++ b/guide/lib/examples/date.rb
@@ -26,5 +26,22 @@ module Examples
           hint: { text: 'Use the format day, month, year, for example 27 3 2021' }
       SNIPPET
     end
+
+    def time_field
+      <<~SNIPPET
+        = f.govuk_time_field :time_of_birth,
+          legend: { text: 'Enter your time of birth' },
+          hint: { text: 'For example, 12 30 45' }
+      SNIPPET
+    end
+
+    def time_omit_second_field
+      <<~SNIPPET
+        = f.govuk_time_field :time_of_birth,
+          omit_second: true,
+          legend: { text: 'Enter your time of birth' },
+          hint: { text: 'For example, 12 30' }
+      SNIPPET
+    end
   end
 end

--- a/guide/lib/helpers/person.rb
+++ b/guide/lib/helpers/person.rb
@@ -77,6 +77,12 @@ class Person
     :graduation_month
   )
 
+  # time fields
+  attr_accessor(
+    :time_of_birth,
+    :time_of_vaccination
+  )
+
   # labels, captions, hints and legends
   attr_accessor(
     :favourite_colour,

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -111,6 +111,8 @@ module GOVUKDesignSystemFormBuilder
     default_submit_button_text: 'Continue',
     default_date_segments: { day: '3i', month: '2i', year: '1i' },
     default_date_segment_names: { day: 'Day', month: 'Month', year: 'Year' },
+    default_time_segments: { hour: '4i', minute: '5i', second: '6i' },
+    default_time_segment_names: { hour: 'Hour', minute: 'Minute', second: 'Second' },
     default_radio_divider_text: 'or',
     default_check_box_divider_text: 'or',
     default_error_message_prefix: 'Error',

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -957,13 +957,61 @@ module GOVUKDesignSystemFormBuilder
     #     hint: { text: 'Leave this field blank if you don't know exactly' } do
     #
     #       p.govuk-inset-text
-    #         | If you don't fill this in you won't be eligable for a refund
+    #         | If you don't fill this in you won't be eligible for a refund
     #
     # @example A date input with legend supplied as a proc
     #  = f.govuk_date_field :finishes_on,
     #    legend: -> { tag.h3('Which category do you belong to?') }
     def govuk_date_field(attribute_name, hint: {}, legend: {}, caption: {}, date_of_birth: false, omit_day: false, maxlength_enabled: false, segments: config.default_date_segments, segment_names: config.default_date_segment_names, form_group: {}, **kwargs, &block)
       Elements::Date.new(self, object_name, attribute_name, hint:, legend:, caption:, date_of_birth:, omit_day:, maxlength_enabled:, segments:, segment_names:, form_group:, **kwargs, &block).html
+    end
+
+    # Generates three inputs for the +hour+, +minute+ and +second+ components of a time
+    #
+    # @note When using this input values will be retrieved from the attribute if it is a Time object or a multiparam date hash
+    # @param attribute_name [Symbol] The name of the attribute
+    # @param hint [Hash,Proc] The content of the hint. No hint will be added if 'text' is left +nil+. When a +Proc+ is
+    #   supplied the hint will be wrapped in a +div+ instead of a +span+
+    # @option hint text [String] the hint text
+    # @option hint kwargs [Hash] additional arguments are applied as attributes to the hint
+    # @param legend [NilClass,Hash,Proc] options for configuring the legend. Legend will be omitted if +nil+.
+    # @option legend text [String] the fieldset legend's text content
+    # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
+    # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+.
+    # @option legend hidden [Boolean] control the visibility of the legend. Hidden legends will still be read by screenreaders
+    # @option legend kwargs [Hash] additional arguments are applied as attributes on the +legend+ element
+    # @param caption [Hash] configures or sets the caption content which is inserted above the legend
+    # @option caption text [String] the caption text
+    # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
+    # @option caption kwargs [Hash] additional arguments are applied as attributes on the caption +span+ element
+    # @param omit_second [Boolean] do not render a second input, only capture hour and minute
+    # @param maxlength_enabled [Boolean] adds maxlength attribute to hour, minute and second inputs (2)
+    # @param segments [Hash] allows Rails' multiparameter attributes to be overridden on a field-by-field basis. Hash must
+    #   contain +hour:+, +minute:+ and +second:+ keys. Defaults to the default value set in the +default_time_segments+ setting in {GOVUKDesignSystemFormBuilder.DEFAULTS}
+    # @param segment_names [Hash] allows the day, month and year labels to be overridden. Hash must
+    #   contain +hour:+, +minute:+ and +second:+ keys. Defaults to the default value set in the +default_time_segment_names+ setting in {GOVUKDesignSystemFormBuilder.DEFAULTS}
+    # @param form_group [Hash] configures the form group
+    # @option form_group kwargs [Hash] additional attributes added to the form group
+    # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
+    # @param block [Block] arbitrary HTML that will be rendered between the hint and the input group
+    # @return [ActiveSupport::SafeBuffer] HTML output
+    #
+    # @see https://github.com/alphagov/govuk-frontend/issues/1449 GOV.UK date input element attributes, using text instead of number
+    # @see https://design-system.service.gov.uk/styles/typography/#headings-with-captions Headings with captions
+    #
+    # @example A regular time input with a legend, hint and injected content
+    #   = f.govuk_time_field :starts_at,
+    #     legend: { 'When does your event start?' },
+    #     hint: { text: 'Leave this field blank if you don't know exactly' } do
+    #
+    #       p.govuk-inset-text
+    #         | If you don't fill this, the event will be all day
+    #
+    # @example A time input with legend supplied as a proc
+    #  = f.govuk_time_field :finishes_at,
+    #    legend: -> { tag.h3('When does the event finish?') }
+    def govuk_time_field(attribute_name, hint: {}, legend: {}, caption: {}, omit_second: false, maxlength_enabled: false, segments: config.default_time_segments, segment_names: config.default_time_segment_names, form_group: {}, **kwargs, &block)
+      Elements::Time.new(self, object_name, attribute_name, hint:, legend:, caption:, omit_second:, maxlength_enabled:, segments:, segment_names:, form_group:, **kwargs, &block).html
     end
 
     # Generates a summary of errors in the form, each linking to the corresponding

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -8,8 +8,7 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Supplemental
       include Traits::HTMLClasses
       include Traits::Localisation
-
-      MULTIPARAMETER_KEY = { day: 3, month: 2, year: 1 }.freeze
+      include Traits::DateInput
 
       def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, omit_day:, maxlength_enabled:, segments:, form_group:, segment_names:, date_of_birth: false, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
@@ -26,32 +25,14 @@ module GOVUKDesignSystemFormBuilder
         @html_attributes   = kwargs
       end
 
-      def html
-        Containers::FormGroup.new(*bound, **@form_group, **@html_attributes).html do
-          Containers::Fieldset.new(*bound, **fieldset_options).html do
-            safe_join([supplemental_content, hint_element, error_element, date])
-          end
-        end
-      end
-
     private
 
-      def fieldset_options
-        { legend: @legend, caption: @caption, described_by: [error_id, hint_id, supplemental_id] }
-      end
-
-      def date
-        tag.div(class: %(#{brand}-date-input)) do
-          safe_join([day, month, year])
-        end
+      def parts
+        [day, month, year]
       end
 
       def omit_day?
         @omit_day
-      end
-
-      def maxlength_enabled?
-        @maxlength_enabled
       end
 
       def day
@@ -75,94 +56,10 @@ module GOVUKDesignSystemFormBuilder
         date_part(:year, width: 4)
       end
 
-      def date_part(segment, width:, link_errors: false)
-        tag.div(class: %(#{brand}-date-input__item)) do
-          tag.div(class: %(#{brand}-form-group)) do
-            safe_join([label(segment, link_errors), input(segment, link_errors, width, value(segment))])
-          end
-        end
-      end
-
-      def value(segment)
-        attribute = @builder.object.try(@attribute_name)
-
-        return unless attribute
-
-        if attribute.respond_to?(segment)
-          attribute.send(segment)
-        elsif attribute.respond_to?(:fetch)
-          attribute.fetch(MULTIPARAMETER_KEY[segment]) do
-            warn("No key '#{segment}' found in MULTIPARAMETER_KEY hash. Expected to find #{MULTIPARAMETER_KEY.values}")
-
-            nil
-          end
-        else
-          fail(ArgumentError, "invalid Date-like object: must be a Date, Time, DateTime or Hash in MULTIPARAMETER_KEY format")
-        end
-      end
-
-      def label(segment, link_errors)
-        tag.label(
-          segment_label_text(segment),
-          class: label_classes,
-          for: id(segment, link_errors)
-        )
-      end
-
-      def segment_label_text(segment)
-        localised_text(:label, segment) || @segment_names.fetch(segment)
-      end
-
-      def input(segment, link_errors, width, value)
-        tag.input(
-          id: id(segment, link_errors),
-          class: classes(width),
-          name: name(segment),
-          type: 'text',
-          inputmode: 'numeric',
-          value:,
-          autocomplete: date_of_birth_autocomplete_value(segment),
-          maxlength: (width if maxlength_enabled?),
-        )
-      end
-
-      def classes(width)
-        build_classes(
-          %(input),
-          %(date-input__input),
-          %(input--width-#{width}),
-          %(input--error) => has_errors?,
-        ).prefix(brand)
-      end
-
-      # if the field has errors we want the govuk_error_summary to
-      # be able to link to the day field. Otherwise, generate IDs
-      # in the normal fashion
-      def id(segment, link_errors)
-        if has_errors? && link_errors
-          field_id(link_errors:)
-        else
-          [@object_name, @attribute_name, @segments.fetch(segment)].join("_")
-        end
-      end
-
-      def name(segment)
-        format(
-          "%<object_name>s[%<input_name>s(%<segment>s)]",
-          object_name: @object_name,
-          input_name: @attribute_name,
-          segment: @segments.fetch(segment)
-        )
-      end
-
-      def date_of_birth_autocomplete_value(segment)
+      def autocomplete_value(segment)
         return unless @date_of_birth
 
         { day: 'bday-day', month: 'bday-month', year: 'bday-year' }.fetch(segment)
-      end
-
-      def label_classes
-        build_classes(%(label), %(date-input__label)).prefix(brand)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/time.rb
+++ b/lib/govuk_design_system_formbuilder/elements/time.rb
@@ -1,0 +1,63 @@
+module GOVUKDesignSystemFormBuilder
+  module Elements
+    class Time < Base
+      using PrefixableArray
+
+      include Traits::Error
+      include Traits::Hint
+      include Traits::Supplemental
+      include Traits::HTMLClasses
+      include Traits::Localisation
+      include Traits::DateInput
+
+      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, omit_second:, maxlength_enabled:, segments:, form_group:, segment_names:, **kwargs, &block)
+        super(builder, object_name, attribute_name, &block)
+
+        @legend            = legend
+        @caption           = caption
+        @hint              = hint
+        @omit_second       = omit_second
+        @maxlength_enabled = maxlength_enabled
+        @segments          = segments
+        @segment_names     = segment_names
+        @form_group        = form_group
+        @html_attributes   = kwargs
+      end
+
+    private
+
+      def parts
+        [hour, minute, second]
+      end
+
+      def omit_second?
+        @omit_second
+      end
+
+      def hour
+        date_part(:hour, width: 2, link_errors: true)
+      end
+
+      def minute
+        date_part(:minute, width: 2)
+      end
+
+      def second
+        if omit_second?
+          return tag.input(
+            id: id(:second, false),
+            name: name(:second),
+            type: 'hidden',
+            value: value(:second) || 0,
+          )
+        end
+
+        date_part(:second, width: 2)
+      end
+
+      def autocomplete_value(_segment)
+        nil
+      end
+    end
+  end
+end

--- a/lib/govuk_design_system_formbuilder/traits/date_input.rb
+++ b/lib/govuk_design_system_formbuilder/traits/date_input.rb
@@ -1,0 +1,118 @@
+module GOVUKDesignSystemFormBuilder
+  module Traits
+    module DateInput
+      using PrefixableArray
+
+      MULTIPARAMETER_KEY = { year: 1, month: 2, day: 3, hour: 4, minute: 5, second: 6 }.freeze
+      SEGMENT_METHOD = { year: :year, month: :month, day: :day, hour: :hour, minute: :min, second: :sec }.freeze
+
+      def html
+        Containers::FormGroup.new(*bound, **@form_group, **@html_attributes).html do
+          Containers::Fieldset.new(*bound, **fieldset_options).html do
+            safe_join([supplemental_content, hint_element, error_element, date_input])
+          end
+        end
+      end
+
+    private
+
+      def date_input
+        tag.div(class: %(#{brand}-date-input)) do
+          safe_join(parts)
+        end
+      end
+
+      def maxlength_enabled?
+        @maxlength_enabled
+      end
+
+      def fieldset_options
+        { legend: @legend, caption: @caption, described_by: [error_id, hint_id, supplemental_id] }
+      end
+
+      def segment_label_text(segment)
+        localised_text(:label, segment) || @segment_names.fetch(segment)
+      end
+
+      def classes(width)
+        build_classes(
+          %(input),
+          %(date-input__input),
+          %(input--width-#{width}),
+          %(input--error) => has_errors?,
+        ).prefix(brand)
+      end
+
+      def date_part(segment, width:, link_errors: false)
+        tag.div(class: %(#{brand}-date-input__item)) do
+          tag.div(class: %(#{brand}-form-group)) do
+            safe_join([label(segment, link_errors), input(segment, link_errors, width, value(segment))])
+          end
+        end
+      end
+
+      def value(segment)
+        attribute = @builder.object.try(@attribute_name)
+
+        return unless attribute
+
+        if attribute.respond_to?(:fetch)
+          attribute.fetch(MULTIPARAMETER_KEY[segment]) do
+            warn("No key '#{segment}' found in MULTIPARAMETER_KEY hash. Expected to find #{MULTIPARAMETER_KEY.values}")
+
+            nil
+          end
+        elsif attribute.respond_to?(SEGMENT_METHOD[segment])
+          attribute.send(SEGMENT_METHOD.fetch(segment))
+        else
+          fail(ArgumentError, "invalid Date-like object: must be a Date, Time, DateTime or Hash in MULTIPARAMETER_KEY format")
+        end
+      end
+
+      def label(segment, link_errors)
+        tag.label(
+          segment_label_text(segment),
+          class: label_classes,
+          for: id(segment, link_errors)
+        )
+      end
+
+      def input(segment, link_errors, width, value)
+        tag.input(
+          id: id(segment, link_errors),
+          class: classes(width),
+          name: name(segment),
+          type: 'text',
+          inputmode: 'numeric',
+          value:,
+          autocomplete: autocomplete_value(segment),
+          maxlength: (width if maxlength_enabled?),
+        )
+      end
+
+      # if the field has errors we want the govuk_error_summary to
+      # be able to link to the hour field. Otherwise, generate IDs
+      # in the normal fashion
+      def id(segment, link_errors)
+        if has_errors? && link_errors
+          field_id(link_errors:)
+        else
+          [@object_name, @attribute_name, @segments.fetch(segment)].join("_")
+        end
+      end
+
+      def name(segment)
+        format(
+          "%<object_name>s[%<input_name>s(%<segment>s)]",
+          object_name: @object_name,
+          input_name: @attribute_name,
+          segment: @segments.fetch(segment)
+        )
+      end
+
+      def label_classes
+        build_classes(%(label), %(date-input__label)).prefix(brand)
+      end
+    end
+  end
+end

--- a/spec/govuk_design_system_formbuilder/builder/configuration/time_segment_configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration/time_segment_configuration_spec.rb
@@ -1,0 +1,45 @@
+describe GOVUKDesignSystemFormBuilder::FormBuilder do
+  include_context 'setup builder'
+  include_context 'setup examples'
+
+  after { GOVUKDesignSystemFormBuilder.reset! }
+
+  describe 'default time segments' do
+    let(:overridden_segments) { { hour: 'c', minute: 'b', second: 'a' } }
+
+    before do
+      GOVUKDesignSystemFormBuilder.configure do |conf|
+        conf.default_time_segments = overridden_segments
+      end
+    end
+
+    subject { builder.govuk_time_field(:govuk_time_field) }
+
+    specify 'uses the configured date segments' do
+      overridden_segments.each do |segment, value|
+        expect(subject).to have_tag("label", with: { for: "person_govuk_time_field_#{value}" }, text: segment.capitalize)
+        expect(subject).to have_tag("input", with: { name: "person[govuk_time_field(#{value})]" })
+      end
+    end
+  end
+
+  describe 'default time segment names' do
+    let(:overridden_segment_names) { { hour: "Hora", minute: "Minuto", second: "Segunda" } }
+
+    before do
+      GOVUKDesignSystemFormBuilder.configure do |conf|
+        conf.default_time_segment_names = overridden_segment_names
+      end
+    end
+
+    subject { builder.govuk_time_field(:govuk_time_field) }
+
+    specify 'uses the configured time segment names for labels' do
+      multiparamater_keys = { hour: '4i', minute: '5i', second: '6i' }
+
+      overridden_segment_names.each do |segment, value|
+        expect(subject).to have_tag("label", text: value, with: { for: "person_govuk_time_field_#{multiparamater_keys.fetch(segment)}" })
+      end
+    end
+  end
+end

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -66,7 +66,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that supports setting the legend caption via localisation'
     it_behaves_like 'a field that supports setting the hint via localisation'
 
-    describe 'localising the date, month and year labels' do
+    describe 'localising the day, month and year labels' do
       let(:localisations) { { en: YAML.load_file('spec/support/locales/sample.en.yaml') } }
       let(:expected_day_label) { I18n.translate("helpers.label.person.#{attribute}.day") }
       let(:expected_month_label) { I18n.translate("helpers.label.person.#{attribute}.month") }

--- a/spec/govuk_design_system_formbuilder/builder/time_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/time_spec.rb
@@ -1,0 +1,339 @@
+describe GOVUKDesignSystemFormBuilder::FormBuilder do
+  include_context 'setup builder'
+
+  describe '#govuk_time_field' do
+    let(:method) { :govuk_time_field }
+    let(:attribute) { :born_at }
+
+    let(:fieldset_heading) { 'Time of birth' }
+    let(:legend_text) { 'When were you born?' }
+    let(:hint_text) { 'It says it on your birth certificate' }
+
+    let(:hour_multiparam_attribute) { '4i' }
+    let(:minute_multiparam_attribute) { '5i' }
+    let(:second_multiparam_attribute) { '6i' }
+    let(:multiparam_attributes) { [hour_multiparam_attribute, minute_multiparam_attribute, second_multiparam_attribute] }
+
+    let(:hour_identifier) { "person_born_at_#{hour_multiparam_attribute}" }
+    let(:minute_identifier) { "person_born_at_#{minute_multiparam_attribute}" }
+    let(:second_identifier) { "person_born_at_#{second_multiparam_attribute}" }
+
+    let(:args) { [method, attribute] }
+    subject { builder.send(*args) }
+
+    let(:field_type) { 'input' }
+    let(:aria_described_by_target) { 'fieldset' }
+
+    include_examples 'HTML formatting checks'
+
+    it_behaves_like 'a field that supports hints'
+
+    it_behaves_like 'a field that supports errors' do
+      let(:object) { Person.new(born_at: Time.new(2000, 1, 1, 11)) }
+
+      let(:error_message) { /Your time of birth must be after midday/ }
+      let(:error_class) { 'govuk-input--error' }
+      let(:error_identifier) { 'person-born-at-error' }
+    end
+
+    it_behaves_like 'a field that accepts arbitrary blocks of HTML' do
+      let(:described_element) { 'fieldset' }
+
+      # the block content should be before the hint and time inputs
+      context 'ordering' do
+        let(:hint_div_selector) { 'div.govuk-hint' }
+        let(:block_paragraph_selector) { 'p.block-content' }
+        let(:govuk_date_selector) { 'div.govuk-date-input' }
+
+        let(:paragraph) { 'A descriptive paragraph all about times' }
+
+        subject do
+          builder.send(*args, legend: { text: legend_text }, hint: { text: hint_text }) do
+            builder.tag.p(paragraph, class: 'block-content')
+          end
+        end
+
+        specify 'the block content should be before the hint and the time inputs' do
+          actual = parsed_subject.css([hint_div_selector, block_paragraph_selector, govuk_date_selector].join(",")).flat_map(&:classes)
+          expected = %w(block-content govuk-hint govuk-date-input)
+
+          expect(actual).to eql(expected)
+        end
+      end
+    end
+
+    it_behaves_like 'a field that supports setting the legend via localisation'
+    it_behaves_like 'a field that supports setting the legend caption via localisation'
+    it_behaves_like 'a field that supports setting the hint via localisation'
+
+    describe 'localising the hour, minute and second labels' do
+      let(:localisations) { { en: YAML.load_file('spec/support/locales/sample.en.yaml') } }
+      let(:expected_hour_label) { I18n.translate("helpers.label.person.#{attribute}.hour") }
+      let(:expected_minute_label) { I18n.translate("helpers.label.person.#{attribute}.minute") }
+      let(:expected_second_label) { I18n.translate("helpers.label.person.#{attribute}.second") }
+
+      subject { builder.send(*args) }
+
+      specify 'the hour, minute and second labels are localised' do
+        with_localisations(localisations) do
+          aggregate_failures do
+            expect(subject).to have_tag('label', text: expected_hour_label, with: { class: 'govuk-label' })
+            expect(subject).to have_tag('label', text: expected_minute_label, with: { class: 'govuk-label' })
+            expect(subject).to have_tag('label', text: expected_second_label, with: { class: 'govuk-label' })
+          end
+        end
+      end
+    end
+
+    it_behaves_like 'a field that supports custom branding'
+    it_behaves_like 'a field that contains a customisable form group'
+
+    it_behaves_like 'a field that supports a fieldset with legend'
+    it_behaves_like 'a field that supports captions on the legend'
+
+    it_behaves_like 'a time field that accepts a plain ruby object' do
+      let(:described_element) { ['input', { count: 3 }] }
+    end
+
+    specify 'should output a form group with fieldset, date group and 3 inputs and labels' do
+      expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
+        with_tag('fieldset', with: { class: 'govuk-fieldset' }) do
+          with_tag('div', with: { class: 'govuk-date-input' }) do
+            with_tag('input', with: { type: 'text' }, count: 3)
+            with_tag('label', count: 3)
+          end
+        end
+      end
+    end
+
+    context 'separate time part inputs' do
+      specify 'inputs should have the correct labels' do
+        expect(subject).to have_tag('div', with: { class: 'govuk-date-input' }) do
+          %w(Hour Minute Second).each do |label_text|
+            with_tag('label', text: label_text)
+          end
+        end
+      end
+
+      specify 'inputs should have the correct name' do
+        multiparam_attributes.each do |mpa|
+          expect(subject).to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{mpa})]" })
+        end
+      end
+
+      specify 'inputs should have an inputmode of numeric' do
+        expect(subject).to have_tag('input', with: { inputmode: 'numeric' })
+      end
+
+      specify 'labels should be associated with inputs' do
+        [hour_identifier, minute_identifier, second_identifier].each do |identifier|
+          expect(subject).to have_tag('label', with: { for: identifier }, count: 1)
+          expect(subject).to have_tag('input', with: { id: identifier }, count: 1)
+        end
+      end
+
+      specify 'inputs should have the correct classes' do
+        expect(subject).to have_tag(
+          'input',
+          count: 3,
+          with: { class: %w(govuk-input govuk-date-input__input) }
+        )
+      end
+
+      specify 'inputs should have the width class' do
+        expect(subject).to have_tag(
+          'input',
+          count: 3,
+          with: { class: %w(govuk-input--width-2) }
+        )
+      end
+    end
+
+    context 'when segments are overridden' do
+      subject { builder.send(*args, segments: { hour: "hour", minute: "minute", second: "second" }) }
+
+      specify "sets the hour field correctly" do
+        expect(subject).to have_tag('input', with: { id: "person_born_at_hour", name: "person[born_at(hour)]" })
+      end
+
+      specify "sets the minute field correctly" do
+        expect(subject).to have_tag('input', with: { id: "person_born_at_minute", name: "person[born_at(minute)]" })
+      end
+
+      specify "sets the second field correctly" do
+        expect(subject).to have_tag('input', with: { id: "person_born_at_second", name: "person[born_at(second)]" })
+      end
+    end
+
+    context 'when segment names are overridden' do
+      subject { builder.send(*args, segment_names: { hour: "Hora", minute: "Minuto", second: "Segunda" }) }
+
+      specify "sets the hour label correctly" do
+        expect(subject).to have_tag('label', text: "Hora", with: { for: hour_identifier })
+      end
+
+      specify "sets the minute label correctly" do
+        expect(subject).to have_tag('label', text: "Minuto", with: { for: minute_identifier })
+      end
+
+      specify "sets the second label correctly" do
+        expect(subject).to have_tag('label', text: "Segunda", with: { for: second_identifier })
+      end
+    end
+
+    context 'showing only hour and minute inputs' do
+      subject { builder.send(*args, omit_second: true) }
+
+      specify 'there should only be minute and second text inputs' do
+        expect(subject).to have_tag('input', count: 3)
+
+        [hour_multiparam_attribute, minute_multiparam_attribute].each do |mpa|
+          expect(subject).to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{mpa})]", type: 'text' })
+        end
+
+        expect(subject).to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{second_multiparam_attribute})]", type: 'hidden' })
+      end
+
+      specify 'there be no second label' do
+        expect(subject).not_to have_tag('label', text: 'Second')
+      end
+
+      specify 'there should only be hour and minute labels' do
+        expect(subject).to have_tag('label', text: 'Hour')
+        expect(subject).to have_tag('label', text: 'Minute')
+      end
+    end
+
+    context 'not restricting chars with maxlength' do
+      subject { builder.send(*args, maxlength_enabled: false) }
+
+      specify 'there should be a hour maxlength attribute' do
+        expect(subject).not_to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{hour_multiparam_attribute})]", maxlength: '2' })
+      end
+
+      specify 'there should be a minute maxlength attribute' do
+        expect(subject).not_to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{minute_multiparam_attribute})]", maxlength: '2' })
+      end
+
+      specify 'there should be a second maxlength attribute' do
+        expect(subject).not_to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{second_multiparam_attribute})]", maxlength: '2' })
+      end
+    end
+
+    context 'restricting chars with maxlength' do
+      subject { builder.send(*args, maxlength_enabled: true) }
+
+      specify 'there should be a hour maxlength attribute' do
+        expect(subject).to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{hour_multiparam_attribute})]", maxlength: '2' })
+      end
+
+      specify 'there should be a minute maxlength attribute' do
+        expect(subject).to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{minute_multiparam_attribute})]", maxlength: '2' })
+      end
+
+      specify 'there should be a second maxlength attribute' do
+        expect(subject).to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{second_multiparam_attribute})]", maxlength: '2' })
+      end
+    end
+
+    context 'default values' do
+      let(:birth_hour) { 12 }
+      let(:birth_minute) { 30 }
+      let(:birth_second) { 45 }
+
+      context "when the attribute is a `Date` object" do
+        let(:object) do
+          Person.new(
+            name: 'Joey',
+            born_at: Time.new(2000, 1, 1, birth_hour, birth_minute, birth_second)
+          )
+        end
+
+        specify 'should set the hour value correctly' do
+          expect(subject).to have_tag('input', with: {
+            id: hour_identifier,
+            value: birth_hour
+          })
+        end
+
+        specify 'should set the minute value correctly' do
+          expect(subject).to have_tag('input', with: {
+            id: minute_identifier,
+            value: birth_minute
+          })
+        end
+
+        specify 'should set the second value correctly' do
+          expect(subject).to have_tag('input', with: {
+            id: second_identifier,
+            value: birth_second
+          })
+        end
+      end
+
+      context "when the attribute is a multiparameter hash object" do
+        let(:object) do
+          Person.new(
+            name: 'Joey',
+            born_at: { 4 => birth_hour, 5 => birth_minute, 6 => birth_second }
+          )
+        end
+
+        specify 'should set the hour value correctly' do
+          expect(subject).to have_tag('input', with: {
+            id: hour_identifier,
+            value: birth_hour
+          })
+        end
+
+        specify 'should set the minute value correctly' do
+          expect(subject).to have_tag('input', with: {
+            id: minute_identifier,
+            value: birth_minute
+          })
+        end
+
+        specify 'should set the second value correctly' do
+          expect(subject).to have_tag('input', with: {
+            id: second_identifier,
+            value: birth_second
+          })
+        end
+      end
+    end
+
+    describe "additional attributes" do
+      subject { builder.send(*args, data: { test: "abc" }) }
+
+      specify "should have additional attributes" do
+        expect(subject).to have_tag('div', with: { 'data-test': 'abc' })
+      end
+    end
+
+    describe "invalid time-like objects" do
+      let(:wrong_time) { WrongTime.new(nil, nil, nil) }
+      before { object.born_at = wrong_time }
+
+      specify "fails with an appropriate error message" do
+        expect { subject }.to raise_error(ArgumentError, /invalid Date-like object/)
+      end
+    end
+
+    describe "hashes without the right keys" do
+      let(:wrong_hash) { { h: 12, m: 30, s: 45 } }
+      before { object.born_at = wrong_hash }
+      before { allow(Rails).to receive_message_chain(:logger, :warn) }
+      before { subject }
+
+      specify "logs an appropriate warning" do
+        expect(Rails.logger).to have_received(:warn).with(/No key '.*' found in MULTIPARAMETER_KEY hash/).exactly(wrong_hash.length).times
+      end
+
+      specify "doesn't generate inputs with values" do
+        parsed_subject.css('input').each do |element|
+          expect(element.attributes.keys).not_to include('value')
+        end
+      end
+    end
+  end
+end

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -12,6 +12,7 @@ class Being
   attr_accessor(
     :name,
     :born_on,
+    :born_at,
     :gender,
     :over18,
     :favourite_colour,
@@ -44,6 +45,7 @@ class Person < Being
   validates :cv, length: { maximum: 30 }, presence: true
 
   validate :born_on_must_be_in_the_past, if: -> { born_on.present? }
+  validate :born_at_must_be_after_midday, if: ->  { born_at.present? }
   validate :photo_must_be_jpeg, if: -> { photo.present? }
 
   validates :hairstyle, presence: { message: 'Describe your <br/> hairstyle' }, on: :trust_error_messages
@@ -69,6 +71,11 @@ private
 
   def born_on_must_be_in_the_past
     errors.add(:born_on, 'Your date of birth must be in the past') unless born_on < Date.today
+  end
+
+  def born_at_must_be_after_midday
+    # This is not a realistic example, but it's used in the tests.
+    errors.add(:born_at, 'Your time of birth must be after midday') unless born_at.hour > 12
   end
 
   def photo_must_be_jpeg
@@ -108,6 +115,7 @@ class Department
 end
 
 WrongDate = Struct.new(:d, :m, :y)
+WrongTime = Struct.new(:h, :m, :s)
 
 class OrderedErrors
   include ActiveModel::Model

--- a/spec/support/locales/sample.en.yaml
+++ b/spec/support/locales/sample.en.yaml
@@ -1,6 +1,7 @@
 helpers:
   error:
     message_prefix: "Oh dear"
+
   label:
     person:
       name: Who goes there?
@@ -29,6 +30,10 @@ helpers:
         day: Tag
         month: Monat
         year: Jahr
+      born_at:
+        hour: Hora
+        minute: Minuto
+        second: Segunda
 
   caption:
     person:
@@ -37,16 +42,20 @@ helpers:
       photo: Personal appearance
       cv: Background information
       born_on: Required data
+      born_at: Required data
       projects: Workplace data
       address:
         number_and_street: "Work address"
+
   legend:
     person:
       favourite_colour: To which colours are you most partial?
       born_on: What is your date of birth?
+      born_at: What is your time of birth?
       projects: What do you do all day at work?
       address:
         number_and_street: Building number and street name
+
   hint:
     person:
       name: Enter your full name including middle names, nicknames and aliases
@@ -55,6 +64,7 @@ helpers:
       cv: Where did you work? What did you do?
       photo: Make sure your face is clear and you are looking at the camera
       born_on: Check your birth certificate or passport
+      born_at: Check your birth certificate or passport
       projects: If you cannot remember check with your teammates or manager
       department_options:
         it: Computers and stuff

--- a/spec/support/shared/shared_plain_ruby_object_examples.rb
+++ b/spec/support/shared/shared_plain_ruby_object_examples.rb
@@ -1,11 +1,12 @@
 class Biscuit
-  attr_accessor :name, :weight, :calories, :expires_on
+  attr_accessor :name, :weight, :calories, :expires_on, :expires_at
 
-  def initialize(name, weight, calories, expires_on = Date.today.next_year)
+  def initialize(name, weight, calories, expires_on = Date.today.next_year, expires_at: Time.now)
     self.name       = name
     self.weight     = weight
     self.calories   = calories
     self.expires_on = expires_on
+    self.expires_at = expires_at
   end
 end
 
@@ -23,6 +24,16 @@ shared_examples 'a date field that accepts a plain ruby object' do
   let(:object) { Biscuit.new('Rocky', 32, 184) }
   let(:object_name) { :biscuit }
   let(:attribute) { :expires_on }
+
+  specify 'should render the element successfully' do
+    expect(subject).to have_tag(*described_element)
+  end
+end
+
+shared_examples 'a time field that accepts a plain ruby object' do
+  let(:object) { Biscuit.new('Rocky', 32, 184) }
+  let(:object_name) { :biscuit }
+  let(:attribute) { :expires_at }
 
   specify 'should render the element successfully' do
     expect(subject).to have_tag(*described_element)


### PR DESCRIPTION
This adds a new type of field which can be used to render a time input. It works in a very similar way to the date field, but instead of day, month and year the user is asked for hour, minute and second.

Ruby doesn't have a built-in type capable of modelling just the time component of a date/time. Instead, the value is stored as a `Time` object where the day, month and year are ignored. When Rails is dealing with the PostgreSQL `TIME` type, the date component is set to 2020-01-01.

To implement this I've introduced a `DateInput` trait which is shared across both the date and the time fields. Any common logic across the two fields is in the trait.

I can't see a time field in the GOV.UK Design System so I've added a warning to the documentation that this is not a standard component.