### PR TITLE
Remove remaining `supplemental_id` references

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -36,7 +36,7 @@ module GOVUKDesignSystemFormBuilder
           {
             legend: @legend,
             caption: @caption,
-            described_by: [error_id, hint_id, supplemental_id]
+            described_by: [error_id, hint_id]
           }
         end
 

--- a/lib/govuk_design_system_formbuilder/elements/collection_select.rb
+++ b/lib/govuk_design_system_formbuilder/elements/collection_select.rb
@@ -43,7 +43,7 @@ module GOVUKDesignSystemFormBuilder
         {
           id: field_id(link_errors: true),
           class: classes,
-          aria: { describedby: combine_references(hint_id, error_id, supplemental_id) }
+          aria: { describedby: combine_references(hint_id, error_id) }
         }
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -55,7 +55,7 @@ module GOVUKDesignSystemFormBuilder
         {
           id: field_id(link_errors: true),
           class: classes,
-          aria: { describedby: combine_references(hint_id, error_id, supplemental_id) }
+          aria: { describedby: combine_references(hint_id, error_id) }
         }
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -43,7 +43,7 @@ module GOVUKDesignSystemFormBuilder
           {
             legend: @legend,
             caption: @caption,
-            described_by: [error_id, hint_id, supplemental_id]
+            described_by: [error_id, hint_id]
           }
         end
 

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -47,7 +47,7 @@ module GOVUKDesignSystemFormBuilder
           id: field_id(link_errors: true),
           class: classes,
           rows: @rows,
-          aria: { describedby: combine_references(hint_id, error_id, supplemental_id, limit_description_id) },
+          aria: { describedby: combine_references(hint_id, error_id, limit_description_id) },
         }
       end
 

--- a/lib/govuk_design_system_formbuilder/traits/date_input.rb
+++ b/lib/govuk_design_system_formbuilder/traits/date_input.rb
@@ -27,7 +27,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def fieldset_options
-        { legend: @legend, caption: @caption, described_by: [error_id, hint_id, supplemental_id] }
+        { legend: @legend, caption: @caption, described_by: [error_id, hint_id] }
       end
 
       def segment_label_text(segment)

--- a/lib/govuk_design_system_formbuilder/traits/input.rb
+++ b/lib/govuk_design_system_formbuilder/traits/input.rb
@@ -55,7 +55,7 @@ module GOVUKDesignSystemFormBuilder
         {
           id: field_id(link_errors: true),
           class: classes,
-          aria: { describedby: combine_references(hint_id, error_id, supplemental_id) }
+          aria: { describedby: combine_references(hint_id, error_id) }
         }
       end
 

--- a/lib/govuk_design_system_formbuilder/traits/supplemental.rb
+++ b/lib/govuk_design_system_formbuilder/traits/supplemental.rb
@@ -1,12 +1,6 @@
 module GOVUKDesignSystemFormBuilder
   module Traits
     module Supplemental
-      def supplemental_id
-        return if @block_content.blank?
-
-        build_id('supplemental')
-      end
-
     private
 
       def supplemental_content


### PR DESCRIPTION
This should really have been done as part of #580, but it completes the tidying up of the supplemental ARIA link work.
