### PR TITLE
Ensure password reveal button says 'Show' when no i18n options are passed in

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -329,7 +329,7 @@ module GOVUKDesignSystemFormBuilder
       label: {},
       caption: {},
       form_group: {},
-      show_password_text: nil,
+      show_password_text: config.default_show_password_text,
       hide_password_text: nil,
       show_password_aria_label_text: nil,
       hide_password_aria_label_text: nil,

--- a/spec/govuk_design_system_formbuilder/builder/password_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/password_spec.rb
@@ -11,11 +11,11 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     let(:field_type) { 'input' }
     subject { builder.send(*args, **kwargs) }
 
-    specify 'renders a form group containing a wrapper around an input and button' do
+    specify "renders a form group containing a wrapper around an input and a 'Show' button" do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
         with_tag('div', with: { class: %w(govuk-input__wrapper govuk-password-input__wrapper) }) do
           with_tag('input', with: { type: 'password' })
-          with_tag('button')
+          with_tag('button', text: "Show")
         end
       end
     end


### PR DESCRIPTION
This fixes a bug introduced in #631 where when no i18n value is passed in the button is first rendered with no text. Once clicked the text in the button appears.

Fixes #636 