### PR TITLE
Add the ability to configure defaults for JavaScript localisation values

### DIFF
--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -17,6 +17,38 @@ module GOVUKDesignSystemFormBuilder
     end
   end
 
+  GOVUK_FRONTEND_DEFAULTS = {
+    # password field
+    default_show_password_text: 'Show',
+    default_hide_password_text: 'Hide',
+    default_show_password_aria_label_text: 'Show password',
+    default_hide_password_aria_label_text: 'Hide password',
+    default_password_shown_announcement_text: 'Your password is visible',
+    default_password_hidden_announcement_text: 'Your password is hidden',
+
+    # text area (character count)
+    default_text_area_description_text: nil,
+    default_text_area_words_under_limit_other_text: 'You have %{count} words remaining',
+    default_text_area_words_under_limit_one_text: 'You have %{count} word remaining',
+    default_text_area_words_at_limit_text: 'You have 0 words remaining',
+    default_text_area_words_over_limit_other_text: 'You have %{count} words too many',
+    default_text_area_words_over_limit_one_text: 'You have %{count} word too many',
+    default_text_area_characters_under_limit_other_text: 'You have %{count} characters remaining',
+    default_text_area_characters_under_limit_one_text: 'You have %{count} character remaining',
+    default_text_area_characters_at_limit_text: 'You have 0 characters remaining',
+    default_text_area_characters_over_limit_other_text: 'You have %{count} characters too many',
+    default_text_area_characters_over_limit_one_text: 'You have %{count} character too many',
+
+    # file upload
+    default_file_choose_files_button_text: 'Choose file',
+    default_file_drop_instruction_text: 'or drop file',
+    default_file_no_file_chosen_text: 'No file chosen',
+    default_file_multiple_files_chosen_one_text: 'One file chosen',
+    default_file_multiple_files_chosen_other_text: '%{count} files chosen',
+    default_file_entered_drop_zone: 'Entered drop zone',
+    default_file_left_drop_zone: 'Left drop zone',
+  }.freeze
+
   # @!group Defaults
 
   # Default form builder configuration
@@ -82,6 +114,86 @@ module GOVUKDesignSystemFormBuilder
   #   When nil, no data attribute will be added. Defaults to turbo since Rails 7,
   #   change to 'turbolinks' for Rails 6.1
   #
