### PR TITLE
Allow word/character counts to be localised

### DIFF
--- a/guide/content/form-elements/textarea.slim
+++ b/guide/content/form-elements/textarea.slim
@@ -36,4 +36,28 @@ p.govuk-body
     | To do this, set the <code>threshold</code> parameter in conjunction with a
       word or character limit.
 
+== render('/partials/example.*',
+  caption: 'Customising the limit text',
+  code: text_area_with_custom_limit_text) do
+
+  markdown:
+    When localising the textarea you can configure the strings used by the component using
+    the parameters:
+
+  ul.govuk-list.govuk-list--bullet
+    li
+      code under_limit_other_text
+    li
+      code under_limit_one_text
+    li
+      code at_limit_text
+    li
+      code over_limit_other_text
+    li
+      code over_limit_one_text
+
+  markdown:
+    The `%{count}` placeholder will be replaced by the number of characters or
+    words away from the limit you are.
+
 == render('/partials/related-navigation.*', links: text_area_info)

--- a/guide/lib/examples/text_area.rb
+++ b/guide/lib/examples/text_area.rb
@@ -29,5 +29,18 @@ module Examples
           threshold: 50
       SNIPPET
     end
+
+    def text_area_with_custom_limit_text
+      <<~SNIPPET
+        = f.govuk_text_area :personal_statement,
+          label: { text: 'Déclaration personnelle' },
+          max_chars: 20,
+          under_limit_other_text: '%{count} caractères restants' ,
+          under_limit_one_text: '%{count} caractère restant',
+          at_limit_text: 'Plus aucun caractère restant',
+          over_limit_other_text: '%{count} caractères de trop' ,
+          over_limit_one_text: '%{count} caractère de trop'
+      SNIPPET
+    end
   end
 end

--- a/guide/lib/helpers/person.rb
+++ b/guide/lib/helpers/person.rb
@@ -70,7 +70,8 @@ class Person
     :responsibilities,
     :job_description,
     :cv,
-    :education_history
+    :education_history,
+    :personal_statement
   )
 
   # date fields

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -385,6 +385,11 @@ module GOVUKDesignSystemFormBuilder
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +textarea+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
+    # @param characters_under_limit_other_text [String] Text that informs the user they have X word/characters remaining. Default is "%{count} characters to go". If javascript is not provided, this option will be ignored.
+    # @param characters_under_limit_one_text [String] Text that informs the user they have 1 word/character remaining. Default is "%{count} character to go". If javascript is not provided, this option will be ignored.
+    # @param characters_at_limit_text [String] The text that informs the user they've reached the character limit. Default is "No characters left". If javascript is not provided, this option will be ignored.
+    # @param characters_over_limit_other_text [String] Text that informs the user they have added X words/characters too many. Default is "%{count} characters to go". If javascript is not provided, this option will be ignored.
+    # @param characters_over_limit_one_text [String] Text that informs the user they have added 1 word/character too many. Default is "%{count} character to go". If javascript is not provided, this option will be ignored.
     # @return [ActiveSupport::SafeBuffer] HTML output
     # @see https://design-system.service.gov.uk/components/textarea/ GOV.UK text area component
     # @see https://design-system.service.gov.uk/components/character-count GOV.UK character count component
@@ -409,8 +414,46 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_text_area :instructions,
     #     label: -> { tag.h3("How do you set it up?") }
     #
