### PR TITLE
Add proc support to govuk_error_summary

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -1037,7 +1037,7 @@ module GOVUKDesignSystemFormBuilder
     # Generates a summary of errors in the form, each linking to the corresponding
     # part of the form that contains the error
     #
-    # @param title [String] the error summary heading
+    # @param title [String,Proc] the error summary heading
     # @param link_base_errors_to [Symbol,String] set the field that errors on +:base+ are linked
     #   to, as there won't be a field representing the object base.
     # @param order [Array<Symbol>] the attribute order in which error messages are displayed. Ordered

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -9,7 +9,7 @@ module GOVUKDesignSystemFormBuilder
       def initialize(builder, object_name, title, link_base_errors_to:, order:, presenter:, **kwargs, &block)
         super(builder, object_name, nil, &block)
 
-        @title               = title
+        @title               = build_text(title)
         @link_base_errors_to = link_base_errors_to
         @html_attributes     = kwargs
         @order               = order
@@ -27,6 +27,17 @@ module GOVUKDesignSystemFormBuilder
       end
 
     private
+
+      def build_text(text)
+        case text
+        when String
+          text
+        when Proc
+          capture { text.call }
+        else
+          fail(ArgumentError, %(text must be a String or Proc))
+        end
+      end
 
       def title
         tag.h2(@title, class: summary_class('title'))

--- a/spec/govuk_design_system_formbuilder/builder/configuration/error_summary_configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration/error_summary_configuration_spec.rb
@@ -32,5 +32,16 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         expect(subject).to have_tag('h2', text: error_summary_title, with: { class: 'govuk-error-summary__title' })
       end
     end
+
+    context %(overriding with custom proc) do
+      let(:error_summary_title) { -> { %(I'm a proc!) } }
+      let(:args) { [method, error_summary_title] }
+
+      subject { builder.send(*args) }
+
+      specify 'should use supplied text when overridden' do
+        expect(subject).to have_tag('h2', text: error_summary_title.call, with: { class: 'govuk-error-summary__title' })
+      end
+    end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/configuration/submit_configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration/submit_configuration_spec.rb
@@ -36,6 +36,15 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             expect(subject).to have_tag('button', with: { type: 'submit' }, text: submit_button_text)
           end
         end
+
+        context 'overriding with proc text' do
+          let(:submit_button_text) { -> { %(I'm a proc!) } }
+          let(:args) { [method, submit_button_text] }
+
+          specify 'should use supplied value when overridden' do
+            expect(subject).to have_tag('button', with: { type: 'submit' }, text: submit_button_text.call)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
While using the form builder, we found that we were unable to translate the default error summary heading in the same way we had done for the submit button e.g. `-> { I18n.t('translation') }`.

This change allows the error summary to call procs in the same way the submit element does.

Additionally, it adds a test case for proc support on the submit button.