+  # * +:default_text_area_description_text+ sets the text that's displayed beneath
+  #   the text area when word counts are enabled. Defaults to nil
+  #
+  # * +:default_text_area_words_under_limit_other_text+ sets the text displayed when the
+  #   user is approaching the limit of words. Defaults to "You have %{count} words remaining"
+  #
+  # * +:default_text_area_words_under_limit_one_text+ sets the text that's displayed when the
+  #   user is 1 word below the limit. Defaults to "You have %{count} word remaining"
+  #
+  # * +:default_text_area_words_at_limit_text+ sets the text that's displayed when the user
+  #   has reached the limit. Defaults to "You have 0 words remaining"
+  #
+  # * +:default_text_area_words_over_limit_other_text+ sets the text displayed when the
+  #   user is more than 1 word above the limit. Defaults to "You have %{count}
+  #   words too many"
+  #
+  # * +:default_text_area_words_over_limit_one_text+ sets the text that's displayed when the
+  #   user is 1 word above the limit. Defaults to "You have %{count} word too many"
+  #
+  # * +:default_text_area_characters_under_limit_other_text+ sets the text displayed when the
+  #   user is approaching the limit of characters. Defaults to "You have %{count} characters
+  #   remaining"
+  #
+  # * +:default_text_area_characters_under_limit_one_text+ sets the text that's displayed when the
+  #   user is 1 character below the limit. Defaults to "You have %{count} character remaining"
+  #
+  # * +:default_text_area_characters_at_limit_text+ sets the text that's displayed when the user
+  #   has reached the limit. Defaults to "You have 0 characters remaining"
+  #
+  # * +:default_text_area_characters_over_limit_other_text+ sets the text displayed when the
+  #   user is more than 1 character above the limit. Defaults to "You have %{count}
+  #   characters too many"
+  #
+  # * +:default_text_area_characters_over_limit_one_text+ sets the text that's displayed when the
+  #   user is 1 character above the limit. Defaults to "You have %{count} character too many"
+  #
+  # * +:default_show_password_text+ Button text when the password is hidden. Defaults to 'Show'
+  #
+  # * +:default_hide_password_text+ Button text when the password is revealed. Defaults to 'Hide'
+  #
+  # * +:default_show_password_aria_label_text+ Button text exposed to assistive technologies like
+  #   screen readers, when the password is hidden. Defaults to "Show password"
+  #
+  # * +:default_hide_password_aria_label_text+ Button text exposed to assistive technologies like
+  #   screen readers, when the password is visible. Defaults to "Hide password".
+  #
+  # * +:default_password_shown_announcement_text+ Announcement made to screen reader users when
+  #   their password has become visible in plain text. Defaults to "Your password is visible"
+  #
+  # * +:default_password_hidden_announcement_text+ Announcement made to screen reader users when
+  #   their password has been obscured and is not visible. Defaults to "Your password is hidden"
+  #
+  # * +:default_file_choose_files_button_text+ The text of the button that opens the file picker.
+  #   Default is "Choose file". If javascript is not provided, this option will be ignored
+  #
+  # * +:default_file_drop_instruction_text+ The text informing users they can drop files.
+  #   Default is "or drop file". If javascript is not provided, this option will be ignore
+  #
+  # * +:default_file_no_file_chosen_text+ The text displayed when no file has been chosen by
+  #   the user. Default is "No file chosen". If javascript is not provided, this option will be
+  #   ignored
+  #
+  # * +:default_file_multiple_files_chosen_one_text+ The text displayed when multiple files are
+  #   enabled and one file has been chosen by the user. The component will replace the %{count}
+  #   placeholder with the number of files selected. If javascript is not provided, this option
+  #   will be ignored. Defaults to 'One file chosen'
+  #
+  # * +:default_file_multiple_files_chosen_other_text+ The text displayed when multiple files are
+  #   enabled and multiple files have been chosen by the user. The component will replace the %{count}
+  #   placeholder with the number of files selected. If javascript is not provided, this option
+  #   will be ignored. Defaults to '%{count} files chosen'
+  #
+  # * +:default_file_entered_drop_zone+ The text announced by assistive technology when user drags
+  #   files and enters the drop zone. Default is "Entered drop zone". If javascript is not provided,
+  #   this option will be ignored
+  #
+  # * +:default_file_left_drop_zone+ The text announced by assistive technology when user drags
+  #   files and leaves the drop zone without dropping. Default is "Left drop zone". If javascript
+  #   is not provided, this option will be ignored.
+  #
   # * +:localisation_schema_fallback+ sets the prefix elements for the array
   #   used to build the localisation string. The final two elements are always
   #   are the object name and attribute name. The _special_ value +__context__+,
@@ -124,12 +236,6 @@ module GOVUKDesignSystemFormBuilder
     default_collection_radio_buttons_include_hidden: true,
     default_collection_radio_buttons_auto_bold_labels: true,
     default_submit_validate: false,
-    default_show_password_text: "Show",
-    default_hide_password_text: "Hide",
-    default_show_password_aria_label_text: "Show password",
-    default_hide_password_aria_label_text: "Hide password",
-    default_password_shown_announcement_text: "Your password is visible",
-    default_password_hidden_announcement_text: "Your password is hidden",
     localisation_schema_fallback: %i(helpers __context__),
     localisation_schema_label: nil,
     localisation_schema_hint: nil,
@@ -142,6 +248,8 @@ module GOVUKDesignSystemFormBuilder
     # temporarily allow the new nested localisation functionality to be
     # disabled
     enable_nested_localisation: true,
+
+    **GOVUK_FRONTEND_DEFAULTS
   }.freeze
 
   DEFAULTS.each do |key, value|

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -329,12 +329,12 @@ module GOVUKDesignSystemFormBuilder
       label: {},
       caption: {},
       form_group: {},
-      show_password_text: config.default_show_password_text,
-      hide_password_text: config.default_hide_password_text,
-      show_password_aria_label_text: config.default_show_password_aria_label_text,
-      hide_password_aria_label_text: config.default_hide_password_aria_label_text,
-      password_shown_announcement_text: config.default_password_shown_announcement_text,
-      password_hidden_announcement_text: config.default_password_hidden_announcement_text,
+      show_password_text: nil,
+      hide_password_text: nil,
+      show_password_aria_label_text: nil,
+      hide_password_aria_label_text: nil,
+      password_shown_announcement_text: nil,
+      password_hidden_announcement_text: nil,
       **kwargs,
       &block
     )