-    def govuk_text_area(attribute_name, hint: {}, label: {}, caption: {}, max_words: nil, max_chars: nil, rows: 5, threshold: nil, form_group: {}, **kwargs, &block)
-      Elements::TextArea.new(self, object_name, attribute_name, hint:, label:, caption:, max_words:, max_chars:, rows:, threshold:, form_group:, **kwargs, &block).html
+    def govuk_text_area(
+      attribute_name,
+      hint: {},
+      label: {},
+      caption: {},
+      max_words: nil,
+      max_chars: nil,
+      rows: 5,
+      threshold: nil,
+      form_group: {},
+      description_other_text: nil,
+      under_limit_other_text: nil,
+      under_limit_one_text: nil,
+      at_limit_text: nil,
+      over_limit_one_text: nil,
+      over_limit_other_text: nil,
+      **kwargs,
+      &block
+    )
+      Elements::TextArea.new(
+        self,
+        object_name,
+        attribute_name,
+        hint:,
+        label:,
+        caption:,
+        max_words:,
+        max_chars:,
+        rows:,
+        threshold:,
+        form_group:,
+        description_other_text:,
+        under_limit_other_text:,
+        under_limit_one_text:,
+        at_limit_text:,
+        over_limit_one_text:,
+        over_limit_other_text:,
+        **kwargs,
+        &block
+      ).html
     end
 
     # Generates a +select+ element containing +option+ for each member in the provided collection

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -10,7 +10,27 @@ module GOVUKDesignSystemFormBuilder
       include Traits::HTMLAttributes
       include Traits::HTMLClasses
 
-      def initialize(builder, object_name, attribute_name, hint:, label:, caption:, rows:, max_words:, max_chars:, threshold:, form_group:, **kwargs, &block)
+      def initialize(
+        builder,
+        object_name,
+        attribute_name,
+        hint:,
+        label:,
+        caption:,
+        rows:,
+        max_words:,
+        max_chars:,
+        threshold:,
+        form_group:,
+        description_other_text:,
+        under_limit_other_text:,
+        under_limit_one_text:,
+        at_limit_text:,
+        over_limit_other_text:,
+        over_limit_one_text:,
+        **kwargs,
+        &block
+      )
         super(builder, object_name, attribute_name, &block)
 
         fail ArgumentError, 'limit can be words or chars' if max_words && max_chars
@@ -24,10 +44,17 @@ module GOVUKDesignSystemFormBuilder
         @rows            = rows
         @form_group      = form_group
         @html_attributes = kwargs
+
+        @description_other_text = description_other_text
+        @under_limit_other_text = under_limit_other_text
+        @under_limit_one_text   = under_limit_one_text
+        @at_limit_text          = at_limit_text
+        @over_limit_other_text  = over_limit_other_text
+        @over_limit_one_text    = over_limit_one_text
       end
 
       def html
-        Containers::FormGroup.new(*bound, **@form_group.merge(limit_form_group_options)).html do
+        Containers::FormGroup.new(*bound, **@form_group.merge(limit_form_group_options), **i18n_data).html do
           safe_join([label_element, supplemental_content, hint_element, error_element, text_area, limit_description])
         end
       end
@@ -108,6 +135,28 @@ module GOVUKDesignSystemFormBuilder
 
       def limit_threshold_options
         { threshold: @threshold }
+      end
+
+      def i18n_data
+        # "data-i18n.textarea-description.other" => @textarea_description_other_text,
+        case limit_type
+        when 'characters'
+          {
+            'data-i18n.characters-at-limit' => @at_limit_text,
+            'data-i18n.characters-under-limit.other' => @under_limit_other_text,
+            'data-i18n.characters-under-limit.one' => @under_limit_one_text,
+            'data-i18n.characters-over-limit.other' => @over_limit_other_text,
+            'data-i18n.characters-over-limit.one' => @over_limit_one_text,
+          }.compact
+        when 'words'
+          {
+            'data-i18n.words-at-limit' => @at_limit_text,
+            'data-i18n.words-under-limit.other' => @under_limit_other_text,
+            'data-i18n.words-under-limit.one' => @under_limit_one_text,
+            'data-i18n.words-over-limit.other' => @over_limit_other_text,
+            'data-i18n.words-over-limit.one' => @over_limit_one_text,
+          }.compact
+        end
       end
     end
   end

--- a/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/text_area_spec.rb
@@ -182,6 +182,70 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         )
       end
     end
