### PR TITLE
Add `options:` argument to form group

### DIFF
--- a/lib/govuk_design_system_formbuilder/containers/form_group.rb
+++ b/lib/govuk_design_system_formbuilder/containers/form_group.rb
@@ -4,9 +4,10 @@ module GOVUKDesignSystemFormBuilder
       include Traits::HTMLAttributes
       include Traits::HTMLClasses
 
-      def initialize(builder, object_name, attribute_name, **kwargs)
+      def initialize(builder, object_name, attribute_name, options: {}, **kwargs)
         super(builder, object_name, attribute_name)
 
+        @options = options
         @html_attributes = kwargs
       end
 
@@ -18,6 +19,7 @@ module GOVUKDesignSystemFormBuilder
 
       def options
         {
+          **@options,
           class: build_classes(
             %(#{brand}-form-group),
             %(#{brand}-form-group--error) => has_errors?

--- a/lib/govuk_design_system_formbuilder/elements/password.rb
+++ b/lib/govuk_design_system_formbuilder/elements/password.rb
@@ -31,7 +31,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        Containers::FormGroup.new(*bound, **form_group_options).html do
+        Containers::FormGroup.new(*bound, options: @form_group, **form_group_options).html do
           safe_join([label_element, hint_element, error_element, password_input_and_button])
         end
       end
@@ -57,7 +57,6 @@ module GOVUKDesignSystemFormBuilder
 
       def form_group_options
         {
-          **@form_group,
           **i18n_data,
           class: %(#{brand}-password-input),
           data: { module: %(#{brand}-password-input) },

--- a/spec/govuk_design_system_formbuilder/builder/password_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/password_spec.rb
@@ -24,6 +24,14 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group', "data-module" => "govuk-password-input" })
     end
 
+    context 'when extra form group attributes are passed in' do
+      let(:kwargs) { { form_group: { data: { controller: 'password' } } } }
+
+      specify 'the form group attributes are present on the form group element' do
+        expect(subject).to have_tag('div', with: { class: 'govuk-form-group', 'data-module' => 'govuk-password-input', 'data-controller' => 'password' })
+      end
+    end
+
     specify 'the password input has the right classes' do
       expect(subject).to have_tag('input', with: { class: %w(govuk-input govuk-password-input__input govuk-js-password-input-input) })
     end


### PR DESCRIPTION
This fixes a bug in the password input where splatting `@form_group` in with the other `form_group_options` caused the `data:` keys to clash, so the provided one was overwritten by the default.

[Password](https://design-system.service.gov.uk/components/password-input/) is a bit unconventional, it's the only form input to put data attributes on the form group.

To counter this problem, now `options:` are passed in separately. That allows the merging to be handled by deep_merge_html_attributes, which preserves both the default and provided HTML attributes