@@ -1165,6 +1165,9 @@ module GOVUKDesignSystemFormBuilder
     # @param choose_files_button_text [String] The text of the button that opens the file picker. Default is "Choose file". If javascript is not provided, this option will be ignored.
     # @param drop_instruction_text [String] The text informing users they can drop files. Default is "or drop file". If javascript is not provided, this option will be ignored.
     # @param multiple_files_chosen_text [Hash] The text displayed when multiple files have been chosen by the user. The component will replace the %{count} placeholder with the number of files selected. This uses the govuk-frontend pluralisation rules. If javascript is not provided, this option will be ignored.
+    # @param multiple_files_chosen_one_text [String] The text displayed when JavaScript is enabled and one file has been chosen by the user. The component will replace the %{count} placeholder with the number of files selected. This can also be set by passing a hash with key +one:+ to +multiple_files_chosen_text+.
+    # @param multiple_files_chosen_other_text [String] The text displayed when JavaScript is enabled and multiple files have been chosen by the user. The component will replace the %{count} placeholder with the number of files selected. This can also be set by passing a hash with key +other:+ to +multiple_files_chosen_text+.
+
     # @param no_file_chosen_text [String] The text displayed when no file has been chosen by the user. Default is "No file chosen". If javascript is not provided, this option will be ignored.
     # @param entered_drop_zone_text [String] The text announced by assistive technology when user drags files and enters the drop zone. Default is "Entered drop zone". If javascript is not provided, this option will be ignored.
     # @param left_drop_zone_text [String] The text announced by assistive technology when user drags files and leaves the drop zone without dropping. Default is "Left drop zone". If javascript is not provided, this option will be ignored.
@@ -1198,6 +1201,8 @@ module GOVUKDesignSystemFormBuilder
       choose_files_button_text: nil,
       drop_instruction_text: nil,
       multiple_files_chosen_text: nil,
+      multiple_files_chosen_one_text: nil,
+      multiple_files_chosen_other_text: nil,
       no_file_chosen_text: nil,
       entered_drop_zone_text: nil,
       left_drop_zone_text: nil,
@@ -1218,6 +1223,8 @@ module GOVUKDesignSystemFormBuilder
         choose_files_button_text:,
         drop_instruction_text:,
         multiple_files_chosen_text:,
+        multiple_files_chosen_one_text:,
+        multiple_files_chosen_other_text:,
         no_file_chosen_text:,
         entered_drop_zone_text:,
         left_drop_zone_text:,

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -10,8 +10,9 @@ module GOVUKDesignSystemFormBuilder
       include Traits::HTMLAttributes
       include Traits::HTMLClasses
       include Traits::ContentBeforeAndAfter
+      include Traits::DataAttributesI18n
 
