### PR TITLE
Fix #627: Merge password form group options

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/password.rb
+++ b/lib/govuk_design_system_formbuilder/elements/password.rb
@@ -2,6 +2,7 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     class Password < Base
       using PrefixableArray
+      using HTMLAttributesUtils
 
       include Traits::Error
       include Traits::Hint
@@ -57,11 +58,10 @@ module GOVUKDesignSystemFormBuilder
 
       def form_group_options
         {
-          **@form_group,
           **i18n_data,
           class: %(#{brand}-password-input),
           data: { module: %(#{brand}-password-input) },
-        }
+        }.deep_merge_html_attributes(@form_group)
       end
 
       def password_input

--- a/spec/govuk_design_system_formbuilder/builder/password_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/password_spec.rb
@@ -24,6 +24,19 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group', "data-module" => "govuk-password-input" })
     end
 
+    specify 'merges custom form group attributes with the password input attributes' do
+      kwargs[:form_group] = { class: "example", data: { controller: "password" } }
+
+      expect(subject).to have_tag(
+        'div',
+        with: {
+          class: %w(govuk-form-group govuk-password-input example),
+          "data-module" => "govuk-password-input",
+          "data-controller" => "password",
+        }
+      )
+    end
+
     specify 'the password input has the right classes' do
       expect(subject).to have_tag('input', with: { class: %w(govuk-input govuk-password-input__input govuk-js-password-input-input) })
     end


### PR DESCRIPTION
Use `HTMLAttributesUtils` to merge `form_group` options passed to `govuk_password_input` instead of clobbering them.