### PR TITLE
Ensure no custom attributes are lost by the password input

### DIFF
--- a/lib/govuk_design_system_formbuilder/containers/form_group.rb
+++ b/lib/govuk_design_system_formbuilder/containers/form_group.rb
@@ -4,10 +4,9 @@ module GOVUKDesignSystemFormBuilder
       include Traits::HTMLAttributes
       include Traits::HTMLClasses
 
-      def initialize(builder, object_name, attribute_name, options: {}, **kwargs)
+      def initialize(builder, object_name, attribute_name, **kwargs)
         super(builder, object_name, attribute_name)
 
-        @options = options
         @html_attributes = kwargs
       end
 
@@ -19,7 +18,6 @@ module GOVUKDesignSystemFormBuilder
 
       def options
         {
-          **@options,
           class: build_classes(
             %(#{brand}-form-group),
             %(#{brand}-form-group--error) => has_errors?

--- a/lib/govuk_design_system_formbuilder/elements/password.rb
+++ b/lib/govuk_design_system_formbuilder/elements/password.rb
@@ -2,6 +2,7 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     class Password < Base
       using PrefixableArray
+      using HTMLAttributesUtils
 
       include Traits::Error
       include Traits::Hint
@@ -60,7 +61,7 @@ module GOVUKDesignSystemFormBuilder
           **i18n_data,
           class: %(#{brand}-password-input),
           data: { module: %(#{brand}-password-input) },
-        }
+        }.deep_merge_html_attributes(@form_group)
       end
 
       def password_input

--- a/lib/govuk_design_system_formbuilder/elements/password.rb
+++ b/lib/govuk_design_system_formbuilder/elements/password.rb
@@ -32,7 +32,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def html
-        Containers::FormGroup.new(*bound, options: @form_group, **form_group_options).html do
+        Containers::FormGroup.new(*bound, **form_group_options).html do
           safe_join([label_element, hint_element, error_element, password_input_and_button])
         end
       end

--- a/spec/govuk_design_system_formbuilder/builder/password_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/password_spec.rb
@@ -24,12 +24,17 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group', "data-module" => "govuk-password-input" })
     end
 
-    context 'when extra form group attributes are passed in' do
-      let(:kwargs) { { form_group: { data: { controller: 'password' } } } }
+    specify 'merges custom form group attributes with the password input attributes' do
+      kwargs[:form_group] = { class: "example", data: { controller: "password" } }
 
-      specify 'the form group attributes are present on the form group element' do
-        expect(subject).to have_tag('div', with: { class: 'govuk-form-group', 'data-module' => 'govuk-password-input', 'data-controller' => 'password' })
-      end
+      expect(subject).to have_tag(
+        'div',
+        with: {
+          class: %w(govuk-form-group govuk-password-input example),
+          "data-module" => "govuk-password-input",
+          "data-controller" => "password",
+        }
+      )
     end
 
     specify 'the password input has the right classes' do


### PR DESCRIPTION
This PR undoes the changes in #629 and replaces the approach with that from #627, which deals with `class` properly too.
