### PR TITLE
Fix password input error class

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/password.rb
+++ b/lib/govuk_design_system_formbuilder/elements/password.rb
@@ -68,7 +68,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def classes
-        build_classes('input', 'password-input__input', 'js-password-input-input', %(password-input--error) => has_errors?).prefix(brand)
+        build_classes('input', 'password-input__input', 'js-password-input-input', %(input--error) => has_errors?).prefix(brand)
       end
 
       def wrapper_classes

--- a/spec/govuk_design_system_formbuilder/builder/password_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/password_spec.rb
@@ -220,7 +220,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       let(:aria_described_by_target) { 'input' }
 
       let(:error_message) { /Password must be longer than 8 characters/ }
-      let(:error_class) { 'govuk-password-input--error' }
+      let(:error_class) { 'govuk-input--error' }
       let(:error_identifier) { 'person-password-error' }
     end
   end


### PR DESCRIPTION
When using the form builder, I noticed that the password field was not being highlighted in red on error. This appears to be caused by the error class appended to the password field being incorrect.

The error message in the [design system](https://design-system.service.gov.uk/components/password-input/#error-messages) shows the example to just have `govuk-input--error` rather than `govuk-password-input--error`.