-      def initialize(builder, object_name, attribute_name, hint:, label:, caption:, form_group:, javascript:, before_input:, after_input:, choose_files_button_text:, drop_instruction_text:, multiple_files_chosen_text:, no_file_chosen_text:, entered_drop_zone_text:, left_drop_zone_text:, **kwargs, &block)
+      def initialize(builder, object_name, attribute_name, hint:, label:, caption:, form_group:, javascript:, before_input:, after_input:, choose_files_button_text:, drop_instruction_text:, multiple_files_chosen_text:, multiple_files_chosen_one_text:, multiple_files_chosen_other_text:, no_file_chosen_text:, entered_drop_zone_text:, left_drop_zone_text:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
         @label = label
@@ -26,6 +27,8 @@ module GOVUKDesignSystemFormBuilder
         @choose_files_button_text = choose_files_button_text
         @drop_instruction_text = drop_instruction_text
         @multiple_files_chosen_text = multiple_files_chosen_text
+        @multiple_files_chosen_one_text = multiple_files_chosen_one_text
+        @multiple_files_chosen_other_text = multiple_files_chosen_other_text
         @no_file_chosen_text = no_file_chosen_text
         @entered_drop_zone_text = entered_drop_zone_text
         @left_drop_zone_text = left_drop_zone_text
@@ -64,21 +67,28 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def i18n_data
-        data = {
-          "data-i18n.choose-files-button" => @choose_files_button_text,
-          "data-i18n.drop-instruction" => @drop_instruction_text,
-          "data-i18n.no-file-chosen" => @no_file_chosen_text,
-          "data-i18n.entered-drop-zone" => @entered_drop_zone_text,
-          "data-i18n.left-drop-zone" => @left_drop_zone_text,
-        }
+        attrs = [
+          I18nAttr.new("data-i18n.choose-files-button",         @choose_files_button_text,         :default_file_choose_files_button_text),
+          I18nAttr.new("data-i18n.drop-instruction",            @drop_instruction_text,            :default_file_drop_instruction_text),
+          I18nAttr.new("data-i18n.no-file-chosen",              @no_file_chosen_text,              :default_file_no_file_chosen_text),
+          I18nAttr.new("data-i18n.multiple-files-chosen.one",   @multiple_files_chosen_one_text,   :default_file_multiple_files_chosen_one_text),
+          I18nAttr.new("data-i18n.multiple-files-chosen.other", @multiple_files_chosen_other_text, :default_file_multiple_files_chosen_other_text),
+          I18nAttr.new("data-i18n.entered-drop-zone",           @entered_drop_zone_text,           :default_file_entered_drop_zone),
+          I18nAttr.new("data-i18n.left-drop-zone",              @left_drop_zone_text,              :default_file_left_drop_zone)
+        ]
 
+        # deal with the Nunjucks stlye hash format as an alternative
         if @multiple_files_chosen_text.is_a?(Hash)
-          @multiple_files_chosen_text.each do |key, value|
-            data["data-i18n.multiple-files-chosen.#{key}"] = value
+          if (text = @multiple_files_chosen_text.symbolize_keys[:other])
+            attrs << I18nAttr.new("data-i18n.multiple-files-chosen.other", text, :default_file_multiple_files_chosen_other_text)
+          end
+
+          if (text = @multiple_files_chosen_text.symbolize_keys[:one])
+            attrs << I18nAttr.new("data-i18n.multiple-files-chosen.one", text, :default_file_multiple_files_chosen_one_text)
           end
         end
 
-        data.compact
+        build_data_attr_hash(attrs)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/password.rb
+++ b/lib/govuk_design_system_formbuilder/elements/password.rb
@@ -9,8 +9,7 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Label
       include Traits::HTMLAttributes
       include Traits::HTMLClasses
-
-      I18nAttr = Struct.new(:key, :text, :default)
+      include Traits::DataAttributesI18n
 
       def initialize(builder, object_name, attribute_name, label:, caption:, hint:, form_group:, show_password_text:, hide_password_text:, show_password_aria_label_text:, hide_password_aria_label_text:, password_hidden_announcement_text:, password_shown_announcement_text:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
@@ -91,16 +90,16 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def i18n_data
-        [
-          I18nAttr.new("data-i18n.show-password",                @show_password_text,                config.default_show_password_text),
-          I18nAttr.new("data-i18n.hide-password",                @hide_password_text,                config.default_hide_password_text),
-          I18nAttr.new("data-i18n.show-password-aria-label",     @show_password_aria_label_text,     config.default_show_password_aria_label_text),
-          I18nAttr.new("data-i18n.hide-password-aria-label",     @hide_password_aria_label_text,     config.default_hide_password_aria_label_text),
-          I18nAttr.new("data-i18n.password-shown-announcement",  @password_shown_announcement_text,  config.default_password_shown_announcement_text),
-          I18nAttr.new("data-i18n.password-hidden-announcement", @password_hidden_announcement_text, config.default_password_hidden_announcement_text),
-        ].each_with_object({}) do |attr, h|
-          h[attr.key] = attr.text unless attr.text == attr.default
-        end
+        attrs = [
+          I18nAttr.new("data-i18n.show-password",                @show_password_text,                :default_show_password_text),
+          I18nAttr.new("data-i18n.hide-password",                @hide_password_text,                :default_hide_password_text),
+          I18nAttr.new("data-i18n.show-password-aria-label",     @show_password_aria_label_text,     :default_show_password_aria_label_text),
+          I18nAttr.new("data-i18n.hide-password-aria-label",     @hide_password_aria_label_text,     :default_hide_password_aria_label_text),
+          I18nAttr.new("data-i18n.password-shown-announcement",  @password_shown_announcement_text,  :default_password_shown_announcement_text),
+          I18nAttr.new("data-i18n.password-hidden-announcement", @password_hidden_announcement_text, :default_password_hidden_announcement_text),
+        ]
+
+        build_data_attr_hash(attrs)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -9,6 +9,7 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Supplemental
       include Traits::HTMLAttributes
       include Traits::HTMLClasses
+      include Traits::DataAttributesI18n
 
       def initialize(
         builder,
@@ -138,25 +139,28 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def i18n_data
-        # "data-i18n.textarea-description.other" => @textarea_description_other_text,
-        case limit_type
-        when 'characters'
-          {
-            'data-i18n.characters-at-limit' => @at_limit_text,
-            'data-i18n.characters-under-limit.other' => @under_limit_other_text,
-            'data-i18n.characters-under-limit.one' => @under_limit_one_text,
-            'data-i18n.characters-over-limit.other' => @over_limit_other_text,
-            'data-i18n.characters-over-limit.one' => @over_limit_one_text,
-          }.compact
-        when 'words'
-          {
-            'data-i18n.words-at-limit' => @at_limit_text,
-            'data-i18n.words-under-limit.other' => @under_limit_other_text,
-            'data-i18n.words-under-limit.one' => @under_limit_one_text,
-            'data-i18n.words-over-limit.other' => @over_limit_other_text,
-            'data-i18n.words-over-limit.one' => @over_limit_one_text,
-          }.compact
-        end
+        return {} unless limit_quantity
+
+        attrs = case limit_type
+                when 'characters'
+                  [
+                    I18nAttr.new('data-i18n.characters-under-limit.other', @under_limit_other_text, :default_text_area_characters_under_limit_other_text),
+                    I18nAttr.new('data-i18n.characters-under-limit.one',   @under_limit_one_text,   :default_text_area_characters_under_limit_one_text),
+                    I18nAttr.new('data-i18n.characters-at-limit',          @at_limit_text,          :default_text_area_characters_at_limit_text),
+                    I18nAttr.new('data-i18n.characters-over-limit.other',  @over_limit_other_text,  :default_text_area_characters_over_limit_other_text),
+                    I18nAttr.new('data-i18n.characters-over-limit.one',    @over_limit_one_text,    :default_text_area_characters_over_limit_one_text),
+                  ]
+                when 'words'
+                  [
+                    I18nAttr.new('data-i18n.words-under-limit.other', @under_limit_other_text, :default_text_area_words_under_limit_other_text),
+                    I18nAttr.new('data-i18n.words-under-limit.one',   @under_limit_one_text,   :default_text_area_words_under_limit_one_text),
+                    I18nAttr.new('data-i18n.words-at-limit',          @at_limit_text,          :default_text_area_words_at_limit_text),
+                    I18nAttr.new('data-i18n.words-over-limit.other',  @over_limit_other_text,  :default_text_area_words_over_limit_other_text),
+                    I18nAttr.new('data-i18n.words-over-limit.one',    @over_limit_one_text,    :default_text_area_words_over_limit_one_text),
+                  ]
+                end
+
+        build_data_attr_hash(attrs)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/traits/data_attributes_i18n.rb
+++ b/lib/govuk_design_system_formbuilder/traits/data_attributes_i18n.rb
@@ -1,0 +1,25 @@
+module GOVUKDesignSystemFormBuilder
+  module Traits
+    module DataAttributesI18n
+      I18nAttr = Struct.new(:data_attribute_key, :text, :config_key) do
+        def default
+          GOVUKDesignSystemFormBuilder.config[config_key]
+        end
+      end
+
+    private
+
+      def build_data_attr_hash(attrs)
+        attrs.each_with_object({}) do |attr, h|
+          text = attr.text || attr.default
+
+          h[attr.data_attribute_key] = text unless govuk_default?(attr.config_key, text)
+        end
+      end
+
+      def govuk_default?(key, value)
+        GOVUKDesignSystemFormBuilder::GOVUK_FRONTEND_DEFAULTS.fetch(key) == value
+      end
+    end
+  end
+end

--- a/spec/govuk_design_system_formbuilder/builder/configuration/localisation_data_attributes_configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration/localisation_data_attributes_configuration_spec.rb
@@ -1,0 +1,208 @@
+describe GOVUKDesignSystemFormBuilder::FormBuilder do
+  include_context 'setup builder'
+  include_context 'setup examples'
+
+  after { GOVUKDesignSystemFormBuilder.reset! }
+
+  describe "textarea" do
+    let(:method) { :govuk_text_area }
+    let(:attribute) { :cv }
+    let(:args) { [method, attribute] }
+    let(:kwargs) { {} }
+    let(:form_group) { parsed_subject.at_css('div.govuk-form-group') }
+
+    let(:characters_under_limit_other_text) { 'Hai %{count} caratteri rimanenti' }
+    let(:characters_under_limit_one_text) { 'Ti rimane %{count} carattere' }
+    let(:characters_at_limit_text) { 'Hai 0 caratteri rimanenti' }
+    let(:characters_over_limit_other_text) { 'Hai %{count} caratteri di troppo' }
+    let(:characters_over_limit_one_text) { 'Hai %{count} carattere di troppo' }
+
+    let(:words_under_limit_other_text) { 'Hai %{count} parole rimanenti' }
+    let(:words_under_limit_one_text) { 'Ti rimane %{count} parola' }
+    let(:words_at_limit_text) { 'Hai 0 parole rimanenti' }
+    let(:words_over_limit_other_text) { 'Hai %{count} parole di troppo' }
+    let(:words_over_limit_one_text) { 'Hai %{count} parola di troppo' }
+
+    subject { builder.send(*args, **kwargs) }
+
+    context 'when the config is default' do
+      specify 'no data i18n attributes are set' do
+        data_attribute_keys = form_group.attributes.keys.select { |a| a =~ /data-i18n/ }
+
+        expect(data_attribute_keys).to be_empty
+      end
+    end
+
+    context 'when not limiting anything' do
+      before do
+        GOVUKDesignSystemFormBuilder.configure do |conf|
+          conf.default_text_area_characters_under_limit_other_text = 'abc'
+        end
+      end
+
+      specify 'no data i18n attributes are set' do
+        data_attribute_keys = form_group.attributes.keys.select { |a| a =~ /data-i18n/ }
+
+        expect(data_attribute_keys).to be_empty
+      end
+    end
+
+    context 'when limiting is enabled and data i18n attributes are localised in the config' do
+      before do
+        GOVUKDesignSystemFormBuilder.configure do |conf|
+          conf.default_text_area_description_text = nil
+          conf.default_text_area_characters_under_limit_other_text = characters_under_limit_other_text
+          conf.default_text_area_characters_under_limit_one_text = characters_under_limit_one_text
+          conf.default_text_area_characters_at_limit_text = characters_at_limit_text
+          conf.default_text_area_characters_over_limit_other_text = characters_over_limit_other_text
+          conf.default_text_area_characters_over_limit_one_text = characters_over_limit_one_text
+          conf.default_text_area_words_under_limit_other_text = words_under_limit_other_text
+          conf.default_text_area_words_under_limit_one_text = words_under_limit_one_text
+          conf.default_text_area_words_at_limit_text = words_at_limit_text
+          conf.default_text_area_words_over_limit_other_text = words_over_limit_other_text
+          conf.default_text_area_words_over_limit_one_text = words_over_limit_one_text
+        end
+      end
+
+      context 'for characters' do
+        let(:kwargs) { { max_chars: 20 } }
+
+        specify 'the character data i18n attributes are localised in the markup' do
+          aggregate_failures do
+            expect(form_group.attributes['data-i18n.characters-under-limit.other'].text).to eql(characters_under_limit_other_text)
+            expect(form_group.attributes['data-i18n.characters-under-limit.one'].text).to eql(characters_under_limit_one_text)
+            expect(form_group.attributes['data-i18n.characters-at-limit'].text).to eql(characters_at_limit_text)
+            expect(form_group.attributes['data-i18n.characters-over-limit.other'].text).to eql(characters_over_limit_other_text)
+            expect(form_group.attributes['data-i18n.characters-over-limit.one'].text).to eql(characters_over_limit_one_text)
+          end
+        end
+
+        specify 'the word data i18n attributes are not localised in the markup' do
+          data_attribute_keys = form_group.attributes.keys.select { |a| a.start_with?('data-i18n.word') }
+
+          expect(data_attribute_keys).to be_empty
+        end
+      end
+
+      context 'for words' do
+        let(:kwargs) { { max_words: 20 } }
+
+        specify 'the word data i18n attributes are localised in the markup' do
+          aggregate_failures do
+            expect(form_group.attributes['data-i18n.words-under-limit.other'].text).to eql(words_under_limit_other_text)
+            expect(form_group.attributes['data-i18n.words-under-limit.one'].text).to eql(words_under_limit_one_text)
+            expect(form_group.attributes['data-i18n.words-at-limit'].text).to eql(words_at_limit_text)
+            expect(form_group.attributes['data-i18n.words-over-limit.other'].text).to eql(words_over_limit_other_text)
+            expect(form_group.attributes['data-i18n.words-over-limit.one'].text).to eql(words_over_limit_one_text)
+          end
+        end
+
+        specify 'the character data i18n attributes are not localised in the markup' do
+          data_attribute_keys = form_group.attributes.keys.select { |a| a.start_with?('data-i18n.character') }
+
+          expect(data_attribute_keys).to be_empty
+        end
+      end
+    end
+  end
+
+  describe 'file upload' do
+    let(:method) { :govuk_file_field }
+    let(:attribute) { :photo }
+    let(:args) { [method, attribute] }
+    let(:kwargs) { { javascript: true } }
+    let(:drop_zone) { parsed_subject.at_css('div.govuk-drop-zone') }
+
+    let(:default_file_choose_files_button_text) { 'Scegli file' }
+    let(:default_file_drop_instruction_text) { 'o trascina il file' }
+    let(:default_file_no_file_chosen_text) { 'Nessun file selezionato' }
+    let(:default_file_multiple_files_chosen_one_text) { '%{count} file selezionato' }
+    let(:default_file_multiple_files_chosen_other_text) { '%{count} file selezionati' }
+    let(:default_file_entered_drop_zone) { 'Area di rilascio inserita' }
+    let(:default_file_left_drop_zone) { 'Area di rilascio abbandonata' }
+
+    subject { builder.send(*args, **kwargs) }
+
+    context 'when the config is default' do
+      specify 'no data i18n attributes are localised in the markup' do
+        data_attribute_keys = drop_zone.attributes.keys.select { |a| a =~ /data-i18n/ }
+
+        expect(data_attribute_keys).to be_empty
+      end
+    end
+
+    context 'when default strings are localised in the config' do
+      before do
+        GOVUKDesignSystemFormBuilder.configure do |conf|
+          conf.default_file_choose_files_button_text = default_file_choose_files_button_text
+          conf.default_file_drop_instruction_text = default_file_drop_instruction_text
+          conf.default_file_no_file_chosen_text = default_file_no_file_chosen_text
+          conf.default_file_multiple_files_chosen_one_text = default_file_multiple_files_chosen_one_text
+          conf.default_file_multiple_files_chosen_other_text = default_file_multiple_files_chosen_other_text
+          conf.default_file_entered_drop_zone = default_file_entered_drop_zone
+          conf.default_file_left_drop_zone = default_file_left_drop_zone
+        end
+      end
+
+      specify 'the character data i18n attributes are localised in the markup' do
+        aggregate_failures do
+          expect(drop_zone.attributes['data-i18n.choose-files-button'].text).to eql(default_file_choose_files_button_text)
+          expect(drop_zone.attributes['data-i18n.drop-instruction'].text).to eql(default_file_drop_instruction_text)
+          expect(drop_zone.attributes['data-i18n.no-file-chosen'].text).to eql(default_file_no_file_chosen_text)
+          expect(drop_zone.attributes['data-i18n.multiple-files-chosen.one'].text).to eql(default_file_multiple_files_chosen_one_text)
+          expect(drop_zone.attributes['data-i18n.multiple-files-chosen.other'].text).to eql(default_file_multiple_files_chosen_other_text)
+          expect(drop_zone.attributes['data-i18n.entered-drop-zone'].text).to eql(default_file_entered_drop_zone)
+          expect(drop_zone.attributes['data-i18n.left-drop-zone'].text).to eql(default_file_left_drop_zone)
+        end
+      end
+    end
+  end
+
+  describe 'password input' do
+    let(:method) { :govuk_password_field }
+    let(:attribute) { :password }
+    let(:args) { [method, attribute] }
+    let(:form_group) { parsed_subject.at_css('div.govuk-form-group') }
+
+    let(:default_show_password_text) { 'Mostra' }
+    let(:default_hide_password_text) { 'Nascondi' }
+    let(:default_show_password_aria_label_text) { 'Mostra password' }
+    let(:default_hide_password_aria_label_text) { 'Nascondi password' }
+    let(:default_password_shown_announcement_text) { 'La tua password è visibile' }
+    let(:default_password_hidden_announcement_text) { 'La tua password è nascosta' }
+
+    subject { builder.send(*args) }
+
+    context 'when the config is default' do
+      specify 'no data i18n attributes are set' do
+        data_attribute_keys = form_group.attributes.keys.select { |a| a =~ /data-i18n/ }
+
+        expect(data_attribute_keys).to be_empty
+      end
+    end
+
+    context 'when default strings are localised in the config' do
+      before do
+        GOVUKDesignSystemFormBuilder.configure do |conf|
+          conf.default_show_password_text = default_show_password_text
+          conf.default_hide_password_text = default_hide_password_text
+          conf.default_show_password_aria_label_text = default_show_password_aria_label_text
+          conf.default_hide_password_aria_label_text = default_hide_password_aria_label_text
+          conf.default_password_shown_announcement_text = default_password_shown_announcement_text
+          conf.default_password_hidden_announcement_text = default_password_hidden_announcement_text
+        end
+      end
+
+      specify 'the character data i18n attributes are localised in the markup' do
+        aggregate_failures do
+          expect(form_group.attributes['data-i18n.show-password'].text).to eql(default_show_password_text)
+          expect(form_group.attributes['data-i18n.hide-password'].text).to eql(default_hide_password_text)
+          expect(form_group.attributes['data-i18n.show-password-aria-label'].text).to eql(default_show_password_aria_label_text)
+          expect(form_group.attributes['data-i18n.hide-password-aria-label'].text).to eql(default_hide_password_aria_label_text)
+          expect(form_group.attributes['data-i18n.password-shown-announcement'].text).to eql(default_password_shown_announcement_text)
+          expect(form_group.attributes['data-i18n.password-hidden-announcement'].text).to eql(default_password_hidden_announcement_text)
+        end
+      end
+    end
+  end
+end

--- a/spec/govuk_design_system_formbuilder/builder/file_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/file_spec.rb
@@ -124,6 +124,32 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           end
         end
 
+        context "when the multiple files chosen 'one' text is customised" do
+          subject { builder.send(*args, javascript: true, multiple_files_chosen_one_text: custom_multiple_files_chosen_one_text) }
+
+          let(:drop_instruction_key) { "data-i18n.multiple-files-chosen.one" }
+          let(:custom_multiple_files_chosen_one_text) { "You've dropped one file" }
+
+          specify "the div has the corresponding i18n data attribute set" do
+            drop_instruction_attr = parsed_subject.at_css("div.govuk-drop-zone").attributes.fetch(drop_instruction_key).value
+
+            expect(drop_instruction_attr).to eql(custom_multiple_files_chosen_one_text)
+          end
+        end
+
+        context "when the multiple files chosen 'one' text is customised" do
+          subject { builder.send(*args, javascript: true, multiple_files_chosen_other_text: custom_multiple_files_chosen_other_text) }
+
+          let(:drop_instruction_key) { "data-i18n.multiple-files-chosen.other" }
+          let(:custom_multiple_files_chosen_other_text) { "You've dropped one file" }
+
+          specify "the div has the corresponding i18n data attribute set" do
+            drop_instruction_attr = parsed_subject.at_css("div.govuk-drop-zone").attributes.fetch(drop_instruction_key).value
+
+            expect(drop_instruction_attr).to eql(custom_multiple_files_chosen_other_text)
+          end
+        end
+
         context "when the no file chosen text is customised" do
           subject { builder.send(*args, javascript: true, no_file_chosen_text: custom_no_file_chosen_text) }
 


### PR DESCRIPTION
This PR adds the ability to set default values for the data attributes used by govuk-frontend to provide localisation for JavaScript-enhanced inputs (password, file upload, textarea).

In order to do this the way these are dealt with has been standardised into the `DataAttributesI18n` trait.

The library now keeps track of the default values from govuk-frontend too and will only set data attributes if they differ from what's specified upstream.

[Here's a list of all of the new configuration options](https://github.com/x-govuk/govuk-form-builder/pull/631/changes#diff-86650226f1c0af3e77b207cb0ffef4e0481402dde611091fd9ec20125b995381).