+
+    describe 'GOV.UK frontend localisation' do
+      context 'when no i18n options are set' do
+        specify 'the div has no i18n data attributes set' do
+          expect(subject).not_to include(/data-i18n/)
+        end
+      end
+
+      context 'when i18n character options are set' do
+        let(:under_limit_other_text) { '%{count} caractères restants' }
+        let(:under_limit_one_text) { '%{count} caractère restant' }
+        let(:at_limit_text) { 'Plus aucun caractère restant' }
+        let(:over_limit_other_text) { '%{count} caractères de trop' }
+        let(:over_limit_one_text) { '%{count} caractère de trop' }
+
+        subject { builder.send(*args, max_chars: 20, at_limit_text:, under_limit_other_text:, under_limit_one_text:, over_limit_other_text:, over_limit_one_text:) }
+
+        let(:form_group) { parsed_subject.at_css('div.govuk-form-group') }
+
+        specify 'the i18n attributes are present on the form group div element' do
+          aggregate_failures do
+            expect(form_group.attributes['data-i18n.characters-under-limit.other'].text).to eql(under_limit_other_text)
+            expect(form_group.attributes['data-i18n.characters-under-limit.one'].text).to eql(under_limit_one_text)
+            expect(form_group.attributes['data-i18n.characters-at-limit'].text).to eql(at_limit_text)
+            expect(form_group.attributes['data-i18n.characters-over-limit.other'].text).to eql(over_limit_other_text)
+            expect(form_group.attributes['data-i18n.characters-over-limit.one'].text).to eql(over_limit_one_text)
+          end
+        end
+
+        specify 'all i18n attributes are characters (rather than words)' do
+          values = form_group.attributes.keys.select { |key| key.start_with?('data-i18n') }
+
+          expect(values).to all(match(/characters/))
+        end
+      end
+
+      context 'when i18n word options are set' do
+        let(:at_limit_text) { 'Plus aucun caractère restant' }
+        let(:under_limit_other_text) { '%{count} mots restants' }
+        let(:under_limit_one_text) { '%{count} mot restant' }
+        let(:over_limit_other_text) { '%{count} mots de trop' }
+        let(:over_limit_one_text) { '%{count} mot de trop' }
+
+        subject { builder.send(*args, max_words: 20, at_limit_text:, under_limit_other_text:, under_limit_one_text:, over_limit_other_text:, over_limit_one_text:) }
+
+        let(:form_group) { parsed_subject.at_css('div.govuk-form-group') }
+
+        specify 'the i18n attributes are present on the form group div element' do
+          aggregate_failures do
+            expect(form_group.attributes['data-i18n.words-under-limit.other'].text).to eql(under_limit_other_text)
+            expect(form_group.attributes['data-i18n.words-under-limit.one'].text).to eql(under_limit_one_text)
+            expect(form_group.attributes['data-i18n.words-at-limit'].text).to eql(at_limit_text)
+            expect(form_group.attributes['data-i18n.words-over-limit.other'].text).to eql(over_limit_other_text)
+            expect(form_group.attributes['data-i18n.words-over-limit.one'].text).to eql(over_limit_one_text)
+          end
+        end
+
+        specify 'all i18n attributes are words (rather than characters)' do
+          values = form_group.attributes.keys.select { |key| key.start_with?('data-i18n') }
+
+          expect(values).to all(match(/words/))
+        end
+      end
+    end
   end
 
   context 'rows' do


### PR DESCRIPTION
This functionality, which isn't well-covered in the design system's documentation, allows the dynamic JavaScript content used by text area character counts to be localised.

This is handled by adding the following arguments to the `#govuk_textarea` helper:

* `under_limit_other_text`
* `under_limit_one_text`
* `at_limit_text`
* `over_limit_other_text`
* `over_limit_one_text`

They all default to nil so the default behaviour of textareas won't change.

This differs slightly from the upstream Nunjucks in that the parameter names don't differentiate between words/characters, and the form builder will decide which HTML attributes to set depending on whether `max_chars` or `max_words` is set.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/7d4ba32c-8fdd-4813-abbd-5798ec682672" />

Fixes #594 